### PR TITLE
DOCSP-25767 add versioning documentation v1.0

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -30,4 +30,5 @@ mdb-download-center = "`MongoDB Download Center <https://www.mongodb.com/try/dow
 
 [substitutions]
 c2c-product-name = "Cluster-to-Cluster Sync"
+version = "{+version+}"
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -8,9 +8,8 @@ Cluster-to-Cluster Sync
 .. default-domain:: mongodb
 
 {+c2c-product-name+} provides continuous data synchronization or a 
-one-time data migration between two MongoDB clusters in the same or
-hybrid environments. You can enable {+c2c-product-name+} with the
-:ref:`mongosync <c2c-mongosync>` utility.
+one-time data migration between two MongoDB clusters. You can enable
+{+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 ``mongosync`` can continuously synchronize data between two clusters.
 You can use ``mongosync`` to create dedicated analytics, development,
@@ -24,7 +23,8 @@ facilitate a one time data migration between clusters.
 To get started with ``mongosync``, refer to the :ref:`Quick Start Guide
 <c2c-quickstart>`. For more detailed information, refer to the
 :ref:`c2c-install` or :ref:`c2c-connecting` page that best fits your
-situation.
+situation. See also the :ref:`c2c-limitations` page for important
+restrictions.
 
 .. include:: /includes/limitations-warning
 

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -15,4 +15,5 @@ Reference
    /reference/disaster-recovery
    /reference/limitations
    /reference/logging
+   /reference/versioning
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -54,11 +54,10 @@ General Limitations
 - `Queryable Encryption
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
   not supported.
-- If you replace the ``mongosync`` binary during an upgrade or a
-  downgrade, when you start the replacement binaries the ``mongosync``
-  processes will not resume any work that may have been in progress.
-  Syncing operations restart from the beginning when you start the new
-  processes.
+- After you replace the ``mongosync`` binary during an upgrade or a
+  downgrade, you should drop all non-system databases in the destination
+  cluster. Syncing operations will restart from the beginning when you
+  start the new processes.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -57,7 +57,7 @@ General Limitations
 - If you change the ``mongosync`` binary during an upgrade or a
   downgrade, the replacement ``mongosync`` processes will not resume any
   work that may have been in progress. You must restart any prior
-  synching operations from the beginning.
+  syncing operations from the beginning.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -56,8 +56,8 @@ General Limitations
   not supported.
 - After you replace the ``mongosync`` binary during an upgrade or a
   downgrade, you should drop all non-system databases in the destination
-  cluster. Syncing operations will restart from the beginning when you
-  start the new processes.
+  cluster before starting the new binary. Syncing operations will
+  restart from the beginning when you start the new processes.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -54,6 +54,10 @@ General Limitations
 - `Queryable Encryption
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
   not supported.
+- If you change the ``mongosync`` binary during an upgrade or a
+  downgrade, the replacement ``mongosync`` processes will not resume any
+  work that may have been in progress. You must restart any prior
+  synching operations from the beginning.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -54,10 +54,11 @@ General Limitations
 - `Queryable Encryption
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__ is
   not supported.
-- If you change the ``mongosync`` binary during an upgrade or a
-  downgrade, the replacement ``mongosync`` processes will not resume any
-  work that may have been in progress. You must restart any prior
-  syncing operations from the beginning.
+- If you replace the ``mongosync`` binary during an upgrade or a
+  downgrade, when you start the replacement binaries the ``mongosync``
+  processes will not resume any work that may have been in progress.
+  Syncing operations restart from the beginning when you start the new
+  processes.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -130,19 +130,20 @@ Major Releases
   destination cluster for a given set of input and configuration
   details. Except:
 
-  - Bug fixes for cases where ``mongosync`` failed to replicate data.
+  - Bug fixes for cases where ``mongosync`` fails to replicate data.
   - When the earlier behavior is explicitly documented as unsupported.
 
 - Changes to documented CLI parameters or configuration keys such that
   ``mongosync`` rejects formerly valid input. Except:
 
-  - This does not include bug fixes.
-  - CLI parameters or configuration keys may be deprecated. The meaning
-    of documented CLI parameters or configuration keys will never
-    change. If needed, new parameters or keys will replace the older,
-    deprecated entities. 
+  - Bug fixes such as parsing or type errors.
+  - Even though CLI parameters or configuration keys may be deprecated,
+    the meaning of documented CLI parameters or configuration keys will
+    never change. If needed, new parameters or keys will replace the
+    older, deprecated entities. 
 
-- Breaking compatibility with a supported version of MongoDB Server.
+- Changes that break compatibility with a supported version of MongoDB
+  Server.
 - Dropping a version of the REST API. ``mongosync`` may dropping all
   older endpoints in favor of a new version of the API. There will never
   be any other types of backwards incompatible changes in the REST API.
@@ -151,18 +152,19 @@ Major Releases
   the feature.
 - If ``mongosync`` already supports a major version of MongoDB Server,
   changes that require new access privileges in order to continue
-  support.
+  supporting that version of MongoDB Server.
 
 Minor Releases
 ~~~~~~~~~~~~~~
 
-- Support for a previously incompatible MongoDB Server version.
-- New access privileges for previously unsupported major Server release
-- Support for previously unsupported collection types.
-- Support for previously unsupported index types.
-- New endpoints, new fields, or new accepted inputs in the REST API.
-- New documented CLI options.
-- New configuration keys or accepted values.
+- Adding support for a previously incompatible MongoDB Server version.
+- Requiring new access privileges for previously unsupported major
+  release of MongoDB Server.
+- Adding support for previously unsupported collection types.
+- Adding support for previously unsupported index types.
+- Adding new endpoints, new fields, or new accepted inputs in the REST API.
+- Adding new documented CLI options.
+- Adding new configuration keys or accepted values.
 
 Patch Releases
 ~~~~~~~~~~~~~~
@@ -170,10 +172,9 @@ Patch Releases
 - Backwards compatible bug fixes.
 - Performance regression fixes.
 - Performance improvements.
-- Changes to help strings.
+- Changes to help text strings.
 - Changes to log text strings.
 - Changes to informational text in API responses, but not changes to
   enum-style string fields like "state".
 - Typo fixes.
-
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -21,17 +21,15 @@ version.
 MongoDB uses the following guidelines to determine when to increment the
 version number: 
 
-- Major number. The release breaks backwards compatibility.
-- Minor number. The release includes significant new features that are
+- Major number: The release breaks backwards compatibility.
+- Minor number: The release includes significant new features that are
   backwards compatible.
-- Patch number.: This release only includes small, backwards compatible
+- Patch number: This release only includes small, backwards compatible
   changes.
 
 
 Currently Supported Versions
 ----------------------------
-
-The supported version of ``mongosync`` is {+version+}.
 
 If you are using an unsupported version of ``mongosync``, you may be
 asked to upgrade in order to receive support.
@@ -79,9 +77,10 @@ Patch Releases
 ~~~~~~~~~~~~~~
 
 Only the latest version in each major release series receives new patch
-releases. For example, when version 5.1.0 is released, version 5.0.x
-will no longer receive patch releases. At the same time, version 4.3.2
-will continue to receive patches until version 4.4.0 is released. 
+releases. For example, when version {+c2c-product-name+} 2.1.0 is
+released, version 2.0.x would no longer receive patch releases. At the
+same time, version 1.3.2 would continue to receive patches until version
+1.4.0 was released.
 
 Upgrade and Downgrade
 ~~~~~~~~~~~~~~~~~~~~~
@@ -104,9 +103,9 @@ To upgrade, or downgrade, ``mongosync``:
 Persistent Metadata
 ~~~~~~~~~~~~~~~~~~~
 
-During normal operation, ``mongosync`` creates some metadata that is
+During normal operation, ``mongosync`` creates metadata that is
 persisted to disk. This metadata is not versioned and may change at any
-time.in any version.
+time.
 
 Log Messages
 ~~~~~~~~~~~~
@@ -115,7 +114,7 @@ Log message formats are not versioned and may change at any time. This
 includes changes to the message text, as well as the presence, absence,
 or contents of other fields in the message. 
 
-User scripts and applications should use the :ref:`monitoring API
-<c2c-api-progress>` to determine ``mongosync's`` current state. Scripts
-and applications should not rely on logging output.
+User scripts and applications should not rely on logging output. Scripts
+and applications should use the :ref:`monitoring API <c2c-api-progress>`
+to determine the current state of ``mongosync``.
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -1,8 +1,8 @@
 .. _c2c-release-version-numbers:
 
-===============================
-``mongosync`` Version Numbering
-===============================
+========================
+``mongosync`` Versioning
+========================
 
 .. default-domain:: mongodb
 
@@ -78,9 +78,9 @@ Patch Releases
 
 Only the latest version in each major release series receives new patch
 releases. For example, when version {+c2c-product-name+} 2.1.0 is
-released, version 2.0.x would no longer receive patch releases. At the
-same time, version 1.3.2 would continue to receive patches until version
-1.4.0 was released.
+released, version 2.0 would no longer receive patch releases. At the
+same time, version 1.3 would continue to receive patches until version
+1.4 was released.
 
 Upgrade and Downgrade
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -96,7 +96,7 @@ To upgrade, or downgrade, ``mongosync``:
 .. warning::
  
    The new ``mongosync`` processes do not resume any work that may have
-   been in progress. You must restart any ongoing synching operations
+   been in progress. You must restart any ongoing syncing operations
    from the beginning.
 
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -1,0 +1,121 @@
+.. _c2c-release-version-numbers:
+
+===============================
+``mongosync`` Version Numbering
+===============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+
+{+c2c-product-name+} uses `Semantic Versioning 2.0.0
+<https://semver.org/>`__. Version numbers have the form X.Y.Z, where X
+is the major version, Y is the minor version, and Z is the patch
+version.
+
+MongoDB uses the following guidelines to determine when to increment the
+version number: 
+
+- Major number. The release breaks backwards compatibility.
+- Minor number. The release includes significant new features that are
+  backwards compatible.
+- Patch number.: This release only includes small, backwards compatible
+  changes.
+
+
+Currently Supported Versions
+----------------------------
+
+The supported version of ``mongosync`` is {+version+}.
+
+If you are using an unsupported version of ``mongosync``, you may be
+asked to upgrade in order to receive support.
+
+
+MongoDB Server Version Compatibility and Support
+------------------------------------------------
+
+{+c2c-product-name+} supports the following versions of MongoDB Server:
+
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - ``mongosync`` Version
+     - MongoDB Server Version
+
+   * - 1.0.0
+     - 6.0.x
+
+Considerations
+--------------
+
+{+c2c-product-name+} has the following version related considerations:
+
+Same Server Version
+~~~~~~~~~~~~~~~~~~~
+
+{+c2c-product-name+} only supports syncing between the same version of
+MongoDB Server. All three :ref:`server version numbers
+<release-version-numbers>`, including the patch number, must be the
+same on both servers.
+
+Support Lifecycle 
+~~~~~~~~~~~~~~~~~
+
+- Major releases are supported for at least one year from the first
+  release in that series.
+- If a version of {+c2c-product-name+} only works with an unsupported 
+  version of MongoDB Server, that version of {+c2c-product-name+} is
+  also unsupported.
+
+Patch Releases
+~~~~~~~~~~~~~~
+
+Only the latest version in each major release series receives new patch
+releases. For example, when version 5.1.0 is released, version 5.0.x
+will no longer receive patch releases. At the same time, version 4.3.2
+will continue to receive patches until version 4.4.0 is released. 
+
+Upgrade and Downgrade
+~~~~~~~~~~~~~~~~~~~~~
+
+To upgrade, or downgrade, ``mongosync``:
+
+- Stop all currently running ``mongosync`` processes.
+- Drop all non-system databases in the destination cluster.
+- :ref:`Install <c2c-install>` new ``mongosync`` binaries.
+- :ref:`Start <c2c-api-start>` the ``mongosync`` processes using the new
+  binaries.
+
+.. warning::
+ 
+   The new ``mongosync`` processes do not resume any work that may have
+   been in progress. You must restart any ongoing synching operations
+   from the beginning.
+
+
+Persistent Metadata
+~~~~~~~~~~~~~~~~~~~
+
+During normal operation, ``mongosync`` creates some metadata that is
+persisted to disk. This metadata is not versioned and may change at any
+time.in any version.
+
+Log Messages
+~~~~~~~~~~~~
+
+Log message formats are not versioned and may change at any time. This
+includes changes to the message text, as well as the presence, absence,
+or contents of other fields in the message. 
+
+User scripts and applications should use the :ref:`monitoring API
+<c2c-api-progress>` to determine ``mongosync's`` current state. Scripts
+and applications should not rely on logging output.
+

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -14,9 +14,9 @@
 
 
 {+c2c-product-name+} uses `Semantic Versioning 2.0.0
-<https://semver.org/>`__. Version numbers have the form X.Y.Z, where X
-is the major version, Y is the minor version, and Z is the patch
-version.
+<https://semver.org/>`__. Version numbers have the form ``X.Y.Z``, where
+``X`` is the major version, ``Y`` is the minor version, and ``Z`` is the
+patch version.
 
 MongoDB uses the following guidelines to determine when to increment the
 version number: 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -85,7 +85,7 @@ same time, version 1.3.2 would continue to receive patches until version
 Upgrade and Downgrade
 ~~~~~~~~~~~~~~~~~~~~~
 
-To upgrade, or downgrade, ``mongosync``:
+To upgrade, or downgrade ``mongosync``:
 
 - Stop all currently running ``mongosync`` processes.
 - Drop all non-system databases in the destination cluster.
@@ -96,16 +96,15 @@ To upgrade, or downgrade, ``mongosync``:
 .. warning::
  
    The new ``mongosync`` processes do not resume any work that may have
-   been in progress. You must restart any ongoing syncing operations
-   from the beginning.
-
+   been in progress. Syncing operations restart from the beginning when
+   you start the new processes.
 
 Persistent Metadata
 ~~~~~~~~~~~~~~~~~~~
 
 During normal operation, ``mongosync`` creates metadata that is
-persisted to disk. This metadata is not versioned and may change at any
-time.
+persisted to disk in the destination database. This metadata is not
+versioned and may change at any time.
 
 Log Messages
 ~~~~~~~~~~~~

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -117,3 +117,63 @@ User scripts and applications should not rely on logging output. Scripts
 and applications should use the :ref:`monitoring API <c2c-api-progress>`
 to determine the current state of ``mongosync``.
 
+Examples
+--------
+
+The following examples illustrate the kinds of changes that would result
+in each type of version number update. 
+
+Major Releases
+~~~~~~~~~~~~~~
+
+- Changes that produce a different, user-visible result on the
+  destination cluster for a given set of input and configuration
+  details. Except:
+
+  - Bug fixes for cases where ``mongosync`` failed to replicate data.
+  - When the earlier behavior is explicitly documented as unsupported.
+
+- Changes to documented CLI parameters or configuration keys such that
+  ``mongosync`` rejects formerly valid input. Except:
+
+  - This does not include bug fixes.
+  - CLI parameters or configuration keys may be deprecated. The meaning
+    of documented CLI parameters or configuration keys will never
+    change. If needed, new parameters or keys will replace the older,
+    deprecated entities. 
+
+- Breaking compatibility with a supported version of MongoDB Server.
+- Dropping a version of the REST API. ``mongosync`` may dropping all
+  older endpoints in favor of a new version of the API. There will never
+  be any other types of backwards incompatible changes in the REST API.
+- Removing support for a previously supported MongoDB Server feature if
+  ``mongosync`` still supports a version of MongoDB Server that supports
+  the feature.
+- If ``mongosync`` already supports a major version of MongoDB Server,
+  changes that require new access privileges in order to continue
+  support.
+
+Minor Releases
+~~~~~~~~~~~~~~
+
+- Support for a previously incompatible MongoDB Server version.
+- New access privileges for previously unsupported major Server release
+- Support for previously unsupported collection types.
+- Support for previously unsupported index types.
+- New endpoints, new fields, or new accepted inputs in the REST API.
+- New documented CLI options.
+- New configuration keys or accepted values.
+
+Patch Releases
+~~~~~~~~~~~~~~
+
+- Backwards compatible bug fixes.
+- Performance regression fixes.
+- Performance improvements.
+- Changes to help strings.
+- Changes to log text strings.
+- Changes to informational text in API responses, but not changes to
+  enum-style string fields like "state".
+- Typo fixes.
+
+

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -19,7 +19,7 @@
 patch version.
 
 MongoDB uses the following guidelines to determine when to increment the
-version number: 
+version number for {+c2c-product-name+}: 
 
 - Major number: The release breaks backwards compatibility.
 - Minor number: The release includes significant new features that are

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -126,11 +126,12 @@ in each type of version number update.
 Major Releases
 ~~~~~~~~~~~~~~
 
-- Changes that produce a different, user-visible result on the
-  destination cluster for a given set of input and configuration
-  details. Except:
+- Changes that make the new and old versions of ``mongosync`` produce
+  different results on the  destination cluster for the same set of
+  inputs. Except:
 
-  - Bug fixes for cases where ``mongosync`` fails to replicate data.
+  - Bug fixes for cases where the older version of ``mongosync`` fails
+    to replicate data.
   - When the earlier behavior is explicitly documented as unsupported.
 
 - Changes to documented CLI parameters or configuration keys such that
@@ -158,7 +159,7 @@ Minor Releases
 ~~~~~~~~~~~~~~
 
 - Adding support for a previously incompatible MongoDB Server version.
-- Requiring new access privileges for previously unsupported major
+- Requiring new access privileges for a previously unsupported major
   release of MongoDB Server.
 - Adding support for previously unsupported collection types.
 - Adding support for previously unsupported index types.


### PR DESCRIPTION
[VERSIONING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-25767-add-versioning-documentation-v1.0/reference/versioning/)
[INDEX PAGE](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-25767-add-versioning-documentation-v1.0/)
[LIMITATIONS](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-25767-add-versioning-documentation-v1.0/reference/limitations/)

[JIRA](https://jira.mongodb.org/browse/DOCSP-25767)

