### PR TITLE
DOCSP-23883 Fixes connection example

### DIFF
--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -43,12 +43,9 @@ following command on one line:
 
 .. code-block:: shell
 
-   mongosync --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,
-                       clusterOne02.fancyCorp.com:20020,
-                       clusterOne03.fancyCorp.com:20020
-             --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,
-                       clusterTwo02.fancyCorp.com:20020,
-                       clusterTwo03.fancyCorp.com:20020
+   $ mongosync \
+         --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
+         --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
 
 Atlas clusters require TLS connections. To use ``mongosync`` with Atlas
 clusters, you add the :urioption:`tls=true <tls>` option. For example,

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -44,8 +44,8 @@ following command on one line:
 .. code-block:: shell
 
    $ mongosync \
-         --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
-         --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
+         --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
+         --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
 
 Atlas clusters require TLS connections. To use ``mongosync`` with Atlas
 clusters, you add the :urioption:`tls=true <tls>` option. For example,

--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -43,7 +43,7 @@ following command on one line:
 
 .. code-block:: shell
 
-   $ mongosync \
+   mongosync \
          --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
          --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -164,12 +164,9 @@ command is reformated here for clarity):
 
 .. code-block:: shell
 
-   ./bin/mongosync --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020, \
-                              clusterOne02.fancyCorp.com:20020, \
-                              clusterOne03.fancyCorp.com:20020 \
-                   --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020, \
-                              clusterTwo02.fancyCorp.com:20020, \
-                              clusterTwo03.fancyCorp.com:20020
+   $ ./bin/mongosync \
+         --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020 \
+         --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
 
 Initialization Notes
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -164,7 +164,7 @@ command is reformated here for clarity):
 
 .. code-block:: shell
 
-   $ ./bin/mongosync \
+   ./bin/mongosync \
          --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
          --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -165,8 +165,8 @@ command is reformated here for clarity):
 .. code-block:: shell
 
    $ ./bin/mongosync \
-         --cluster0 mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020 \
-         --cluster1 mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
+         --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
+         --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
 
 Initialization Notes
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

Fixes issue with `mongosync` initialization examples.  The `--cluster0` and `--cluster1` options take a MongoDB URL with commas separating each mongod instance in the cluster.  We split these out into new lines for readability, but this causes the shell to interpret additional mongod instances as commands rather than extensions of the option argument.

Inlining `--cluster0` and `--cluster1` arguments corrects the issue.

# Staging

* [Connection Example](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23883-bad-example/connecting/atlas-to-atlas/#connect-the-source-and-destination-clusters-with-mongosync)
* [Quickstart Example](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-23883-bad-example/quickstart/#initialize-mongosync)

# Jira
[DOCSP-23883](https://jira.mongodb.org/browse/DOCSP-23883)

# Build
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63fcf58205dd3cc8144f903b)