### PR TITLE
DOCSP-26789 duplicate note box

### DIFF
--- a/source/includes/fact-atlas-roles.rst
+++ b/source/includes/fact-atlas-roles.rst
@@ -1,17 +1,4 @@
 The user specified in the connection string must have, at a minimum, the
 :atlasrole:`atlasAdmin` role.
 
-.. note:: 
-
-   To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
-   you must :atlas:`create a custom role 
-   </reference/api/custom-roles-create-a-role>` that grants the
-   following ActionTypes:
-   
-   - :authaction:`setUserWriteBlockMode`
-   - :authaction:`bypassWriteBlockingMode`
-   
-   The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
-   ActionTypes are available starting in MongoDB 6.0. To create the custom
-   roles, all clusters in a project must be on MongoDB 6.0 or higher.
-
+.. include:: /includes/fact-reverse-sync-action-types.rst

--- a/source/includes/fact-reverse-sync-action-types.rst
+++ b/source/includes/fact-reverse-sync-action-types.rst
@@ -1,0 +1,14 @@
+.. note:: 
+
+   To use ``mongosync`` in the :ref:`reverse direction <c2c-api-reverse>`,
+   you must :atlas:`create a custom role 
+   </reference/api/custom-roles-create-a-role>` that grants the
+   following ActionTypes:
+   
+   - :authaction:`setUserWriteBlockMode`
+   - :authaction:`bypassWriteBlockingMode`
+   
+   The ``setUserWriteBlockMode`` and ``bypassWriteBlockingMode``
+   ActionTypes are available starting in MongoDB 6.0. To create the custom
+   roles, all clusters in a project must be on MongoDB 6.0 or higher.
+

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -245,6 +245,8 @@ Synchronization Notes
   .. literalinclude:: /includes/api/requests/reverse.sh
    :language: shell
 
+.. include:: /includes/fact-reverse-sync-action-types.rst
+
 - You may need to increase the file descriptor ``ulimits`` on the host
   that is running ``mongosync``. This applies to any UNIX-like system,
   but macOS in particular has low defaults. See :ref:`UNIX ulimit
@@ -253,5 +255,4 @@ Synchronization Notes
 - To estimate the size of ``oplog`` needed for initial synchronization,
   see: :ref:`c2c-oplog-sizing`.
 
-.. include:: /includes/fact-reverse-sync-action-types.rst
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -253,3 +253,5 @@ Synchronization Notes
 - To estimate the size of ``oplog`` needed for initial synchronization,
   see: :ref:`c2c-oplog-sizing`.
 
+.. include:: /includes/fact-reverse-sync-action-types.rst
+

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -47,6 +47,8 @@ To use the ``reverse`` endpoint:
   :ref:`resync <resync-replica-member>` all of the nodes in the
   original source cluster before reversing.
 
+.. include:: /includes/fact-reverse-sync-action-types.rst
+
 Request
 -------
 


### PR DESCRIPTION
[STAGING reverse](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-26789-duplicate-note-box-v1.0/reference/api/reverse/)
[STAGING sync notes](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-26789-duplicate-note-box-v1.0/quickstart/#synchronization-notes)
[STAGING atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-26789-duplicate-note-box-v1.0/connecting/onprem-to-atlas/#roles)

[JIRA](https://jira.mongodb.org/browse/DOCSP-26789)