### PR TITLE
DOCS-15881 m to n sharding

### DIFF
--- a/source/includes/fact-reverse-limitation.rst
+++ b/source/includes/fact-reverse-limitation.rst
@@ -1,0 +1,3 @@
+The source and destination clusters must have the same number of
+shards. You cannot reverse sync when the clusters have different
+topologies.

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -52,8 +52,10 @@ To configure multiple ``mongosync`` instances:
 
       .. _c2c-shard-config-verify:
 
-      The source cluster and destination cluster must have the same
-      number of shards.
+      Starting in ``mongosync`` 1.1, you can sync between clusters with
+      different numbers of shards. However, if you want to reverse the
+      sync, the source cluster and destination cluster must have the
+      same number of shards.
 
    .. step:: Determine the shard IDs
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -46,6 +46,7 @@ To use the ``reverse`` endpoint:
   indexes that were created in MongoDB 4.2 or earlier, you must
   :ref:`resync <resync-replica-member>` all of the nodes in the
   original source cluster before reversing.
+- .. include:: /includes/fact-reverse-limitation.rst
 
 .. include:: /includes/fact-reverse-sync-action-types.rst
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -115,9 +115,10 @@ Sharded Clusters
 Reversing
 ---------
 
-If the old source has :ref:`unique indexes <index-type-unique>` which
-are partially distributed across shards, reversing may cause failures.
-Ensure that unique indexes exist on all shards before reversing.
+- If the old source has :ref:`unique indexes <index-type-unique>` which
+  are partially distributed across shards, reversing may cause failures.
+  Ensure that unique indexes exist on all shards before reversing.
+- .. include:: /includes/fact-reverse-limitation.rst
 
 Multiple Clusters
 -----------------


### PR DESCRIPTION
STAGING
[multiple mongosync](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15881-sharding-m-to-n/multiple-mongosyncs/#configure-multiple-mongosync-instances)
[limitations](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15881-sharding-m-to-n/reference/limitations/#reversing)
[reverse](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15881-sharding-m-to-n/reference/api/reverse/)


[JIRA](https://jira.mongodb.org/browse/DOCS-15881)
Some missing info re: M -> N shard migrations

[build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63e6b243dcefe97797862a9c)