### PR TITLE
DOCS-15470 add can write v1.0

### DIFF
--- a/source/includes/api/responses/progress.json
+++ b/source/includes/api/responses/progress.json
@@ -3,6 +3,7 @@
       {
          "state":"RUNNING",
          "canCommit":true,
+         "canWrite":false,
          "info":"change event application",
          "lagTimeSeconds":0,
          "collectionCopy":

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -20,9 +20,9 @@
 
    * - ``canWrite``
      - boolean
-     - If ``true``, indicates that :ref:`commit <c2c-api-commit>` has
-       completed and that it is possible to write to the destination
-       cluster.
+     - If ``true``, indicates that it is possible to write to the
+       destination cluster. Index validation continues until the 
+       :ref:`commit <c2c-api-commit>` is complete.
 
    * - ``info``
      - string

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -1,7 +1,7 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 14 66
+   :widths: 20 20 60
 
    * - Field
      - Type
@@ -17,6 +17,12 @@
      - If ``true``, indicates that a :ref:`commit <c2c-api-commit>`
        request will succeed. This also means that the initial sync has
        completed and is applying change events.
+
+   * - ``canWrite``
+     - boolean
+     - If ``true``, indicates that :ref:`commit <c2c-api-commit>` has
+       completed and that it is possible to write to the destination
+       cluster.
 
    * - ``info``
      - string

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -32,6 +32,18 @@ All response fields are wrapped in a top-level ``progress`` object.
 
 .. include:: /includes/api/tables/progress-response.rst
 
+Behavior
+--------
+
+- When ``mongosync`` is in the ``IDLE`` state, all output
+  fields except ``state`` and ``canCommit`` are ``null``.
+  
+- When ``mongosync`` is in the ``PAUSED`` state, the
+  ``lagTimeSeconds`` field is ``null``.
+
+- The endpoint does not auto-refresh. To get updated status, call the
+  ``progress`` endpoint again.
+
 Example
 -------
 
@@ -49,16 +61,4 @@ Response
 .. literalinclude:: /includes/api/responses/progress.json
    :language: json
    :copyable: false
-
-Behavior
---------
-
-- When ``mongosync`` is in the ``IDLE`` state, all output
-  fields except ``state`` and ``canCommit`` are ``null``.
-  
-- When ``mongosync`` is in the ``PAUSED`` state, the
-  ``lagTimeSeconds`` field is ``null``.
-
-- The endpoint does not auto-refresh. To get updated status, call the
-  ``progress`` endpoint again.
 


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15470-add-canWrite-v1.0/reference/api/progress/)


[JIRA](https://jira.mongodb.org/browse/DOCS-15470)