### PR TITLE
DOCSP-23077 Directory structure has changed

### DIFF
--- a/source/includes/step-update-path.rst
+++ b/source/includes/step-update-path.rst
@@ -1,23 +1,23 @@
-The ``mongosync`` binary is in the ``dist/`` directory of the
+The ``mongosync`` binary is in the ``bin/`` directory of the
 unpacked tarball. To add the location of the ``mongosync`` binary to
 your ``PATH``, do one of the following:
 
 - Copy the binary into a directory listed in your ``PATH``
   variable, such as ``/usr/local/bin``. (Update
-  ``/path/to/mongosync/dist`` to reflect the location where you
+  ``/path/to/mongosync/bin`` to reflect the location where you
   extracted the ``tar`` file.)
 
   .. code-block:: bash
 
-     sudo cp /path/to/mongosync/dist/mongosync /usr/local/bin/
+     sudo cp /path/to/mongosync/bin/mongosync /usr/local/bin/
 
 - Create symbolic links to the ``mongosync`` binary from a
   directory such as ``/usr/local/bin`` that is already in your
-  ``PATH``. (Update ``/path/to/mongosync/dist`` to reflect the
+  ``PATH``. (Update ``/path/to/mongosync/bin`` to reflect the
   location where you extracted the ``tar`` file.)
 
   .. code-block:: bash
 
-      sudo ln -s  /path/to/mongosync/dist/mongosync /usr/local/bin/mongosync
+      sudo ln -s  /path/to/mongosync/bin/mongosync /usr/local/bin/mongosync
 
 


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23077-fix-directory-structure/installation/install-on-linux/)


[JIRA]https://jira.mongodb.org/browse/DOCSP-23077)