### PR TITLE
cleanup sync states page

### DIFF
--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -14,24 +14,26 @@
 
 
 ``mongosync`` enters different states depending on the requests it
-receives. This page describes the states that ``mongosync`` can be in.
-``mongosync`` is in a single state at a particular time. The possible
-API operations you can run depend on the state of ``mongosync``.
+receives. ``mongosync`` can only be in a single state at a particular
+time. The current ``mongosync`` states determines which API operations
+you can run.
+
+This page describes ``mongosync`` states.
 
 View the Current State
 ----------------------
 
-To view the current state of ``mongosync``, use the
-:ref:`/progress <c2c-api-progress>`. endpoint. The endpoint returns the
-state in the ``state`` field.
+To view the current state of ``mongosync``, use the :ref:`/progress
+<c2c-api-progress>`. endpoint. The :ref:`/progress <c2c-api-progress>`
+endpoint returns the state in the ``state`` field.
 
 .. _c2c-states-descriptions:
 
 State Descriptions
 ------------------
 
-The following table describes each state and the operations you can run
-when ``mongosync`` is in a given state.
+The following table describes each state and lists the permitted
+operations in that state.
 
 .. list-table::
    :header-rows: 1
@@ -49,8 +51,8 @@ when ``mongosync`` is in a given state.
 
    * - ``RUNNING``
      - The sync process is currently running. In this state, data is
-       initially synced to the destination cluster, and subsequent
-       writes are applied.
+       initially synced to the destination cluster. Subsequent writes to
+       the source cluster are applied to the destination cluster.
      - - ``POST`` :ref:`/pause <c2c-api-pause>`
        - ``POST`` :ref:`/commit <c2c-api-commit>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
@@ -64,9 +66,9 @@ when ``mongosync`` is in a given state.
    * - ``COMMITTING``
      - The cutover for the sync process has started. The time it takes
        to transition to the ``COMMITTED`` phase depends on
-       ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or see if
-       ``mongosync`` has finished committing, use the
-       :ref:`/progress <c2c-api-progress>` endpoint.
+       ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or to see if
+       ``mongosync`` has finished committing, use the :ref:`/progress
+       <c2c-api-progress>` endpoint.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
 
    * - ``COMMITTED``

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -14,9 +14,9 @@
 
 
 ``mongosync`` enters different states depending on the requests it
-receives. ``mongosync`` can only be in a single state at a particular
-time. The current ``mongosync`` states determines which API operations
-you can run.
+receives. ``mongosync`` can only be in a single state at a given time.
+The current ``mongosync`` states determines which API operations you can
+run.
 
 This page describes ``mongosync`` states.
 


### PR DESCRIPTION
Address feedback left on PR #26

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/sync-cleanup/reference/mongosync-states/