### PR TITLE
DOCSP-23312 index limit lower by one

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -89,6 +89,9 @@ Sharded Clusters
   synchronizing.
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during resharding.
+- The maximum number of :ref:`shard key indexes
+  <sharding-shard-key-indexes>` is one lower than normal, 63 instead of
+  64.
 
 
 Reversing


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23312-index-limit-lower-v0.9.0/reference/limitations/#sharded-clusters)


[JIRA](https://jira.mongodb.org/browse/DOCSP-23312)