### PR TITLE
DOCSP-23936 Fixes typo

### DIFF
--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -4,7 +4,7 @@ The user specified in the connection string must have, at a minimum, the
 .. note:: 
 
    To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must :atlas:`create a custum role 
+   you must :atlas:`create a custom role 
    </reference/api/custom-roles-create-a-role>` that grants the
    following ActionTypes:
    


### PR DESCRIPTION
[DOCSP-23936](https://jira.mongodb.org/browse/DOCSP-23936)

Staging:
* [Atlas to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23936-custom-typo/connecting/atlas-to-atlas/#roles)
* [On-prem to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23936-custom-typo/connecting/onprem-to-atlas/#roles)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62e40083230aeb802e710ee5) with no new errors