### PR TITLE
DOCS-15438 fle2 not supported

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -44,13 +44,14 @@ General Limitations
 - Network compression is not supported.
 - :dbcommand:`applyOps` operations from the source cluster are not
   supported.
-- Serverless clusters are not supported.
-- The MongoDB Shared Tier is not supported.
 - The :data:`system.js <<database>.system.js>` collection is not
   replicated.
 - Documents that have dollar (``$``) prefixed field names are not
   supported. See :ref:`Field Names with Periods and Dollar Signs
   <crud-concepts-dot-dollar-considerations>`.
+- Serverless clusters are not supported.
+- The MongoDB Shared Tier is not supported.
+- :ref:`Queryable Execution <qe-manual-feature-qe>` is not supported.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -51,7 +51,9 @@ General Limitations
   <crud-concepts-dot-dollar-considerations>`.
 - Serverless clusters are not supported.
 - The MongoDB Shared Tier is not supported.
-- :ref:`Queryable Execution <qe-manual-feature-qe>` is not supported.
+- `Queryable Execution
+  <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
+  not supported.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15438-fle2-not-supported-v0.9.0/reference/limitations/)


[JIRA](https://jira.mongodb.org/browse/DOCS-15438)