### PR TITLE
DOP-3535: correctly redirect old C2C docs

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,9 +1,52 @@
 define: prefix docs/cluster-to-cluster-sync
-define: base https://www.mongodb.com
-define: versions master
+define: base https://www.mongodb.com/docs/cluster-to-cluster-sync
+define: versions v0.9 master
 
-# raw: <source file> -> ${base}/${prefix}/<destination>
+# raw: <source file> -> ${base}/<destination>
 
-raw: docs/cluster-to-cluster-sync -> ${base}/${prefix}/current/
-raw: docs/cluster-to-cluster -> ${base}/${prefix}/current/
+raw: ${prefix} -> ${base}/current/
+raw: docs/cluster-to-cluster -> ${base}/current/
 
+# Redirects for pre-versioned pages to direct to /current
+
+raw: ${prefix}/using-mongosync -> ${base}/current/using-mongosync/
+raw: ${prefix}/reference -> ${base}/current/reference/
+raw: ${prefix}/release-notes -> ${base}/current/release-notes/
+raw: ${prefix}/index -> ${base}/current/index/
+raw: ${prefix}/installation/install-on-linux -> ${base}/current/installation/install-on-linux/
+raw: ${prefix}/installation/install-on-windows -> ${base}/current/installation/install-on-windows/
+raw: ${prefix}/installation/install-on-macos -> ${base}/current/installation/install-on-macos/
+raw: ${prefix}/release-notes/1.2 -> ${base}/current/release-notes/1.2/
+raw: ${prefix}/release-notes/1.0 -> ${base}/current/release-notes/1.0/
+raw: ${prefix}/release-notes/1.1 -> ${base}/current/release-notes/1.1/
+raw: ${prefix}/release-notes/0.9 -> ${base}/current/release-notes/0.9/
+raw: ${prefix}/faq -> ${base}/current/faq/
+raw: ${prefix}/multiple-mongosyncs -> ${base}/current/multiple-mongosyncs/
+raw: ${prefix}/connecting -> ${base}/current/connecting/
+raw: ${prefix}/connecting/onprem-to-atlas -> ${base}/current/connecting/onprem-to-atlas/
+raw: ${prefix}/connecting/atlas-to-atlas -> ${base}/current/connecting/atlas-to-atlas/
+raw: ${prefix}/connecting/onprem-to-onprem -> ${base}/current/connecting/onprem-to-onprem/
+raw: ${prefix}/installation -> ${base}/current/installation/
+raw: ${prefix}/reference/collection-level-filtering -> ${base}/current/reference/collection-level-filtering/
+raw: ${prefix}/reference/oplog-sizing -> ${base}/current/reference/oplog-sizing/
+raw: ${prefix}/reference/configuration -> ${base}/current/reference/configuration/
+raw: ${prefix}/reference/api -> ${base}/current/reference/api/
+raw: ${prefix}/reference/logging -> ${base}/current/reference/logging/
+raw: ${prefix}/reference/mongosync-states -> ${base}/current/reference/mongosync-states/
+raw: ${prefix}/reference/versioning -> ${base}/current/reference/versioning/
+raw: ${prefix}/reference/limitations -> ${base}/current/reference/limitations/
+raw: ${prefix}/reference/api/commit -> ${base}/current/reference/api/commit/
+raw: ${prefix}/reference/api/resume -> ${base}/current/reference/api/resume/
+raw: ${prefix}/reference/api/progress -> ${base}/current/reference/api/progress/
+raw: ${prefix}/reference/api/start -> ${base}/current/reference/api/start/
+raw: ${prefix}/reference/api/pause -> ${base}/current/reference/api/pause/
+raw: ${prefix}/reference/api/reverse -> ${base}/current/reference/api/reverse/
+raw: ${prefix}/reference/disaster-recovery -> ${base}/current/reference/disaster-recovery/
+raw: ${prefix}/reference/mongosync -> ${base}/current/reference/mongosync/
+raw: ${prefix}/quickstart -> ${base}/current/quickstart/
+
+# Handle flipping version from 1.x to "Legacy" for pages not present in "Legacy"
+
+[v0.9]: ${prefix}/${version}/release-notes/1.0 -> ${base}/${version}/release-notes/
+[v0.9]: ${prefix}/${version}/release-notes/1.1 -> ${base}/${version}/release-notes/
+[v0.9]: ${prefix}/${version}/release-notes/1.2 -> ${base}/${version}/release-notes/


### PR DESCRIPTION
Redirects the unversioned pages to /current as requested and adds missing redirects for version flipping the release notes.

Note: if 0.9 is EOL'd and you would like it added to the Legacy site (rather than just labeling it Legacy), then please follow the   instructions here: https://wiki.corp.mongodb.com/display/DE/How+To%3A+Sunset+a+Version+of+Documentation