### PR TITLE
DOCSP-26762 rapid releases not supported

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -25,6 +25,9 @@ General Limitations
 -------------------
 
 - The minimum supported server version is MongoDB 6.0.
+- ``mongosync`` supports major MongoDB releases such as 6.0, 7.0. Rapid
+  releases such as 6.1, 6.2 are not supported. For more information on
+  MongoDB versioning, see :ref:`release-version-numbers`.
 - The source and destination clusters must have the same release
   version.
 - The minimum supported :dbcommand:`Feature Compatibility Version

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -25,9 +25,10 @@ General Limitations
 -------------------
 
 - The minimum supported server version is MongoDB 6.0.
-- ``mongosync`` supports major MongoDB releases such as 6.0, 7.0. Rapid
-  releases such as 6.1, 6.2 are not supported. For more information on
-  MongoDB versioning, see :ref:`release-version-numbers`.
+- ``mongosync`` does not support MongoDB rapid releases such as 6.1 or
+  6.2. Only major MongoDB releases such as 6.0 or 7.0. are supported.
+  For more information on MongoDB versioning, see
+  :ref:`release-version-numbers`.
 - The source and destination clusters must have the same release
   version.
 - The minimum supported :dbcommand:`Feature Compatibility Version


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-26762-rapid-releases-not-supported-v1.0/reference/limitations/#general-limitations)

[JIRA](https://jira.mongodb.org/browse/DOCSP-26762)