### PR TITLE
DOCS-15445 expireAfterSeconds not supported

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -65,10 +65,9 @@ discuss your requirements.
 Unsupported Collection Types
 ----------------------------
 
-- Collections with collation are currently not supported.
-- Capped collections are currently not supported.
 - Time-series collections are not supported.
-
+- Clustered collections with :ref:`expireAfterSeconds
+  <db.createCollection.expireAfterSeconds>` set are not supported.
 
 Sharded Clusters
 ----------------


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15445-expireAfterSeconds-unsupported-v1.0/reference/limitations/)


[JIRA](https://jira.mongodb.org/browse/DOCS-15445)