### PR TITLE
DOCSP-27804 add mapReduce Limitation

### DIFF
--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -11,10 +11,9 @@
 - If a filter includes a :ref:`view <views-landing-page>` but not the
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
-- Operations that use the :pipeline:`$out` aggregation stage or operations
-  that use the :dbcommand:`mapReduce` command when set to replace a collection
-  or create a new sharded collection are
-  only supported if the entire database is specified in the filter.
+- To use the :pipeline:`$out` aggregation stage or the :dbcommand:`mapReduce`
+  command when set to create or replace a collection with filtering
+  requires that you configure the filter to use the entire database.
   You cannot limit the filter to collections within the database.
 
   For more information, see :ref:`c2c-filter-with-out`.

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -11,7 +11,6 @@
 - If a filter includes a :ref:`view <views-landing-page>` but not the
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
-  
 - Operations that use the :pipeline:`$out` aggregation stage or operations
   that use the :dbcommand:`mapReduce` command when set to replace a collection
   or create a new shareded collection are

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -12,8 +12,8 @@
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
 - To use the :pipeline:`$out` aggregation stage or the :dbcommand:`mapReduce`
-  command (when set to create or replace a collection) with filtering
-  requires that you configure the filter to use the entire database.
+  command (when set to create or replace a collection) with filtering,
+  you must configure the filter to use the entire database.
   You cannot limit the filter to collections within the database.
 
   For more information, see :ref:`c2c-filter-with-out`.

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -12,7 +12,7 @@
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
 - To use the :pipeline:`$out` aggregation stage or the :dbcommand:`mapReduce`
-  command when set to create or replace a collection with filtering
+  command (when set to create or replace a collection) with filtering
   requires that you configure the filter to use the entire database.
   You cannot limit the filter to collections within the database.
 

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -16,5 +16,6 @@
   or create a new shareded collection are
   only supported if the entire database is specified in the filter.
   You cannot limit the filter to collections within the database.
+
   For more information, see :ref:`c2c-filter-with-out`.
 

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -13,7 +13,7 @@
 - You cannot specify system collections or system databases in a filter.
 - Operations that use the :pipeline:`$out` aggregation stage or operations
   that use the :dbcommand:`mapReduce` command when set to replace a collection
-  or create a new shareded collection are
+  or create a new sharded collection are
   only supported if the entire database is specified in the filter.
   You cannot limit the filter to collections within the database.
 

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -11,8 +11,9 @@
 - If a filter includes a :ref:`view <views-landing-page>` but not the
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
-- Operations that use the :pipeline:`$out` aggregation stage are only 
-  supported if the entire database is specified in the filter. You
-  cannot limit the filter to a collection within the database. See:
-  :ref:`c2c-filter-with-out`.
+- Operations that use the :pipeline:`$out` aggregation stage or the
+  :dbcommand:`mapReduce` command when set to output a collection are
+  only supported if the entire database is specified in the filter.
+  You cannot limit the filter to collections within the database.
 
+  For more information, see :ref:`c2c-filter-with-out`.

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -11,9 +11,11 @@
 - If a filter includes a :ref:`view <views-landing-page>` but not the
   base collection, only the view is replicated.
 - You cannot specify system collections or system databases in a filter.
-- Operations that use the :pipeline:`$out` aggregation stage or the
-  :dbcommand:`mapReduce` command when set to output a collection are
+  
+- Operations that use the :pipeline:`$out` aggregation stage or operations
+  that use the :dbcommand:`mapReduce` command when set to replace a collection
+  or create a new shareded collection are
   only supported if the entire database is specified in the filter.
   You cannot limit the filter to collections within the database.
-
   For more information, see :ref:`c2c-filter-with-out`.
+

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -220,7 +220,7 @@ This filter works:
      }
    ]
 
-This filter does not work with ``$out``:
+This filter does not work: 
 
 .. code-block:: json
 

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -186,8 +186,8 @@ See the :ref:`renaming examples <c2c-example-rename-while-syncing>`.
 
 .. _c2c-filter-with-out:
 
-Filtering with $out
--------------------
+Filtering with $out and mapReduce
+---------------------------------
 
 The :ref:`$out <agg-out>` aggregation stage creates a new collection
 when it runs. You can use the ``$out`` stage with filtering if you are

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -189,11 +189,11 @@ See the :ref:`renaming examples <c2c-example-rename-while-syncing>`.
 Filtering with mapReduce and $out
 ---------------------------------
 
-The :pipeline:`$out` aggregation stage and :dbcommand:`mapReduce`
-database command can create new collections when run.
-These operations can be used with filtering only when you filter
-the whole database and not just the collections specified in
-the ``$out`` or ``mapReduce`` statements.
+To use the :pipeline:`$out` aggregation stage or
+the :dbcommand:`mapReduce` command set to create
+or replace a collection with filtering requires
+that you filter the whole database and not just
+the specified collection.
 
 For example, consider this aggregation pipeline:
 

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -186,13 +186,14 @@ See the :ref:`renaming examples <c2c-example-rename-while-syncing>`.
 
 .. _c2c-filter-with-out:
 
-Filtering with $out and mapReduce
+Filtering with mapReduce and $out
 ---------------------------------
 
-The :ref:`$out <agg-out>` aggregation stage creates a new collection
-when it runs. You can use the ``$out`` stage with filtering if you are
-filtering on the whole database and not just the collection specified in
-the ``$out`` statement.
+The :pipeline:`$out` aggregation stage and :dbcommand:`mapReduce`
+database command can create new collections when run.
+These operations can be used with filtering only when you filter
+the whole database and not just the collections specified in
+the ``$out`` or ``mapReduce`` statements.
 
 For example, consider this aggregation pipeline:
 

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -191,8 +191,8 @@ Filtering with mapReduce and $out
 
 To use the :pipeline:`$out` aggregation stage or
 the :dbcommand:`mapReduce` command set to create
-or replace a collection with filtering requires
-that you filter the whole database and not just
+or replace a collection with filtering, you must 
+filter the whole database and not just
 the specified collection.
 
 For example, consider this aggregation pipeline:

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -190,8 +190,8 @@ Filtering with mapReduce and $out
 ---------------------------------
 
 To use the :pipeline:`$out` aggregation stage or
-the :dbcommand:`mapReduce` command set to create
-or replace a collection with filtering, you must 
+the :dbcommand:`mapReduce` command (when set to create
+or replace a collection) with filtering, you must 
 filter the whole database and not just
 the specified collection.
 


### PR DESCRIPTION
## Description

Adds `mapReduce` to `$out` limitations.

## Staging
* [Filtering with mapReduce & $out](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-27804-add-mapReduce/reference/collection-level-filtering/#filtering-with-mapreduce-and--out)
* [Limitations](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-27804-add-mapReduce/reference/collection-level-filtering/#limitations) (Changes made to last bullet point).

## Jira

[DOCSP-27804](https://jira.mongodb.org/browse/DOCSP-27804)

## Build

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6418d26cb070a41637f8721d)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=641b12bab070a41637727069)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6421e42666f244bf57e361ef)

