### PR TITLE
DOCSP-23785 auth writeblock - backport v1.0

### DIFF
--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -28,6 +28,11 @@ Authentication
 
 .. include:: /includes/fact-onprem-auth
 
+Roles
+-----
+
+.. include:: /includes/fact-onprem-roles
+
 Behavior
 --------
 

--- a/source/includes/fact-onprem-roles.rst
+++ b/source/includes/fact-onprem-roles.rst
@@ -1,12 +1,13 @@
+
 The user specified in the connection string must have, at a minimum, the
-:atlasrole:`atlasAdmin` role.
+:authrole:`readAnyDatabase`, :authrole:`clusterMonitor`, and
+:authrole:`backup` roles.
 
 .. note:: 
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must :atlas:`create a custum role 
-   </reference/api/custom-roles-create-a-role>` that grants the
-   following ActionTypes:
+   you must create a custom role (using the :dbcommand:`createRole` command)
+   that grants the following ActionTypes:
    
    - :authaction:`setUserWriteBlockMode`
    - :authaction:`bypassWriteBlockingMode`
@@ -14,4 +15,3 @@ The user specified in the connection string must have, at a minimum, the
    The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
    ActionTypes are available starting in MongoDB 6.0. To create the custom
    roles, all clusters in a project must be on MongoDB 6.0 or higher.
-

--- a/source/includes/fact-write-blocking-requirement.rst
+++ b/source/includes/fact-write-blocking-requirement.rst
@@ -1,3 +1,11 @@
 To set ``enableUserWriteBlocking``, the ``mongosync`` user must have a
-role that includes the ``setUserWriteBlockMode`` and
-``bypassWriteBlockingMode`` ActionTypes.
+role that includes the :authaction:`setUserWriteBlockMode` and
+:authaction:`bypassWriteBlockingMode` ActionTypes. 
+
+.. note:: 
+    
+   When using ``enableUserWriteBlocking``, writes are only blocked for users
+   that do not have the :authaction:`bypassWriteBlockingMode` ActionType. Users
+   who have this ActionType are able to perform writes.
+
+

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -21,11 +21,45 @@ Starts the synchronization between a source and destination cluster.
 Requirements
 ------------
 
+State
+~~~~~
+
 To use the ``start`` endpoint, ``mongosync`` must be in the ``IDLE``
 state.
 
+User Write Blocking
+~~~~~~~~~~~~~~~~~~~
+
 .. include:: /includes/fact-write-blocking-requirement.rst
+
+To set a custom role for the ``mongosync`` user:
  
+#. To create a custom role, use the :dbcommand:`createRole` command:
+
+   .. code-block:: javascript
+   
+      db.adminCommand( {
+         createRole: "reverseSync",
+         privileges: [ {
+             resource: { db: "", collection: "" },
+             actions: [ "setUserWriteBlockMode", "bypassWriteBlockingMode" ]
+         } ],
+         roles: []
+      } )
+ 
+#. To grant the custom role to the ``mongosync`` user, use the :dbcommand:`grantRolesToUser` command:
+
+   .. code-block:: javascript
+
+      db.adminCommand( {
+         grantRolesToUser: "mongosync-user",
+         roles: [ { role: "reverseSync", db: "admin" } ]
+      } )
+
+Ensure that you use this configured ``mongosync`` user in the connection 
+strings for the :setting:`cluster0` or :setting:`cluster1` settings when
+you start ``mongosync``. 
+
 Request
 -------
 


### PR DESCRIPTION
Backports to v1.0 branch.

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62d841f3230aeb802e9e66b8) with no new errors.