### PR TITLE
(DOCSP-22949): pause endpoint

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -18,6 +18,8 @@ When ``mongosync`` runs on its own hardware, it does not have to use
 the same operation system (OS) as the source or destination clusters it
 is connecting.
 
+.. _c2c-faq-increase-oplog:
+
 Should I increase the size of the oplog in the source cluster?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -88,4 +90,3 @@ have more than 2 non-arbiter nodes and you must sync from a non-arbiter
 node. Use the source cluster's connection string to specify a
 :ref:`read preference <mongodb-uri>` for a non-arbiter, data-bearing
 node. 
-

--- a/source/includes/api/requests/pause.sh
+++ b/source/includes/api/requests/pause.sh
@@ -1,0 +1,1 @@
+curl localhost:27182/api/v1/post -XPOST --data '{ }'

--- a/source/includes/api/requests/pause.sh
+++ b/source/includes/api/requests/pause.sh
@@ -1,1 +1,1 @@
-curl localhost:27182/api/v1/post -XPOST --data '{ }'
+curl localhost:27182/api/v1/pause -XPOST --data '{ }'

--- a/source/includes/api/tables/basic-response.rst
+++ b/source/includes/api/tables/basic-response.rst
@@ -1,0 +1,22 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 14 66
+
+   * - Name
+     - Type
+     - Description
+
+   * - ``success``
+     - boolean
+     - When the request is successful, this value is ``true``.
+
+   * - ``error``
+     - string
+     - If an error occurred, indicates the name of the error. This field
+       is omitted from the response when ``success`` is ``true``.
+
+   * - ``errorDescription``
+     - string
+     - Detailed description of the error that occurred. This field is
+       omitted from the response when ``success`` is ``true``.

--- a/source/reference/api.txt
+++ b/source/reference/api.txt
@@ -9,4 +9,5 @@ API
 .. toctree::
    :titlesonly: 
 
+   /reference/api/pause
    /reference/api/start

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -60,5 +60,10 @@ Response
 Behavior
 --------
 
-If the ``pause`` request is successful, {+c2c-product-name+} enters the
-``PAUSED`` state.
+- If the ``pause`` request is successful, {+c2c-product-name+} enters the
+  ``PAUSED`` state.
+
+- If you plan to pause synchronization for an extended period of time,
+  increase the size of the replica set :term:`oplog` in the source
+  cluster. To learn more, see the :ref:`Frequently Asked Questions
+  <c2c-faq-increase-oplog>`. 

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -1,0 +1,61 @@
+.. _c2c-api-pause:
+
+=========
+``pause``
+=========
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Description
+-----------
+
+Pauses the current synchronization operation. 
+
+Request
+-------
+
+.. code-block:: http
+
+   POST /api/v1/pause 
+
+Request Body Parameters
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This endpoint does not use HTTP request body parameters.
+
+Response
+--------
+
+.. include:: /includes/api/tables/basic-response.rst
+
+Example
+-------
+
+The following example pauses the current synchronization operation.
+
+Request
+~~~~~~~
+
+.. literalinclude:: /includes/api/requests/start.sh
+   :language: shell
+
+Response
+~~~~~~~~
+
+.. literalinclude:: /includes/api/responses/success.sh
+   :language: shell
+
+Behavior
+--------
+
+If a ``pause`` request is sent when {+c2c-product-name+} is in a state
+other than ``RUNNING``, the request fails.
+
+After the ``pause`` request completes, {+c2c-product-name+} enters the
+``PAUSED`` state.

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -42,7 +42,7 @@ The following example pauses the current synchronization operation.
 Request
 ~~~~~~~
 
-.. literalinclude:: /includes/api/requests/start.sh
+.. literalinclude:: /includes/api/requests/pause.sh
    :language: shell
 
 Response

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -65,5 +65,5 @@ Behavior
 
 - If you plan to pause synchronization for an extended period of time,
   increase the size of the replica set :term:`oplog` in the source
-  cluster. To learn more, see the :ref:`Frequently Asked Questions
+  cluster. To learn more, see :ref:`Frequently Asked Questions
   <c2c-faq-increase-oplog>`. 

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -17,6 +17,12 @@ Description
 
 Pauses the current synchronization operation. 
 
+Requirement
+-----------
+
+To use the ``pause`` endpoint, the {+c2c-product-name+} must be in the
+``RUNNING`` state.
+
 Request
 -------
 
@@ -54,8 +60,5 @@ Response
 Behavior
 --------
 
-If a ``pause`` request is sent when {+c2c-product-name+} is in a state
-other than ``RUNNING``, the request fails.
-
-After the ``pause`` request completes, {+c2c-product-name+} enters the
+If the ``pause`` request is successful, {+c2c-product-name+} enters the
 ``PAUSED`` state.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -61,7 +61,7 @@ the source and ``cluster1`` is the destination.
 Request
 ~~~~~~~
 
-.. literalinclude:: /includes/api/requests/start.sh
+.. literalinclude:: /includes/api/requests/pause.sh
    :language: shell
 
 Response

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -61,7 +61,7 @@ the source and ``cluster1`` is the destination.
 Request
 ~~~~~~~
 
-.. literalinclude:: /includes/api/requests/pause.sh
+.. literalinclude:: /includes/api/requests/start.sh
    :language: shell
 
 Response

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -50,28 +50,7 @@ Request Body Parameters
 Response
 --------
 
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :widths: 20 14 66
-
-   * - Name
-     - Type
-     - Description
-
-   * - ``success``
-     - boolean
-     - When the request is successful, this value is ``true``.
-
-   * - ``error``
-     - string
-     - If an error occurred, indicates the name of the error. This field
-       is omitted from the response when ``success`` is ``true``.
-
-   * - ``errorDescription``
-     - string
-     - Detailed description of the error that occurred. This field is
-       omitted from the response when ``success`` is ``true``.
+.. include:: /includes/api/tables/basic-response.rst
 
 Example
 -------
@@ -94,5 +73,5 @@ Response
 Behavior
 --------
 
-If {+c2c-product-name+} is in a state other than ``IDLE``, the request
-fails.
+If a ``start`` request is sent when {+c2c-product-name+} is in a state
+other than ``IDLE``, the request fails.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -17,6 +17,12 @@ Description
 
 Starts the synchronization between a source and destination cluster.
 
+Requirement
+-----------
+
+To use the ``start`` endpoint, the {+c2c-product-name+} must be in the
+``IDLE`` state.
+
 Request
 -------
 
@@ -73,5 +79,5 @@ Response
 Behavior
 --------
 
-If a ``start`` request is sent when {+c2c-product-name+} is in a state
-other than ``IDLE``, the request fails.
+If the ``start`` request is successful, {+c2c-product-name+} enters the
+``RUNNING`` state.


### PR DESCRIPTION
Note for review - as part of this update I also added a "Requirement" section to indicate what state the tool must be in in order to send the request. I also applied this small formatting change to the `start` endpoint page.

JIRA: [DOCSP-22949](https://jira.mongodb.org/browse/DOCSP-22949)

Staged:

- [pause endpoint](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-22949/reference/api/pause/)
- [start endpoint](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-22949/reference/api/start/)

Source material: [google doc](https://docs.google.com/document/d/1KbEk-mTRSp2fuxCscMhONmcZA19RoP5MwtfgYo3OUug/edit#heading=h.dxhfelnjfkj8)