### PR TITLE
DOCSP-22838 create product name alias

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "cluster-sync"
-title = "MongoDB Cluster-to-Cluster Synchronization"
+title = {+c2c-fullproduct-name+}
 
 intersphinx = [ "https://docs.mongodb.com/manual/objects.inv" ]
 
@@ -11,6 +11,8 @@ toc_landing_pages = ["/quickstart",
 
 [constants]
 version = "1.0.0"
+c2c-product-name = "Cluster-to-Cluster Sync"
+c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"
 
 [substitutions]
 # string = "some other string"

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "cluster-sync"
-title = {+c2c-fullproduct-name+}
+title = "MongoDB Cluster-to-Cluster Sync"
 
 intersphinx = [ "https://docs.mongodb.com/manual/objects.inv" ]
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,8 +1,8 @@
 .. _c2c-index:
 
-==========================================
-MongoDB Cluster-to-Cluster Synchronization
-==========================================
+=========================
+{+c2c-full-product-name+}
+=========================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
Note: I tried using the alias for the title in the snooty.toml file, but it doesn't appear to work there. Perhaps that's just a step too meta. 

[STAGING](https://docs-mongodborg-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-22838-create-product-name-alias/)


[JIRA](https://jira.mongodb.org/browse/DOCSP-22838)