### PR TITLE
DOCSP-23785 auth writeblock

### DIFF
--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -29,6 +29,11 @@ Authentication
 
 .. include:: /includes/fact-onprem-auth
 
+Roles
+-----
+
+.. include:: /includes/fact-oprem-roles
+
 Behavior
 --------
 

--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -32,7 +32,7 @@ Authentication
 Roles
 -----
 
-.. include:: /includes/fact-oprem-roles
+.. include:: /includes/fact-onprem-roles
 
 Behavior
 --------

--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -4,7 +4,7 @@ The user specified in the connection string must have, at a minimum, the
 .. note:: 
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must :atlas:` create a custum role 
+   you must :atlas:`create a custum role 
    <reference/api/custom-roles-create-a-role>` that grants the
    following ActionTypes:
    

--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -1,15 +1,17 @@
-The user specified in the connection string must have the
+The user specified in the connection string must have, at a minimum, the
 :atlasrole:`atlasAdmin` role.
 
-To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-you must `create a custom role
-</atlas/reference/api/custom-roles-create-a-role/>`__ that grants the
-following ActionTypes:
+.. note:: 
 
-- setUserWriteBlockMode
-- bypassWriteBlockingMode
-
-The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
-ActionTypes are available starting in MongoDB 6.0. To create the custom
-roles, all clusters in a project must be on MongoDB 6.0 or higher.
+   To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
+   you must `create a custom role
+   </atlas/reference/api/custom-roles-create-a-role/>`__ that grants the
+   following ActionTypes:
+   
+   - :authaction:`setUserWriteBlockMode`
+   - :authaction:`bypassWriteBlockingMode`
+   
+   The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
+   ActionTypes are available starting in MongoDB 6.0. To create the custom
+   roles, all clusters in a project must be on MongoDB 6.0 or higher.
 

--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -5,7 +5,7 @@ The user specified in the connection string must have, at a minimum, the
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
    you must :atlas:`create a custum role 
-   <reference/api/custom-roles-create-a-role>` that grants the
+   </reference/api/custom-roles-create-a-role>` that grants the
    following ActionTypes:
    
    - :authaction:`setUserWriteBlockMode`

--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -4,8 +4,8 @@ The user specified in the connection string must have, at a minimum, the
 .. note:: 
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must `create a custom role
-   </atlas/reference/api/custom-roles-create-a-role/>`__ that grants the
+   you must :atlas:` create a custum role 
+   <reference/api/custom-roles-create-a-role>` that grants the
    following ActionTypes:
    
    - :authaction:`setUserWriteBlockMode`

--- a/source/includes/fact-onprem-roles.rst
+++ b/source/includes/fact-onprem-roles.rst
@@ -1,0 +1,18 @@
+
+The user specified in the connection string must have, at a minimum, the
+:authrole:`readAnyDatabase`, :authrole:`clusterMonitor`, and
+:authrole:`backup` roles.
+
+.. note:: 
+
+   To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
+   you must `create a custom role
+   </atlas/reference/api/custom-roles-create-a-role/>`__ that grants the
+   following ActionTypes:
+   
+   - :authaction:`setUserWriteBlockMode`
+   - :authaction:`bypassWriteBlockingMode`
+   
+   The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
+   ActionTypes are available starting in MongoDB 6.0. To create the custom
+   roles, all clusters in a project must be on MongoDB 6.0 or higher.

--- a/source/includes/fact-onprem-roles.rst
+++ b/source/includes/fact-onprem-roles.rst
@@ -6,9 +6,8 @@ The user specified in the connection string must have, at a minimum, the
 .. note:: 
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must `create a custom role
-   </atlas/reference/api/custom-roles-create-a-role/>`__ that grants the
-   following ActionTypes:
+   you must create a custom role (using the :dbcommand:`createRole` command)
+   that grants the following ActionTypes:
    
    - :authaction:`setUserWriteBlockMode`
    - :authaction:`bypassWriteBlockingMode`

--- a/source/includes/fact-write-blocking-requirement.rst
+++ b/source/includes/fact-write-blocking-requirement.rst
@@ -1,3 +1,11 @@
 To set ``enableUserWriteBlocking``, the ``mongosync`` user must have a
 role that includes the :authaction:`setUserWriteBlockMode` and
-:authaction:`bypassWriteBlockingMode` ActionTypes.
+:authaction:`bypassWriteBlockingMode` ActionTypes. 
+
+.. note:: 
+    
+   When using ``enableUserWriteBlocking``, writes are only blocked for users
+   that do not have the :authaction:`bypassWriteBlockingMode` ActionType. Users
+   that do have this ActionType are still able to perform writes.
+
+

--- a/source/includes/fact-write-blocking-requirement.rst
+++ b/source/includes/fact-write-blocking-requirement.rst
@@ -6,6 +6,6 @@ role that includes the :authaction:`setUserWriteBlockMode` and
     
    When using ``enableUserWriteBlocking``, writes are only blocked for users
    that do not have the :authaction:`bypassWriteBlockingMode` ActionType. Users
-   that do have this ActionType are still able to perform writes.
+   who have this ActionType are able to perform writes.
 
 

--- a/source/includes/fact-write-blocking-requirement.rst
+++ b/source/includes/fact-write-blocking-requirement.rst
@@ -1,3 +1,3 @@
 To set ``enableUserWriteBlocking``, the ``mongosync`` user must have a
-role that includes the ``setUserWriteBlockMode`` and
-``bypassWriteBlockingMode`` ActionTypes.
+role that includes the :authaction:`setUserWriteBlockMode` and
+:authaction:`bypassWriteBlockingMode` ActionTypes.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -58,7 +58,7 @@ To set a custom role for the ``mongosync`` user:
       } )
 
 Ensure that you use this configured ``mongosync`` user in the connection 
-string for the :setting:`cluster0` or :setting:`cluster1` settings when
+strings for the :setting:`cluster0` or :setting:`cluster1` settings when
 you start ``mongosync``. 
 
 Request

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -22,11 +22,41 @@ Starts the synchronization between a source and destination cluster.
 Requirements
 ------------
 
+State
+~~~~~
+
 To use the ``start`` endpoint, ``mongosync`` must be in the ``IDLE``
 state.
 
+User Write Blocking
+~~~~~~~~~~~~~~~~~~~
+
 .. include:: /includes/fact-write-blocking-requirement.rst
+
+To set a custom role for the ``mongosync`` user:
  
+#. To create a custom role, use the :dbcommand:`createRole` command:
+
+   .. code-block:: javascript
+   
+      db.adminCommand( {
+         createRole: "reverseSync",
+         privileges: [ {
+             resource: { db: "", collection: "" },
+             actions: [ "setUserWriteBlockMode", "bypassWriteBlockingMode" ]
+         } ],
+         roles: []
+      } )
+ 
+#. To grant the custom role to the ``mongosync`` user, use the :dbcommand:`grantRolesToUser` command:
+
+   .. code-block:: javascript
+
+      db.adminCommand( {
+         grantRolesToUser: "mongosync",
+         roles: [ { role: "reverseSync", db: "admin" } ]
+      } )
+
 Request
 -------
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -57,7 +57,7 @@ To set a custom role for the ``mongosync`` user:
          roles: [ { role: "reverseSync", db: "admin" } ]
       } )
 
-Ensure that you uuse this configured ``mongosync`` user in the connection 
+Ensure that you use this configured ``mongosync`` user in the connection 
 string for :setting:`cluster0` or :setting:`cluster1`. 
 
 Request

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -53,9 +53,12 @@ To set a custom role for the ``mongosync`` user:
    .. code-block:: javascript
 
       db.adminCommand( {
-         grantRolesToUser: "mongosync",
+         grantRolesToUser: "mongosync-user",
          roles: [ { role: "reverseSync", db: "admin" } ]
       } )
+
+Ensure that you uuse this configured ``mongosync`` user in the connection 
+string for :setting:`cluster0` or :setting:`cluster1`. 
 
 Request
 -------

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -58,7 +58,8 @@ To set a custom role for the ``mongosync`` user:
       } )
 
 Ensure that you use this configured ``mongosync`` user in the connection 
-string for :setting:`cluster0` or :setting:`cluster1`. 
+string for the :setting:`cluster0` or :setting:`cluster1` settings when
+you start ``mongosync``. 
 
 Request
 -------


### PR DESCRIPTION
[DOCSP-23785](https://jira.mongodb.org/browse/DOCSP-23785)

Staging:

* Updates [Requirements](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23785-auth-writeblock/reference/api/start/#requirements) for `start` API call with note about `bypassWriteBlockingMode` and example of how to create a custom role.
* Adds [Roles](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23785-auth-writeblock/connecting/onprem-to-onprem/#roles) section to On-Prem-to-On-Prem connections
* Moves Reverse Direction content in [On-Prem-to-Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23785-auth-writeblock/connecting/onprem-to-atlas/#roles) roles into an admonition to better highlight it.

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62d8308a230aeb802e9ac8d3) with no new errors.