### PR TITLE
DOCS-15937 typo, line lengths

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -86,15 +86,17 @@ Sharded Clusters
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
-  - Collections included in the ``sharding.shardingEntries`` option for the
-    :ref:`c2c-api-start` command cannot be renamed to use a different
-    database while ``mongosync`` is running.
-  - When using the ``sharding.createSupprtingIndexes`` option to create indexes
-    supporting shard keys on the destination cluster during sync, 
-    you cannot create these indexes afterwards on the source cluster.  
+  - Collections included in the ``sharding.shardingEntries`` option for
+    the :ref:`c2c-api-start` command cannot be renamed to use a
+    different database while ``mongosync`` is running.
+  - When using the ``sharding.createSupportingIndexes`` option to create
+    indexes supporting shard keys on the destination cluster during
+    sync, you cannot create these indexes afterwards on the source
+    cluster.  
     
-    The index must either exist before ``mongosync`` starts or be created after
-    the migration is complete and ``mongosync`` has stopped.
+    The index must either exist before ``mongosync`` starts or be
+    created after the migration is complete and ``mongosync`` has
+    stopped.
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
   for more details.


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15937-typo/reference/limitations/#sharded-clusters)

[JIRA](https://jira.mongodb.org/browse/DOCS-15937)
Typo in parameter name

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=640b5b4c054271fb0ab001ac)