### PR TITLE
(DOCSP-23080): Add copyable false options

### DIFF
--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -48,6 +48,7 @@ Request
 -------
 
 .. code-block:: http
+   :copyable: false
 
    POST /api/v1/commit 
 
@@ -86,6 +87,7 @@ Response
 .. literalinclude:: /includes/api/responses/progress.json
    :language: shell
    :emphasize-lines: 5
+   :copyable: false
 
 The ``progress`` endpoint returned ``"canCommit":true``, which means
 that the ``commit`` request can run successfully.

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -108,6 +108,7 @@ Response
 
 .. literalinclude:: /includes/api/responses/success.json
    :language: json
+   :copyable: false
 
 Behavior
 --------

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -29,6 +29,7 @@ Request
 -------
 
 .. code-block:: http
+   :copyable: false
 
    POST /api/v1/pause 
 
@@ -58,6 +59,7 @@ Response
 
 .. literalinclude:: /includes/api/responses/success.json
    :language: shell
+   :copyable: false
 
 Behavior
 --------

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -21,6 +21,7 @@ Request
 -------
 
 .. code-block:: http
+   :copyable: false
 
    GET /api/v1/progress 
 
@@ -47,6 +48,7 @@ Response
 
 .. literalinclude:: /includes/api/responses/progress.json
    :language: json
+   :copyable: false
 
 Behavior
 --------

--- a/source/reference/api/resume.txt
+++ b/source/reference/api/resume.txt
@@ -30,6 +30,7 @@ Request
 -------
 
 .. code-block:: http
+   :copyable: false
 
    POST /api/v1/resume 
 
@@ -59,6 +60,7 @@ Response
 
 .. literalinclude:: /includes/api/responses/success.json
    :language: shell
+   :copyable: false
 
 Behavior
 --------

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -29,6 +29,7 @@ Request
 -------
 
 .. code-block:: http
+   :copyable: false
 
    POST /api/v1/start 
 
@@ -76,7 +77,8 @@ Response
 ~~~~~~~~
 
 .. literalinclude:: /includes/api/responses/success.json
-   :language: shell
+   :language: json
+   :copyable: false
 
 Behavior
 --------


### PR DESCRIPTION
Add copyable false options to "Request" (non example) and Response code blocks.

Staged:

- [start](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/copyable-false/reference/api/start/)
- [progress](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/copyable-false/reference/api/progress/)
- [pause](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/copyable-false/reference/api/pause/)
- [resume](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/copyable-false/reference/api/resume/)
- [commit](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/copyable-false/reference/api/commit/)