### PR TITLE
DOCSP-23407 rename and drop not supported

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -53,6 +53,9 @@ General Limitations
 - `Queryable Execution
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
   not supported.
+- If the :dbcommand:`renameCollection` or the :dbcommand:`drop` command
+  modifies a :ref:`capped collection <manual-capped-collection>`,
+  synchronization is not supported.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23407-rename-drop-not-supported-v1.0.0/reference/limitations/)


[JIRA](https://jira.mongodb.org/browse/DOCSP-23407)