### PR TITLE
DOCSP-23770 missing backslash

### DIFF
--- a/source/includes/api/requests/start-reversible.sh
+++ b/source/includes/api/requests/start-reversible.sh
@@ -1,4 +1,4 @@
-curl localhost:27182/api/v1/start -XPOST
+curl localhost:27182/api/v1/start -XPOST \
 --data '
    {
       "source": "cluster0",


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23770-missing-backslash-v0.9.0/reference/api/start/#request-2)


[JIRA](https://jira.mongodb.org/browse/DOCSP-23770)