### PR TITLE
DOCS-15702 Static Unlike Topologies 

### DIFF
--- a/source/includes/api/requests/start-rs-shard.sh
+++ b/source/includes/api/requests/start-rs-shard.sh
@@ -1,0 +1,21 @@
+curl localhost:27182/api/v1/start -XPOST \
+--data '
+   {
+      "source": "cluster0",
+      "destination": "cluster1",
+      "sharding": {
+         "createSupportingIndexes": true,
+         "shardingEntries": [
+            {
+                "database": "accounts",
+                "collection": "us_east",
+                "shardCollection": {
+                   "key": [
+                      { "location": 1 },
+                      { "region": 1 },
+                   ]
+                }
+            }
+         ]
+      }
+   } '

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -94,14 +94,14 @@ Request Body Parameters
    * - ``reversible``
      - boolean
      - Optional
-     - If set to ``true``, enables the synchronization operation to be
+     - If set to ``true``, enables the sync operation to be
        reversed. 
 
        This option is not supported for the following configurations:
 
-       * Synchronizing from a replica set to a sharded cluster
+       * Sync from a replica set to a sharded cluster
 
-       * Synchronizing sharded clusters that have different numbers of shards
+       * Sync sharded clusters that have different numbers of shards
        
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        
@@ -110,7 +110,7 @@ Request Body Parameters
    * - ``sharding``
      - document
      - Optional
-     - Configure synchronization between a replica set and sharded cluster.
+     - Configure sync between a replica set and sharded cluster.
        Sync from a replica set to a sharded cluster requires this
        option.
 
@@ -272,7 +272,7 @@ following configurations:
 
 * Sync from a replica set to a sharded cluster.
 
-* Synchronization between sharded clusters that differ in the number of shards.
+* Sync between sharded clusters that differ in the number of shards.
 
 
 Shard Replica Sets 
@@ -280,7 +280,7 @@ Shard Replica Sets
 
 .. versionadded:: 1.1
 
-Synchronization from a replica set to a sharded cluster requires the 
+Sync from a replica set to a sharded cluster requires the 
 ``sharding`` option. This option configures how ``mongosync`` shards
 collections.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -126,8 +126,8 @@ Request Body Parameters
 Sharding Parameters
 ~~~~~~~~~~~~~~~~~~~
 
-The request body must have the ``sharding`` option when syncing from
-the replica set to a sharded cluster.
+Synchronization from a replica set to a sharded cluster requires the 
+``sharding`` option to shard collections on the destination cluster.
 
 The ``sharding`` option has the following parameters:
 
@@ -142,24 +142,26 @@ The ``sharding`` option has the following parameters:
 
    * - ``createSupportedIndexes``
      - boolean
-     - Sets whether synchronization includes the creation of supporting indexes 
-       on the destination cluster.
+     - Optional. Sets whether synchronization creates a supporting index 
+       for the shard key, if none exists.
 
    * - ``shardingEntries``
      - array
-     - Required.  Specifies the collections to shard on the destiniation
-       cluster.
+     - Required.  Specifies the namespace and key of collections to shard 
+       during synchronization.
+
+       Any collections not included in this array synchronize to unsharded 
+       collections on the destination cluster.
 
    * - | ``shardingEntries``
        | ``.collection``
      - string
-     - Specifies the collection to shard on the destination cluster.
+     - Optional. Specifies the collection to shard. 
 
    * - | ``shardingEntries``
        | ``.database``
      - string
-     - Specifies the database of the collection to shard on the
-       destination cluster.
+     - Optional.  Specifies the database of the collection to shard.
  
    * - | ``shardingEntries``
        | ``.shardCollection``
@@ -170,8 +172,7 @@ The ``sharding`` option has the following parameters:
        | ``.shardCollection``
        | ``.key``
      - array 
-     - Specifies the indexes to use for the shard key on the destination.
-
+     - Specifies the indexes to use for the shard key. 
 
 
 Response
@@ -221,5 +222,54 @@ Response
 Behavior
 --------
 
+State
+~~~~~
+
 If the ``start`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
+
+Sharding Collections
+~~~~~~~~~~~~~~~~~~~~~
+
+Synchronization from a replica set to a sharded cluster requires the 
+``sharding`` option, to specify how ``mongosync`` should shard collections.
+
+The ``sharding.shardEntries`` array specifies the collections to shard.
+Collections that are not listed in this array replicate as unsharded.
+
+Supporting Indexes
+~~~~~~~~~~~~~~~~~~
+
+Synchronization from a replica set to a sharded cluster can automatically
+create a supporting index for the new shard key on the destination cluster.
+This is done by setting the ``sharding.createSupportingIndexes`` option.
+
+When ``sharding.createSupportingIndexes`` is ``false`` (the default): 
+
+* Each shard key the user provides for the `sharding.shardEntries`` option
+  must have an existing index on the source cluster.
+
+* One of the indexes used for the shard key must have simple collation if the 
+  collection uses any other collation.
+
+* To use a unique index in the shard key, you must specify its uniqueness when
+  you create the index on the source cluster. 
+
+* Unique indexes on the source cluster that are incompatible with the requested
+  shard key on the destination cluster, such as a unique index on the source
+  that does not contain the requested shard key as a prefix on the destination,
+  can cause ``mongosync`` to fail.
+
+When ``sharding.createSupportingIndexes`` is ``true``: 
+
+* ``mongosync`` synchronizes indexes on the source cluster to the destination.
+
+* If the supporting indexes exist on the source cluster, ``mongosync`` 
+  synchronizes the indexes to the destination cluster and uses them 
+  as the shard key.
+
+* If the supporting indexes don't exist, ``mongosync`` creates them on the
+  destination cluster.
+
+``mongosync`` either creates supporting indexes for all collections or none.
+

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -136,32 +136,41 @@ The ``sharding`` option has the following parameters:
    :stub-columns: 1
    :widths: 15 15 70
 
+   * - Parameter
+     - Type
+     - Description
+
    * - ``createSupportedIndexes``
      - boolean
-     -
-
-   * - ``ignoreUnusedShardingEntries``
-     - boolean
-     - 
+     - Sets whether synchronization includes the creation of supporting indexes 
+       on the destination cluster.
 
    * - ``shardingEntries``
      - array
-     -
+     - Required.  Specifies the collections to shard on the destiniation
+       cluster.
 
-   * - | ``shardEntries``
+   * - | ``shardingEntries``
        | ``.collection``
      - string
-     -
+     - Specifies the collection to shard on the destination cluster.
 
-   * - | ``shardEntries``
+   * - | ``shardingEntries``
        | ``.database``
      - string
-     - 
+     - Specifies the database of the collection to shard on the
+       destination cluster.
  
-   * - | ``shardEntries``
+   * - | ``shardingEntries``
        | ``.shardCollection``
-     - string
-     -
+     - document 
+     - Specifies the shard key to generate on the destination cluster.
+
+   * - | ``shardingEntries``
+       | ``.shardCollection``
+       | ``.key``
+     - array 
+     - Specifies the indexes to use for the shard key on the destination.
 
 
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -116,6 +116,8 @@ Request Body Parameters
 
        For more information, see :ref:`c2c-api-start-sharding`. 
 
+       .. versionadded:: 1.1
+
    * - ``enableUserWriteBlocking``
      - boolean
      - Optional
@@ -132,6 +134,8 @@ Request Body Parameters
 
 Sharding Parameters
 ~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.1
 
 To synchronize from a replica set to a sharded cluster, set the 
 ``sharding`` option to shard collections on the destination cluster.
@@ -257,8 +261,24 @@ State
 If the ``start`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
 
-Shard Collections
-~~~~~~~~~~~~~~~~~~~~~
+Pre-Split Chunks
+~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.1
+
+When ``mongosync`` synchronizes to a sharded cluster, it pre-splits chunks for
+sharded collections on the destination cluster.  This provides support for the
+following configurations:
+
+* Synchronization from a replica set to a sharded cluster.
+
+* Synchronization between sharded clusters that differ in the number of shards.
+
+
+Shard Replica Sets 
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.1
 
 Synchronization from a replica set to a sharded cluster requires the 
 ``sharding`` option. This option configures how ``mongosync`` shards
@@ -269,6 +289,8 @@ Collections that are not listed in this array replicate as unsharded.
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.1
 
 ``mongosync`` synchronizes indexes from the source cluster to the destination
 cluster.  But, when synchronizing from a replica set to a sharded cluster,
@@ -306,9 +328,10 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 The ``sharding.createSupportingIndexes`` option affects all collections sharded
 during sync.
 
-
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 1.1
 
 Collections listed in the ``sharding.shardEntries`` array 
 when synchronized from the replica set to a sharded cluster 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -258,7 +258,8 @@ Shard Collections
 ~~~~~~~~~~~~~~~~~~~~~
 
 Synchronization from a replica set to a sharded cluster requires the 
-``sharding`` option, to specify how ``mongosync`` should shard collections.
+``sharding`` option. This option configures how ``mongosync`` shards
+collections.
 
 The ``sharding.shardEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
@@ -304,9 +305,9 @@ during sync.
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~
 
-Collections synchronized from a replica set to a sharded cluster listed in
-the ``sharding.shardEntries`` array become sharded collections on the
-destination cluster.
+Collections listed in the ``sharding.shardEntries`` array 
+when synchronized from the replica set to a sharded cluster 
+become sharded collections on the destination cluster.
 
 Renaming a collection (such as with the :dbcommand:`renameCollection` command)
 on the source cluster after calling ``start`` but before ``mongosync`` begins 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -111,7 +111,7 @@ Request Body Parameters
      - document
      - Optional
      - Configure synchronization between a replica set and sharded cluster.
-       Synchronization from a replica set to a sharded cluster requires this
+       Sync from a replica set to a sharded cluster requires this
        option.
 
        For more information, see :ref:`c2c-api-start-sharding`. 
@@ -137,7 +137,7 @@ Sharding Parameters
 
 .. versionadded:: 1.1
 
-To synchronize from a replica set to a sharded cluster, set the 
+To sync from a replica set to a sharded cluster, set the 
 ``sharding`` option to shard collections on the destination cluster.
 
 The ``sharding`` option has the following parameters:
@@ -153,15 +153,15 @@ The ``sharding`` option has the following parameters:
 
    * - ``createSupportedIndexes``
      - boolean
-     - Optional. Sets whether synchronization creates a supporting index 
+     - Optional. Sets whether sync creates a supporting index 
        for the shard key, if none exists.  Defaults to ``false``.
 
    * - ``shardingEntries``
      - array of documents
      - Required. Sets the namespace and key of collections to shard 
-       during synchronization.
+       during sync.
 
-       Collections not included in this array synchronize to unsharded 
+       Collections not included in this array sync to unsharded 
        collections on the destination cluster.  If set with an empty array, 
        no collections are sharded.
 
@@ -189,7 +189,7 @@ The ``sharding`` option has the following parameters:
        For more information, see :ref:`shard-key`.
 
 ``mongosync`` throws an error if the ``sharding`` option is not set when
-synchronizing from a replica set to a sharded cluster.  ``mongosync`` also
+syncing from a replica set to a sharded cluster.  ``mongosync`` also
 throws an error if the ``sharding`` option is set with any other configuration.
 
 Response
@@ -266,11 +266,11 @@ Pre-Split Chunks
 
 .. versionadded:: 1.1
 
-When ``mongosync`` synchronizes to a sharded cluster, it pre-splits chunks for
+When ``mongosync`` syncs to a sharded cluster, it pre-splits chunks for
 sharded collections on the destination cluster.  This is supported in the
 following configurations:
 
-* Synchronization from a replica set to a sharded cluster.
+* Sync from a replica set to a sharded cluster.
 
 * Synchronization between sharded clusters that differ in the number of shards.
 
@@ -292,8 +292,8 @@ Supporting Indexes
 
 .. versionadded:: 1.1
 
-``mongosync`` synchronizes indexes from the source cluster to the destination
-cluster.  But, when synchronizing from a replica set to a sharded cluster,
+``mongosync`` syncs indexes from the source cluster to the destination
+cluster.  But, when syncing from a replica set to a sharded cluster,
 ``mongosync`` may require the an additional index to support the shard key,
 which may not exist on the source cluster.
 
@@ -319,7 +319,7 @@ When ``sharding.createSupportingIndexes`` is ``false`` (the default):
 When ``sharding.createSupportingIndexes`` is ``true``: 
 
 * If the supporting indexes exist on the source cluster, ``mongosync`` 
-  synchronizes the indexes to the destination cluster and uses them 
+  syncs the indexes to the destination cluster and uses them 
   as the shard key.
 
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
@@ -334,7 +334,7 @@ Rename During Sync
 .. versionadded:: 1.1
 
 Collections listed in the ``sharding.shardEntries`` array 
-when synchronized from the replica set to a sharded cluster 
+when synced from the replica set to a sharded cluster 
 become sharded collections on the destination cluster.
 
 Renaming a collection (such as with the :dbcommand:`renameCollection` command)

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -318,6 +318,11 @@ Renaming a collection (such as with the :dbcommand:`renameCollection` command)
 on the source cluster after calling ``start`` but before ``mongosync`` begins 
 to copy the collection can block the collection from sharding on the destination.
 
+.. note:: 
+
+   Renaming collections to use a different database while ``mongosync``
+   is running is not supported
+
 To check whether it is safe to rename collections, call the 
 :ref:`c2c-api-progress` endpoint and check the value of the 
 ``collectionCopy.estimatedCopiedBytes`` field in the return document.  

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -273,3 +273,27 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 
 ``mongosync`` either creates supporting indexes for all collections or none.
 
+Rename during Sync
+~~~~~~~~~~~~~~~~~~
+
+Collections synchronized from a replica set to a sharded cluster listed in
+the ``sharding.shardEntries`` array, become sharded collections on the
+destination cluster.
+
+Renaming a collection, such as with the :dbcommand:`renameCollection` command
+on the source cluster after calling ``start`` but before ``mongosync`` begins 
+to copy the collection can block the collection from sharding on the destination.
+
+To check whether a collection is safe to rename, call the :ref:`c2c-api-progress`
+endpoint and check the value of the ``collectionCopy.estimatedCopiedBytes`` field 
+in the return document.  
+
+* A value of 0 indicates that ``mongosync`` has not yet begun to copy the
+  collection.  Renaming the collection at this point results in the collection 
+  being unsharded on the destination cluster.
+
+* A value greater than 0 indicates that ``mongosync`` has begun the copy and
+  read the shard map.  Renaming the collection from this point on does not block
+  its sharding on the destination cluster, even in the event  of a crash.
+
+

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -294,7 +294,7 @@ Supporting Indexes
 
 ``mongosync`` syncs indexes from the source cluster to the destination
 cluster.  But, when syncing from a replica set to a sharded cluster,
-``mongosync`` may require the an additional index to support the shard key,
+``mongosync`` may require an additional index to support the shard key,
 which may not exist on the source cluster.
 
 ``mongosync`` can create supporting indexes for sharded collections during sync.
@@ -320,13 +320,12 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 
 * If the supporting indexes exist on the source cluster, ``mongosync`` 
   syncs the indexes to the destination cluster and uses them 
-  as the shard key.
+  as shard keys. 
 
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
   destination cluster.
 
-The ``sharding.createSupportingIndexes`` option affects all collections sharded
-during sync.
+The ``sharding.createSupportingIndexes`` option affects all collections sharded.
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~
@@ -334,7 +333,7 @@ Rename During Sync
 .. versionadded:: 1.1
 
 Collections listed in the ``sharding.shardEntries`` array 
-when synced from the replica set to a sharded cluster 
+when synced from a replica set to a sharded cluster 
 become sharded collections on the destination cluster.
 
 Renaming a collection (such as with the :dbcommand:`renameCollection` command)
@@ -343,8 +342,9 @@ to copy the collection can block the collection from sharding on the destination
 
 .. note:: 
 
-   Renaming collections to use a different database while ``mongosync``
-   is running is not supported
+   Renaming collections to use a different database while syncing from a
+   replica set to a sharded cluster is not supported.
+    
 
 To check whether it is safe to rename collections, call the 
 :ref:`c2c-api-progress` endpoint and check the value of the 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -262,7 +262,7 @@ This is done by setting the ``sharding.createSupportingIndexes`` option.
 
 When ``sharding.createSupportingIndexes`` is ``false`` (the default): 
 
-* Each shard key the user provides for the `sharding.shardEntries`` option
+* Each shard key the user provides for the ``sharding.shardEntries`` option
   must have an existing index on the source cluster.
 
 * One of the indexes used for the shard key must have simple collation if the 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -267,7 +267,7 @@ Pre-Split Chunks
 .. versionadded:: 1.1
 
 When ``mongosync`` synchronizes to a sharded cluster, it pre-splits chunks for
-sharded collections on the destination cluster.  This provides support for the
+sharded collections on the destination cluster.  This is supported in the
 following configurations:
 
 * Synchronization from a replica set to a sharded cluster.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -179,7 +179,9 @@ The ``sharding`` option has the following parameters:
        | ``.shardCollection``
        | ``.key``
      - array 
-     - Sets the indexes to use for the shard key. 
+     - Sets the fields to use for the shard key.
+
+       For more information, see :ref:`shard-key`.
 
 ``mongosync`` throws an error if the ``sharding`` option is not set when
 synchronizing from a replica set to a sharded cluster.  ``mongosync`` also

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -104,45 +104,10 @@ Request Body Parameters
      - document
      - Optional
      - Configure synchronization between a replica set and sharded cluster.
+       Synchronization from a replica set to a sharded cluster requires this
+       option.
 
-   * - | ``sharding``
-       | ``.createSupportedIndexes``
-     - boolean
-     - 
-     -
-
-   * - | ``sharding``
-       | ``.ignoreUnusedShardingEntries``
-     - boolean
-     - 
-     - 
-
-   * - | ``sharding``
-       | ``.shardingEntries``
-     - array
-     -
-     -
-
-   * - | ``sharding``
-       | ``.shardEntries``
-       | ``.collection``
-     - string
-     -
-     -
-
-   * - | ``sharding``
-       | ``.shardEntries``
-       | ``.database``
-     - string
-     - 
-     - 
- 
-   * - | ``sharding``
-       | ``.shardEntries``
-       | ``.shardCollection``
-     - string
-     -
-     -
+       See :ref:`c2c-api-start-sharding` for more information.
 
    * - ``enableUserWriteBlocking``
      - boolean
@@ -154,6 +119,51 @@ Request Body Parameters
        accepts writes.
 
        Default value is ``false``.
+
+
+.. _c2c-api-start-sharding:
+
+Sharding Parameters
+~~~~~~~~~~~~~~~~~~~
+
+The request body must have the ``sharding`` option when syncing from
+the replica set to a sharded cluster.
+
+The ``sharding`` option has the following parameters:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 15 15 70
+
+   * - ``createSupportedIndexes``
+     - boolean
+     -
+
+   * - ``ignoreUnusedShardingEntries``
+     - boolean
+     - 
+
+   * - ``shardingEntries``
+     - array
+     -
+
+   * - | ``shardEntries``
+       | ``.collection``
+     - string
+     -
+
+   * - | ``shardEntries``
+       | ``.database``
+     - string
+     - 
+ 
+   * - | ``shardEntries``
+       | ``.shardCollection``
+     - string
+     -
+
+
 
 Response
 --------

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -142,12 +142,12 @@ The ``sharding`` option has the following parameters:
 
    * - ``createSupportedIndexes``
      - boolean
-     - Optional. Sets whether synchronization creates a supporting index 
+     - Sets whether synchronization creates a supporting index 
        for the shard key, if none exists.
 
    * - ``shardingEntries``
      - array
-     - Required.  Specifies the namespace and key of collections to shard 
+     - Specifies the namespace and key of collections to shard 
        during synchronization.
 
        Any collections not included in this array synchronize to unsharded 
@@ -156,23 +156,23 @@ The ``sharding`` option has the following parameters:
    * - | ``shardingEntries``
        | ``.collection``
      - string
-     - Optional. Specifies the collection to shard. 
+     - Specifies the collection to shard. 
 
    * - | ``shardingEntries``
        | ``.database``
      - string
-     - Optional.  Specifies the database of the collection to shard.
+     - Specifies the database of the collection to shard.
  
    * - | ``shardingEntries``
        | ``.shardCollection``
      - document 
-     - Specifies the shard key to generate on the destination cluster.
+     - Sets the shard key to generate on the destination cluster.
 
    * - | ``shardingEntries``
        | ``.shardCollection``
        | ``.key``
      - array 
-     - Specifies the indexes to use for the shard key. 
+     - Sets the indexes to use for the shard key. 
 
 
 Response
@@ -228,7 +228,7 @@ State
 If the ``start`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
 
-Sharding Collections
+Shard Collections
 ~~~~~~~~~~~~~~~~~~~~~
 
 Synchronization from a replica set to a sharded cluster requires the 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -225,7 +225,7 @@ Example 3 - Start Sync from Replica Set to Sharded Cluster
 Request
 ~~~~~~~
 
-.. literalinclude:: /includes/api/requests/start-shard.sh
+.. literalinclude:: /includes/api/requests/start-rs-shard.sh
    :language: shell
 
 Response

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -100,6 +100,50 @@ Request Body Parameters
        
        Default value is ``false``.
 
+   * - ``sharding``
+     - document
+     - Optional
+     - Configure synchronization between a replica set and sharded cluster.
+
+   * - | ``sharding``
+       | ``.createSupportedIndexes``
+     - boolean
+     - 
+     -
+
+   * - | ``sharding``
+       | ``.ignoreUnusedShardingEntries``
+     - boolean
+     - 
+     - 
+
+   * - | ``sharding``
+       | ``.shardingEntries``
+     - array
+     -
+     -
+
+   * - | ``sharding``
+       | ``.shardEntries``
+       | ``.collection``
+     - string
+     -
+     -
+
+   * - | ``sharding``
+       | ``.shardEntries``
+       | ``.database``
+     - string
+     - 
+     - 
+ 
+   * - | ``sharding``
+       | ``.shardEntries``
+       | ``.shardCollection``
+     - string
+     -
+     -
+
    * - ``enableUserWriteBlocking``
      - boolean
      - Optional

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -95,8 +95,15 @@ Request Body Parameters
      - boolean
      - Optional
      - If set to ``true``, enables the synchronization operation to be
-       reversed. For more information, see the :ref:`reverse
-       <c2c-api-reverse>` endpoint.
+       reversed. 
+
+       This option is not supported for the following configurations:
+
+       * Synchronizing from a replica set to a sharded cluster
+
+       * Synchronizing sharded clusters that have different numbers of shards
+       
+       For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        
        Default value is ``false``.
 
@@ -107,7 +114,7 @@ Request Body Parameters
        Synchronization from a replica set to a sharded cluster requires this
        option.
 
-       See :ref:`c2c-api-start-sharding` for more information.
+       For more information, see :ref:`c2c-api-start-sharding`. 
 
    * - ``enableUserWriteBlocking``
      - boolean
@@ -126,7 +133,7 @@ Request Body Parameters
 Sharding Parameters
 ~~~~~~~~~~~~~~~~~~~
 
-Synchronization from a replica set to a sharded cluster requires the 
+To synchronize from a replica set to a sharded cluster, set the 
 ``sharding`` option to shard collections on the destination cluster.
 
 The ``sharding`` option has the following parameters:
@@ -142,12 +149,12 @@ The ``sharding`` option has the following parameters:
 
    * - ``createSupportedIndexes``
      - boolean
-     - Sets whether synchronization creates a supporting index 
+     - Optional. Sets whether synchronization creates a supporting index 
        for the shard key, if none exists.
 
    * - ``shardingEntries``
-     - array
-     - Specifies the namespace and key of collections to shard 
+     - array of documents
+     - Required. Sets the namespace and key of collections to shard 
        during synchronization.
 
        Any collections not included in this array synchronize to unsharded 
@@ -156,12 +163,12 @@ The ``sharding`` option has the following parameters:
    * - | ``shardingEntries``
        | ``.collection``
      - string
-     - Specifies the collection to shard. 
+     - Sets the collection to shard. 
 
    * - | ``shardingEntries``
        | ``.database``
      - string
-     - Specifies the database of the collection to shard.
+     - Sets the database of the collection to shard.
  
    * - | ``shardingEntries``
        | ``.shardCollection``
@@ -174,6 +181,9 @@ The ``sharding`` option has the following parameters:
      - array 
      - Sets the indexes to use for the shard key. 
 
+``mongosync`` throws an error if the ``sharding`` option is not set when
+synchronizing from a replica set to a sharded cluster.  ``mongosync`` also
+throws an error if the ``sharding`` option is set with any other configuration.
 
 Response
 --------

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -150,7 +150,7 @@ The ``sharding`` option has the following parameters:
    * - ``createSupportedIndexes``
      - boolean
      - Optional. Sets whether synchronization creates a supporting index 
-       for the shard key, if none exists.
+       for the shard key, if none exists.  Defaults to ``false``.
 
    * - ``shardingEntries``
      - array of documents
@@ -272,7 +272,7 @@ This is done by setting the ``sharding.createSupportingIndexes`` option.
 
 When ``sharding.createSupportingIndexes`` is ``false`` (the default): 
 
-* Each shard key the user provides for the ``sharding.shardEntries`` option
+* Each shard key you provide for the ``sharding.shardEntries`` option
   must have an existing index on the source cluster.
 
 * One of the indexes used for the shard key must have simple collation if the 
@@ -297,16 +297,18 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
   destination cluster.
 
-``mongosync`` either creates supporting indexes for all collections or none.
+The ``sharding.createSupportingIndexes`` option affects all collections sharded
+during sync.
 
-Rename during Sync
+
+Rename During Sync
 ~~~~~~~~~~~~~~~~~~
 
 Collections synchronized from a replica set to a sharded cluster listed in
-the ``sharding.shardEntries`` array, become sharded collections on the
+the ``sharding.shardEntries`` array become sharded collections on the
 destination cluster.
 
-Renaming a collection, such as with the :dbcommand:`renameCollection` command
+Renaming a collection (such as with the :dbcommand:`renameCollection` command)
 on the source cluster after calling ``start`` but before ``mongosync`` begins 
 to copy the collection can block the collection from sharding on the destination.
 
@@ -314,12 +316,12 @@ To check whether a collection is safe to rename, call the :ref:`c2c-api-progress
 endpoint and check the value of the ``collectionCopy.estimatedCopiedBytes`` field 
 in the return document.  
 
-* A value of 0 indicates that ``mongosync`` has not yet begun to copy the
+* A value of 0 indicates that ``mongosync`` has not started to copy the
   collection.  Renaming the collection at this point results in the collection 
   being unsharded on the destination cluster.
 
-* A value greater than 0 indicates that ``mongosync`` has begun the copy and
-  read the shard map.  Renaming the collection from this point on does not block
+* A value greater than 0 indicates that ``mongosync`` has started the copy.
+  Renaming the collection from this point on does not block
   its sharding on the destination cluster, even in the event  of a crash.
 
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -157,8 +157,9 @@ The ``sharding`` option has the following parameters:
      - Required. Sets the namespace and key of collections to shard 
        during synchronization.
 
-       Any collections not included in this array synchronize to unsharded 
-       collections on the destination cluster.
+       Collections not included in this array synchronize to unsharded 
+       collections on the destination cluster.  If set with an empty array, 
+       no collections are sharded.
 
    * - | ``shardingEntries``
        | ``.collection``
@@ -269,8 +270,12 @@ Collections that are not listed in this array replicate as unsharded.
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~
 
-Synchronization from a replica set to a sharded cluster can automatically
-create a supporting index for the new shard key on the destination cluster.
+``mongosync`` synchronizes indexes from the source cluster to the destination
+cluster.  But, when synchronizing from a replica set to a sharded cluster,
+``mongosync`` may require the an additional index to support the shard key,
+which may not exist on the source cluster.
+
+``mongosync`` can create supporting indexes for sharded collections during sync.
 This is done by setting the ``sharding.createSupportingIndexes`` option.
 
 When ``sharding.createSupportingIndexes`` is ``false`` (the default): 
@@ -290,8 +295,6 @@ When ``sharding.createSupportingIndexes`` is ``false`` (the default):
   can cause ``mongosync`` to fail.
 
 When ``sharding.createSupportingIndexes`` is ``true``: 
-
-* ``mongosync`` synchronizes indexes on the source cluster to the destination.
 
 * If the supporting indexes exist on the source cluster, ``mongosync`` 
   synchronizes the indexes to the destination cluster and uses them 
@@ -315,13 +318,16 @@ Renaming a collection (such as with the :dbcommand:`renameCollection` command)
 on the source cluster after calling ``start`` but before ``mongosync`` begins 
 to copy the collection can block the collection from sharding on the destination.
 
-To check whether a collection is safe to rename, call the :ref:`c2c-api-progress`
-endpoint and check the value of the ``collectionCopy.estimatedCopiedBytes`` field 
-in the return document.  
+To check whether it is safe to rename collections, call the 
+:ref:`c2c-api-progress` endpoint and check the value of the 
+``collectionCopy.estimatedCopiedBytes`` field in the return document.  
 
 * A value of 0 indicates that ``mongosync`` has not started to copy the
-  collection.  Renaming the collection at this point results in the collection 
-  being unsharded on the destination cluster.
+  collection.
+
+  Renaming a collection at this point may result in an unsharded collection 
+  on the destination cluster, as the transition to copying can happen before
+  the rename takes effect on the source.
 
 * A value greater than 0 indicates that ``mongosync`` has started the copy.
   Renaming the collection from this point on does not block

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -219,6 +219,22 @@ Response
    :language: json
    :copyable: false
 
+Example 3 - Start Sync from Replica Set to Sharded Cluster
+----------------------------------------------------------
+
+Request
+~~~~~~~
+
+.. literalinclude:: /includes/api/requests/start-shard.sh
+   :language: shell
+
+Response
+~~~~~~~~
+
+.. literalinclude:: /includes/api/responses/success.json
+   :language: json
+   :copyable: false
+
 Behavior
 --------
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -325,7 +325,7 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
   destination cluster.
 
-The ``sharding.createSupportingIndexes`` option affects all collections sharded.
+The ``sharding.createSupportingIndexes`` option affects all sharded collections.
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -83,7 +83,7 @@ Unsupported Collection Types
 Sharded Clusters
 ----------------
 
-- ``mongosync`` does not support synchronization from a sharded cluster
+- ``mongosync`` does not support sync from a sharded cluster
   to a replica set.
 - Synchronization from a replica set to a sharded cluster has the following
   limitations:
@@ -92,7 +92,7 @@ Sharded Clusters
     :ref:`c2c-api-start` command cannot be renamed to use a different
     database while ``mongosync`` is running.
   - When using the ``sharding.createSupprtingIndexes`` option to create indexes
-    supporting shard keys on the destination cluster during synchronization, 
+    supporting shard keys on the destination cluster during sync, 
     you cannot create these indexes afterwards on the source cluster.  
     
     The index must either exist before ``mongosync`` starts or be created after

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -88,11 +88,12 @@ Sharded Clusters
 - Synchronization from a replica set to a sharded cluster has the following
   limitations:
 
-  - Collections included in ``sharding.shardingEntries`` cannot be renamed to
-    use a different database at any point while ``mongosync`` is running.
+  - Collections included in the ``sharding.shardingEntries`` option for the
+    :ref:`c2c-start` command, cannot be renamed to use a different database 
+    at any point while ``mongosync`` is running.
   - When using the ``sharding.createSupprtingIndexes`` option to create indexes
-    supporting shard keys on the destination cluster, you cannot create these
-    indexes afterwards on the source cluster.  
+    supporting shard keys on the destination cluster during synchronization, 
+    you cannot create these indexes afterwards on the source cluster.  
     
     The index must either exist before ``mongosync`` starts or be created after
     the migration is complete and ``mongosync`` has stopped.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -100,7 +100,6 @@ Sharded Clusters
   <sharding-shard-key-indexes>` is one lower than normal, 63 instead of
   64.
 
-
 Reversing
 ---------
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -83,6 +83,8 @@ Unsupported Collection Types
 Sharded Clusters
 ----------------
 
+- ``mongosync`` does not support synchronization from a sharded cluster
+  to a replica set.
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
   for more details.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -87,6 +87,7 @@ Sharded Clusters
   to a replica set.
 - Synchronization from a replica set to a sharded cluster has the following
   limitations:
+
   - Collections included in ``sharding.shardingEntries`` cannot be renamed to
     use a different database at any point while ``mongosync`` is running.
   - When using the ``sharding.createSupprtingIndexes`` option to create indexes

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -85,7 +85,7 @@ Sharded Clusters
 
 - ``mongosync`` does not support sync from a sharded cluster
   to a replica set.
-- Synchronization from a replica set to a sharded cluster has the following
+- Sync from a replica set to a sharded cluster has the following
   limitations:
 
   - Collections included in the ``sharding.shardingEntries`` option for the

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -83,13 +83,6 @@ Unsupported Collection Types
 Sharded Clusters
 ----------------
 
-- The :ref:`shard topologies <sharding-introduction>` must be the same
-  in the source and target clusters. The following configurations are
-  not supported.
-
-  - Replica set to sharded cluster.
-  - Sharded cluster to replica set.
-  - Unequal numbers of source and destination shards.
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
   for more details.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -85,6 +85,16 @@ Sharded Clusters
 
 - ``mongosync`` does not support synchronization from a sharded cluster
   to a replica set.
+- Synchronization from a replica set to a sharded cluster has the following
+  limitations:
+  - Collections included in ``sharding.shardingEntries`` cannot be renamed to
+    use a different database at any point while ``mongosync`` is running.
+  - When using the ``sharding.createSupprtingIndexes`` option to create indexes
+    supporting shard keys on the destination cluster, you cannot create these
+    indexes afterwards on the source cluster.  
+    
+    The index must either exist before ``mongosync`` starts or be created after
+    the migration is complete and ``mongosync`` has stopped.
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
   for more details.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -89,7 +89,7 @@ Sharded Clusters
   limitations:
 
   - Collections included in the ``sharding.shardingEntries`` option for the
-    :ref:`c2c-start` command, cannot be renamed to use a different database 
+    :ref:`c2c-api-start` command, cannot be renamed to use a different database 
     at any point while ``mongosync`` is running.
   - When using the ``sharding.createSupprtingIndexes`` option to create indexes
     supporting shard keys on the destination cluster during synchronization, 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -89,8 +89,8 @@ Sharded Clusters
   limitations:
 
   - Collections included in the ``sharding.shardingEntries`` option for the
-    :ref:`c2c-api-start` command, cannot be renamed to use a different database 
-    at any point while ``mongosync`` is running.
+    :ref:`c2c-api-start` command cannot be renamed to use a different
+    database while ``mongosync`` is running.
   - When using the ``sharding.createSupprtingIndexes`` option to create indexes
     supporting shard keys on the destination cluster during synchronization, 
     you cannot create these indexes afterwards on the source cluster.  


### PR DESCRIPTION
## Staging

Updates to `/start` endpoint:
* [Sharding Parameters](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/api/start/#sharding-parameters)
* [RS->SC Example](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/api/start/#example-3---start-sync-from-replica-set-to-sharded-cluster)
* Behavior Sections:
  * [Shard Collections](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/api/start/#shard-collections)
  * [Supporting Indexes](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/api/start/#supporting-indexes)
  * [Rename during Sync](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/api/start/#rename-during-sync)
* Removes 'unlike' limitations from [Sharding Limitations](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15702-static-unlike-topologies/reference/limitations/#sharded-clusters) 

## Jira

[DOCS-15702](https://jira.mongodb.org/browse/DOCS-15702)

## Build

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6399fdd4dc742b91f26e2ef5)