### PR TITLE
DOCSP-23911 Adds capped collections line

### DIFF
--- a/source/reference/failure-recovery.txt
+++ b/source/reference/failure-recovery.txt
@@ -75,8 +75,7 @@ TTL Indexes
 During synchronization, ``expireAfterSeconds`` is set
 to ``MAX_INT`` for :ref:`TTL indexes
 <index-feature-ttl>`. To reset ``expireAfterSeconds``, use the
-``collMod`` command. See: :ref:`Change Expiration Value for Indexes
-<ex-change-exp-value>`.
+:dbcommand:`collMod` command to change the expiration value. 
 
 
 .. _c2c-dr-hidden:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -75,6 +75,7 @@ Unsupported Collection Types
 ----------------------------
 
 - Time-series collections are not supported.
+- Capped collections are currently not supported.
 - Clustered collections with :ref:`expireAfterSeconds
   <db.createCollection.expireAfterSeconds>` set are not supported.
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -72,7 +72,7 @@ Unsupported Collection Types
 ----------------------------
 
 - Time-series collections are not supported.
-- Capped collections are currently not supported.
+- Capped collections are not supported.
 - Clustered collections with :ref:`expireAfterSeconds
   <db.createCollection.expireAfterSeconds>` set are not supported.
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -60,9 +60,6 @@ General Limitations
 - `Queryable Execution
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
   not supported.
-- If you run the :dbcommand:`renameCollection` command or the
-  :dbcommand:`drop` command on a :ref:`capped collection
-  <manual-capped-collection>`, synchronization behavior is undefined.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
[DOCSP-23911](https://jira.mongodb.org/browse/DOCSP-23911)

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23911-capped-collections/reference/limitations/#unsupported-collection-types) adds Capped collection line to v1.0

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62d97817230aeb802ecce4bc) with no new errors.