### PR TITLE
DOCSP-23908 Fixes typo

### DIFF
--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -38,7 +38,7 @@ strings for ``cluster0`` and ``cluster1``:
    mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
 
 The ``mongosync`` command layout below is modified for display. To
-connect ``cluster0`` to ``cluster`` with ``mongosync``, enter the
+connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
 following command on one line:
 
 .. code-block:: shell


### PR DESCRIPTION
[DOCSP-23908](https://jira.mongodb.org/browse/DOCSP-23908)

Staging:
* [Atlas to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23908-cluster-typo/connecting/atlas-to-atlas/#connect-the-source-and-destination-clusters-with-mongosync)
* [On-prem to On-prem](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23908-cluster-typo/connecting/onprem-to-onprem/#connect-the-source-and-destination-clusters-with-mongosync)
* [On-prem to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23908-cluster-typo/connecting/onprem-to-atlas/#connect-the-source-and-destination-clusters-with-mongosync)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62e40352230aeb802e71bd0c) with no new errors.