### PR TITLE
DOCSP-25519 uniqueness of id

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -80,8 +80,9 @@ Sharded Clusters
   - Replica set to sharded cluster.
   - Sharded cluster to replica set.
   - Unequal numbers of source and destination shards.
-- The ``_id`` field must be unique across all of the shards in the
-  cluster. See :ref:`sharded-clusters-unique-indexes` for more details.
+- Within a collection, the ``_id`` field must be unique across all of
+  the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
+  for more details.
 - The :dbcommand:`movePrimary` command cannot be used to reassign the
   primary shard while syncing.
 - There is no replication for zone configuration. ``mongosync``

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -80,6 +80,8 @@ Sharded Clusters
   - Replica set to sharded cluster.
   - Sharded cluster to replica set.
   - Unequal numbers of source and destination shards.
+- The ``_id`` field must be unique across all of the shards in the
+  cluster. See :ref:`sharded-clusters-unique-indexes` for more details.
 - The :dbcommand:`movePrimary` command cannot be used to reassign the
   primary shard while syncing.
 - There is no replication for zone configuration. ``mongosync``


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-25519-uniqueness-of-id-v1.0/reference/limitations/#sharded-clusters)

The 'see for more information' link isn't live yet. It will work when [this PR](https://github.com/10gen/docs-mongodb-internal/pull/1933) in the server repo is merged. 

[JIRA](https://jira.mongodb.org/browse/DOCSP-25519)