### PR TITLE
DOCSP-23934 release notes 1.0

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -9,4 +9,5 @@ Release Notes
    :titlesonly: 
 
    /release-notes/0.9
+   /release-notes/1.0
 

--- a/source/release-notes/1.0.txt
+++ b/source/release-notes/1.0.txt
@@ -1,0 +1,44 @@
+.. _c2c-release-notes-1.0:
+
+===================================
+Release Notes for ``mongosync`` 1.0
+===================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. note::
+
+   {*c2c-product-name+} 1.0 Released July 22, 2022
+
+
+Multiple Instances
+------------------
+
+{+c2c-product-name+} 1.0 supports the use of multiple :program:`mongosync` 
+instances to synchronize sharded clusters.
+
+
+DDL Operations
+--------------
+
+{+c2c-product-name+} 1.0 supports DDL operations.
+
+Collation
+----------
+
+{+c2c-product-name+} 1.0 supports synchronization of collections with collation. 
+
+API Improvements
+----------------
+
+{+c2c-product-name+} 1.0 includes improvements to the :ref:`progress
+<c2c-api-status>` command.
+
+
+

--- a/source/release-notes/1.0.txt
+++ b/source/release-notes/1.0.txt
@@ -14,7 +14,7 @@ Release Notes for ``mongosync`` 1.0
 
 .. note::
 
-   {*c2c-product-name+} 1.0 Released July 22, 2022
+   {+c2c-product-name+} 1.0 Released July 22, 2022
 
 
 Multiple Instances
@@ -23,11 +23,17 @@ Multiple Instances
 {+c2c-product-name+} 1.0 supports the use of multiple :program:`mongosync` 
 instances to synchronize sharded clusters.
 
+Each ``mongosync`` instance must connect to ``mongos`` and start with 
+the :option:`--id` option or the :setting:`id` setting, specifying the 
+shard you want it to synchronize.
+
+For more information, see :ref:`Use mongosync on Sharded Clusters
+<c2c-sharded-clusters>`.
 
 DDL Operations
 --------------
 
-{+c2c-product-name+} 1.0 supports DDL operations.
+{+c2c-product-name+} 1.0 supports the synchronization of DDL operations.
 
 Collation
 ----------
@@ -38,7 +44,10 @@ API Improvements
 ----------------
 
 {+c2c-product-name+} 1.0 includes improvements to the :ref:`progress
-<c2c-api-status>` command.
+<c2c-api-progress>` command.
+
+The response to ``progress`` commands now includes a ``canWrite`` field,
+indicating whether it is possible to perform writes on the destination cluster. 
 
 
 

--- a/source/release-notes/1.0.txt
+++ b/source/release-notes/1.0.txt
@@ -14,13 +14,13 @@ Release Notes for ``mongosync`` 1.0
 
 .. note::
 
-   {+c2c-product-name+} 1.0 Released July 22, 2022
+   ``mongosync`` 1.0 Released July 22, 2022
 
 
 Multiple Instances
 ------------------
 
-{+c2c-product-name+} 1.0 supports the use of multiple :program:`mongosync` 
+``mongosync`` 1.0 supports the use of multiple :program:`mongosync` 
 instances to synchronize sharded clusters.
 
 Each ``mongosync`` instance must connect to ``mongos`` and start with 
@@ -33,17 +33,17 @@ For more information, see :ref:`Use mongosync on Sharded Clusters
 DDL Operations
 --------------
 
-{+c2c-product-name+} 1.0 supports the synchronization of DDL operations.
+``mongosync`` 1.0 supports the synchronization of DDL operations.
 
 Collation
 ----------
 
-{+c2c-product-name+} 1.0 supports synchronization of collections with collation. 
+``mongosync`` 1.0 supports synchronization of collections with collation. 
 
 API Improvements
 ----------------
 
-{+c2c-product-name+} 1.0 includes improvements to the :ref:`progress
+``mongosync`` 1.0 includes improvements to the :ref:`progress
 <c2c-api-progress>` command.
 
 The response to ``progress`` commands now includes a ``canWrite`` field,


### PR DESCRIPTION
[DOCSP-23934](https://jira.mongodb.org/browse/DOCSP-23934)

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23934-release-notes-1.0/release-notes/1.0/)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62dac3b4230aeb802e0079f4) with no new errors.