### PR TITLE
(DOCSP-23020): sync states reference page

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -9,7 +9,7 @@
 
    * - ``state``
      - string
-     - The current state of {+c2c-product-name+}. For information on the
+     - The current state of ``mongosync``. For information on the
        possible states, see :ref:`c2c-states-descriptions`.
 
    * - ``canCommit``

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -10,7 +10,7 @@
    * - ``state``
      - string
      - The current state of {+c2c-product-name+}. For information on the
-       possible states, see :ref:`c2c-states`.
+       possible states, see :ref:`c2c-states-descriptions`.
 
    * - ``canCommit``
      - boolean

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -9,7 +9,8 @@
 
    * - ``state``
      - string
-     - The current state of {+c2c-product-name+}.
+     - The current state of {+c2c-product-name+}. For information on the
+       possible states, see :ref:`c2c-states`.
 
    * - ``canCommit``
      - boolean

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -9,3 +9,4 @@ Reference
 
    /reference/mongosync
    /reference/api
+   /reference/mongosync-states

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -26,6 +26,8 @@ To view the current state of {+c2c-product-name+}, use the
 :ref:`/progress <c2c-api-progress>`. endpoint. The endpoint returns the
 state in the ``state`` field.
 
+.. _c2c-states-descriptions:
+
 State Descriptions
 ------------------
 

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -1,8 +1,8 @@
 .. _c2c-states:
 
-==============================
-Cluster-to-Cluster Sync States
-==============================
+====================
+``mongosync`` States
+====================
 
 .. default-domain:: mongodb
 
@@ -13,16 +13,15 @@ Cluster-to-Cluster Sync States
    :class: singlecol
 
 
-{+c2c-product-name+} enters different states depending on the requests
-it receives. This page describes the states that {+c2c-product-name+}
-can be in. {+c2c-product-name+} is in a single state at a particular
-time. The possible API operations you can run depend on the state of
-{+c2c-product-name+}.
+``mongosync`` enters different states depending on the requests it
+receives. This page describes the states that ``mongosync`` can be in.
+``mongosync`` is in a single state at a particular time. The possible
+API operations you can run depend on the state of ``mongosync``.
 
 View the Current State
 ----------------------
 
-To view the current state of {+c2c-product-name+}, use the
+To view the current state of ``mongosync``, use the
 :ref:`/progress <c2c-api-progress>`. endpoint. The endpoint returns the
 state in the ``state`` field.
 
@@ -32,7 +31,7 @@ State Descriptions
 ------------------
 
 The following table describes each state and the operations you can run
-when {+c2c-product-name+} is in a given state.
+when ``mongosync`` is in a given state.
 
 .. list-table::
    :header-rows: 1
@@ -43,14 +42,14 @@ when {+c2c-product-name+} is in a given state.
      - Possible API Operations
 
    * - ``IDLE``
-     - {+c2c-product-name+} is initialized and ready for a sync job to
+     - ``mongosync`` is initialized and ready for a sync job to
        begin.
      - - ``POST`` :ref:`/start <c2c-api-start>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
 
    * - ``RUNNING``
-     - The sync process is currently running. This state is where data
-       is initially synced to the destination cluster, and subsequent
+     - The sync process is currently running. In this state, data is
+       initially synced to the destination cluster, and subsequent
        writes are applied.
      - - ``POST`` :ref:`/pause <c2c-api-pause>`
        - ``POST`` :ref:`/commit <c2c-api-commit>`
@@ -66,7 +65,7 @@ when {+c2c-product-name+} is in a given state.
      - The cutover for the sync process has started. The time it takes
        to transition to the ``COMMITTED`` phase depends on
        ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or see if
-       {+c2c-product-name+} has finished committing, use the
+       ``mongosync`` has finished committing, use the
        :ref:`/progress <c2c-api-progress>` endpoint.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
 

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -30,7 +30,7 @@ State Descriptions
 ------------------
 
 The following table describes each state and the operations you can run
-when {+c2c-product-name+} is in each state.
+when {+c2c-product-name+} is in a given state.
 
 .. list-table::
    :header-rows: 1

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -12,17 +12,60 @@ Cluster-to-Cluster Sync States
    :depth: 2
    :class: singlecol
 
-This page describes the states that {+c2c-product-name+} can be in.
-Different operations move {+c2c-product-name+} to different states.
-{+c2c-product-name+} is in a single state at a particular time. The
-possible API operations you can run depend on the state of
+
+{+c2c-product-name+} enters different states depending on the requests
+it receives. This page describes the states that {+c2c-product-name+}
+can be in. {+c2c-product-name+} is in a single state at a particular
+time. The possible API operations you can run depend on the state of
 {+c2c-product-name+}.
 
 View the Current State
 ----------------------
 
-To view the current state of {+c2c-product-name+}, use the ``/progress``
-endpoint.
+To view the current state of {+c2c-product-name+}, use the
+:ref:`/progress <c2c-api-progress>`. endpoint. The endpoint returns the
+state in the ``state`` field.
 
 State Descriptions
 ------------------
+
+The following table describes each state and the operations you can run
+when {+c2c-product-name+} is in each state.
+
+.. list-table::
+
+   * - State
+     - Description
+     - Possible API Operations
+
+   * - ``IDLE``
+     - {+c2c-product-name+} is initialized and ready for a sync job to
+       begin.
+     - - ``POST`` :ref:`/start <c2c-api-start>`
+       - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+   * - ``RUNNING``
+     - The sync process is currently running. This state is where data
+       is initially synced to the destination cluster, and subsequent
+       writes are applied.
+     - - ``POST`` :ref:`/pause <c2c-api-pause>`
+       - ``POST`` :ref:`/commit <c2c-api-commit>`
+       - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+   * - ``PAUSED``
+     - The sync process is paused. To resume the sync process, send a
+       request to the :ref:`/resume <c2c-api-resume>` endpoint.
+     - - ``POST`` :ref:`/resume <c2c-api-resume>`
+       - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+   * - ``COMMITTING``
+     - The cutover for the sync process has started. The time it takes
+       to transition to the ``COMMITTED`` phase depends on
+       ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or see if
+       {+c2c-product-name+} has finished committing, use the
+       :ref:`/progress <c2c-api-progress>` endpoint.
+     - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+   * - ``COMMITTED``
+     - The cutover for the sync process is complete.
+     - ``GET`` :ref:`/progress <c2c-api-progress>`

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -33,6 +33,8 @@ The following table describes each state and the operations you can run
 when {+c2c-product-name+} is in each state.
 
 .. list-table::
+   :header-rows: 1
+   :widths: 10 30 20
 
    * - State
      - Description

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -66,8 +66,8 @@ when {+c2c-product-name+} is in each state.
        ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or see if
        {+c2c-product-name+} has finished committing, use the
        :ref:`/progress <c2c-api-progress>` endpoint.
-     - ``GET`` :ref:`/progress <c2c-api-progress>`
+     - - ``GET`` :ref:`/progress <c2c-api-progress>`
 
    * - ``COMMITTED``
      - The cutover for the sync process is complete.
-     - ``GET`` :ref:`/progress <c2c-api-progress>`
+     - - ``GET`` :ref:`/progress <c2c-api-progress>`

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -1,0 +1,28 @@
+.. _c2c-states:
+
+==============================
+Cluster-to-Cluster Sync States
+==============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes the states that {+c2c-product-name+} can be in.
+Different operations move {+c2c-product-name+} to different states.
+{+c2c-product-name+} is in a single state at a particular time. The
+possible API operations you can run depend on the state of
+{+c2c-product-name+}.
+
+View the Current State
+----------------------
+
+To view the current state of {+c2c-product-name+}, use the ``/progress``
+endpoint.
+
+State Descriptions
+------------------


### PR DESCRIPTION
New page describing the different states of the c2c utility.

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23020/reference/mongosync-states