### PR TITLE
DOCSP-23808 Removes second configuration entry

### DIFF
--- a/source/reference.txt
+++ b/source/reference.txt
@@ -11,6 +11,5 @@ Reference
    /reference/configuration
    /reference/api
    /reference/mongosync-states
-   /reference/configuration
    /reference/limitations
 


### PR DESCRIPTION
[DOCS-23808](https://jira.mongodb.org/browse/DOCSP-23808)
[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23808-duplicate-toc-entry/reference/configuration/) with only one Configuration entry in the left sidebar.
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62d1dd4a230aeb802ea8dcad) with no new errors.