### PR TITLE
DOCSP-23337 users and roles not synched

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -121,6 +121,14 @@ Behavior
 
 .. _c2c-mongosync-config:
 
+Cluster Independence
+~~~~~~~~~~~~~~~~~~~~
+
+``mongosync`` synchronizes collection data between a source and a
+destination cluster. ``mongosync`` does not synchronize :ref:`users
+<users>` or :ref:`roles <built-in-roles>`. As a result, you can grant
+different levels of access to each cluster.
+
 Configuration File
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -124,10 +124,10 @@ Behavior
 Cluster Independence
 ~~~~~~~~~~~~~~~~~~~~
 
-``mongosync`` synchronizes collection data between a source and a
-destination cluster. ``mongosync`` does not synchronize :ref:`users
-<users>` or :ref:`roles <built-in-roles>`. As a result, you can grant
-different levels of access to each cluster.
+``mongosync`` synchronizes collection data between a source cluster and
+a destination cluster. ``mongosync`` does not synchronize :ref:`users
+<users>` or :ref:`roles <built-in-roles>`. As a result, you can create
+users with different access permissions on each cluster.
 
 Configuration File
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -125,7 +125,7 @@ Cluster Independence
 ~~~~~~~~~~~~~~~~~~~~
 
 ``mongosync`` synchronizes collection data between a source cluster and
-a destination cluster. ``mongosync`` does not synchronize :ref:`users
+destination cluster. ``mongosync`` does not synchronize :ref:`users
 <users>` or :ref:`roles <built-in-roles>`. As a result, you can create
 users with different access permissions on each cluster.
 


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23337-users-and-roles-synched-v0.9.0/reference/mongosync/#cluster-independence)


[JIRA](https://jira.mongodb.org/browse/DOCSP-23337)