### PR TITLE
DOCSP-23870 mongosync atlas

### DIFF
--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -50,8 +50,9 @@ following command on one line:
                        clusterTwo02.fancyCorp.com:20020,
                        clusterTwo03.fancyCorp.com:20020
 
-To use ``mongosync`` with Atlas clusters, you add the
-:urioption:`ssl=true <ssl>` option to enable SSL. For example:
+Atlas clusters require TLS/SSL connections. To use ``mongosync`` with
+Atlas clusters, you add the :urioption:`ssl=true <ssl>` option. For
+example:
 
 .. code-block:: shell
 

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -60,7 +60,8 @@ To use ``mongosync`` with Atlas clusters, you add the
       --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
 You can also use ``mongodb+srv`` connection strings with ``mongosync``.
-For example:
+You do not need to add the :urioption:ssl=true <ssl> option to a
+``mongodb+srv`` connection string. For example:
 
 .. code-block:: shell
 

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -57,4 +57,4 @@ and ``ssl=true`` is not required. For example:
       --cluster1 'mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/'
 
 For more information about connecting to a cluster using ``mongosync``,
-see :ref:`c2c-connecting`.
+see :ref:`c2c-connecting`. 

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -59,9 +59,8 @@ To use ``mongosync`` with Atlas clusters, you add the
       --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/?ssl=true' \
       --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
-You can also use ``mongodb+srv`` connection strings with ``mongosync``,
-and the :urioption:`ssl=true <ssl>` option is not required for Atlas
-clusters. For example:
+You can also use ``mongodb+srv`` connection strings with ``mongosync``.
+For example:
 
 .. code-block:: shell
 

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -37,9 +37,12 @@ strings for ``cluster0`` and ``cluster1``:
    cluster1:
    mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
 
-The ``mongosync`` command layout below is modified for display. To
-connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
-following command on one line:
+<<PUT BACK ORIG EXAMPLE>>
+
+When using Atlas clusters, ...
+
+To connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
+following command:
 
 .. code-block:: shell
 
@@ -47,8 +50,11 @@ following command on one line:
       --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/?ssl=true' \
       --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
-You can also use ``+srv`` connection strings to connect to the cluster,
-and ``ssl=true`` is not required. For example:
+The previous command uses the :urioption:`ssl=true <ssl>` option to use
+SSL.
+
+You can also use ``mongodb+srv`` connection strings with ``mongosync``,
+and the :urioption:`ssl=true <ssl>` option is not required. For example:
 
 .. code-block:: shell
 
@@ -56,5 +62,5 @@ and ``ssl=true`` is not required. For example:
       --cluster0 'mongodb+srv://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020/' \
       --cluster1 'mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/'
 
-For more information about connecting to a cluster using ``mongosync``,
-see :ref:`c2c-connecting`.
+For more details about ``mongodb+srv`` connection strings, see
+:ref:`connections-dns-seedlist`.

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -60,7 +60,7 @@ To use ``mongosync`` with Atlas clusters, you add the
       --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
 You can also use ``mongodb+srv`` connection strings with ``mongosync``.
-You do not need to add the :urioption:ssl=true <ssl> option to a
+You do not need to add the :urioption:`ssl=true <ssl>` option to a
 ``mongodb+srv`` connection string. For example:
 
 .. code-block:: shell

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -37,12 +37,21 @@ strings for ``cluster0`` and ``cluster1``:
    cluster1:
    mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
 
-<<PUT BACK ORIG EXAMPLE>>
+The ``mongosync`` command layout below is modified for display. To
+connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
+following command on one line:
 
-When using Atlas clusters, ...
+.. code-block:: shell
 
-To connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
-following command:
+   mongosync --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,
+                       clusterOne02.fancyCorp.com:20020,
+                       clusterOne03.fancyCorp.com:20020
+             --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,
+                       clusterTwo02.fancyCorp.com:20020,
+                       clusterTwo03.fancyCorp.com:20020
+
+To use ``mongosync`` with Atlas clusters, you add the
+:urioption:`ssl=true <ssl>` option to enable SSL. For example:
 
 .. code-block:: shell
 
@@ -50,11 +59,9 @@ following command:
       --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/?ssl=true' \
       --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
-The previous command uses the :urioption:`ssl=true <ssl>` option to use
-SSL.
-
 You can also use ``mongodb+srv`` connection strings with ``mongosync``,
-and the :urioption:`ssl=true <ssl>` option is not required. For example:
+and the :urioption:`ssl=true <ssl>` option is not required for Atlas
+clusters. For example:
 
 .. code-block:: shell
 

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -43,10 +43,18 @@ following command on one line:
 
 .. code-block:: shell
 
-   mongosync --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,
-                       clusterOne02.fancyCorp.com:20020,
-                       clusterOne03.fancyCorp.com:20020
-             --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,
-                       clusterTwo02.fancyCorp.com:20020,
-                       clusterTwo03.fancyCorp.com:20020
+   mongosync \
+      --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/?ssl=true' \
+      --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/?ssl=true'
 
+You can also use ``+srv`` connection strings to connect to the cluster,
+and ``ssl=true`` is not required. For example:
+
+.. code-block:: shell
+
+   mongosync \
+      --cluster0 'mongodb+srv://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020/' \
+      --cluster1 'mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/'
+
+For more information about connecting to a cluster using ``mongosync``,
+see :ref:`c2c-connecting`.

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -57,4 +57,4 @@ and ``ssl=true`` is not required. For example:
       --cluster1 'mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/'
 
 For more information about connecting to a cluster using ``mongosync``,
-see :ref:`c2c-connecting`. 
+see :ref:`c2c-connecting`.

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -151,11 +151,11 @@ Use ``curl`` or another HTTP client to issue the :ref:`start
 
 .. code-block:: shell
 
-   curl monogsync01Host:27601/api/v1/start -XPOST --data \
+   curl mongosync01Host:27601/api/v1/start -XPOST --data \
         '{ "source": "cluster0", "destination": "cluster1", \
            "reversible": false, "enableUserWriteBlocking": false }'
 
-   curl monogsync02Host:27602/api/v1/start -XPOST --data \
+   curl mongosync02Host:27602/api/v1/start -XPOST --data \
         '{ "source": "cluster0", "destination": "cluster1", \
            "reversible": false, "enableUserWriteBlocking": false }'
 
@@ -175,10 +175,10 @@ instance synchronizing that shard.
 
 .. code-block:: shell
 
-   curl monogsync02Host:27602/api/v1/progress -XGET
+   curl mongosync02Host:27602/api/v1/progress -XGET
 
 This command checks the progress of the ``mongosync`` instance that is
-running on ``monogsync02Host`` and using ``port 27602`` for
+running on ``mongosync02Host`` and using ``port 27602`` for
 synchronization. To check progress on other shards, update the host and
 port number then repeat the API call to each ``mongosync`` instance.
 
@@ -194,10 +194,10 @@ HTTP client to issue the ``pause`` command to a ``mongosync`` instance.
 
 .. code-block:: shell
 
-   curl monogsync01Host:27601/api/v1/pause -XPOST --data '{}'
+   curl mongosync01Host:27601/api/v1/pause -XPOST --data '{}'
 
 This command pauses the ``mongosync`` instance that is running on
-``monogsync01Host`` and using ``port 27601`` for synchronization. To
+``mongosync01Host`` and using ``port 27601`` for synchronization. To
 pause synchronization on other shards, update the host and port number
 then repeat the API call to each ``mongosync`` instance.
 
@@ -216,10 +216,10 @@ Use ``curl`` or another HTTP client to issue the :ref:`resume
 
 .. code-block:: shell
 
-   curl monogsync01Host:27601/api/v1/resume -XPOST --data '{}'
+   curl mongosync01Host:27601/api/v1/resume -XPOST --data '{}'
 
 This command resumes synchronization on the ``mongosync`` instance that
-is running on ``monogsync01Host`` and using ``port 27601``.  To 
+is running on ``mongosync01Host`` and using ``port 27601``.  To 
 resume synchronization on other shards, update the host and port number
 then repeat the API call to each ``mongosync`` instance.
 
@@ -248,13 +248,13 @@ instance.
 .. code-block:: shell
 
    // Check progress
-   curl monogsync01Host:27601/api/v1/progress -XGET
+   curl mongosync01Host:27601/api/v1/progress -XGET
 
    // Commit 
-   curl monogsync01Host:27601/api/v1/commit -XPOST --data '{}'
+   curl mongosync01Host:27601/api/v1/commit -XPOST --data '{}'
 
 These commands only check progress and commit synchronization for the
-``mongosync`` instance that is running on ``monogsync01Host`` and using
+``mongosync`` instance that is running on ``mongosync01Host`` and using
 ``port 27601``. To synchronize all of the shards, make additional calls
 to ``progress`` and  ``commit`` on any other ``mongosync`` instances
 that may be running.
@@ -279,10 +279,10 @@ instance.
 
 .. code-block:: shell
 
-   curl monogsync01Host:27601/api/v1/reverse -XPOST --data '{}'
+   curl mongosync01Host:27601/api/v1/reverse -XPOST --data '{}'
 
 This command reverses synchronization on the ``mongosync``
-instance that is running on ``monogsync01Host`` and using ``port
+instance that is running on ``mongosync01Host`` and using ``port
 27601``. Make additional calls to ``reverse`` on any other
 ``mongosync`` instances that may be running.
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -157,10 +157,10 @@ Follow the instructions below to setup {+c2c-product-name+}.
 
       For more details, see :ref:`c2c-connecting`.
 
-Initialize ``monogsync``
+Initialize ``mongosync``
 ------------------------
 
-``monogsync`` must create an initial connection to the source and
+``mongosync`` must create an initial connection to the source and
 destination clusters before it can start to sync data. To create the
 initial connection, issue the following command on a single line (the
 command is reformated here for clarity):


### PR DESCRIPTION
JIRA

https://jira.mongodb.org/browse/DOCSP-23870

STAGE

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23870-mongosync-atlas/connecting/atlas-to-atlas/#connect-the-source-and-destination-clusters-with-mongosync

NOTE

JIRA states:
"On the [Quickstart page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/quickstart/#define-administrative-users), we mention the following:

"If the source cluster is hosted in Atlas, the user must have the Atlas admin role. The user must also be able to read the change stream for the cluster."

I was able to successfully run a mongosync with just the Atlas admin role for the source cluster. Do we need the second sentence? I found it a little confusing."

Jason comment:

Spoke with JIRA logger and we agreed to keep the roles as they are currently written in the docs.

I also spotted spelling mistakes in the original content, which I've corrected.
