### PR TITLE
DOCSP-28691 when to write to destination cluster

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -20,9 +20,12 @@
 
    * - ``canWrite``
      - boolean
-     - If ``true``, indicates that it is possible to write to the
-       destination cluster. Index validation continues until the 
-       :ref:`commit <c2c-api-commit>` is complete.
+     - If ``true``, indicates that it writes are permitted on the
+       destination cluster. ``mongosync`` exits if you write to the
+       destination cluster while ``canWrite`` is ``false``.
+       
+       Index validation continues until the :ref:`commit
+       <c2c-api-commit>` is complete. 
 
    * - ``info``
      - string

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -21,8 +21,8 @@
    * - ``canWrite``
      - boolean
      - If ``true``, indicates that writes are permitted on the
-       destination cluster. If you write to the destination cluster
-       while ``canWrite`` is ``false``, ``mongosync`` exits.
+       destination cluster. Do not write to the destination cluster
+       while ``canWrite`` is ``false``.
        
        Index validation continues until the :ref:`commit
        <c2c-api-commit>` is complete. 

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -20,9 +20,9 @@
 
    * - ``canWrite``
      - boolean
-     - If ``true``, indicates that it writes are permitted on the
-       destination cluster. ``mongosync`` exits if you write to the
-       destination cluster while ``canWrite`` is ``false``.
+     - If ``true``, indicates that writes are permitted on the
+       destination cluster. If you write to the destination cluster
+       while ``canWrite`` is ``false``, ``mongosync`` exits.
        
        Index validation continues until the :ref:`commit
        <c2c-api-commit>` is complete. 

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -4,5 +4,4 @@ boolean value, ``canWrite``.
 
 - When ``canWrite`` is ``true``, it is safe to write to the destination
   cluster.
-- When ``canWrite`` is false, ``mongosync`` exits if you write to the
-  destination cluster.
+- When ``canWrite`` is false, do not write to the destination cluster.

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -1,5 +1,5 @@
-Check what state ``mongosync`` is in by calling the
-:ref:`c2c-api-progress` API endpoint. The ``/progress`` end point
-returns a boolean value, ``canWrite``. When ``canWrite`` is ``true``, it
-is safe to write to the destination cluster. If you write to the
-destination cluster while ``canWrite`` is false, ``mongosync`` exits.
+To see what state ``mongosync`` is in, call the :ref:`c2c-api-progress`
+API endpoint. The ``/progress`` end point returns a boolean value,
+``canWrite``. When ``canWrite`` is ``true``, it is safe to write to the
+destination cluster. If you write to the destination cluster while
+``canWrite`` is false, ``mongosync`` exits.

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -4,4 +4,5 @@ boolean value, ``canWrite``.
 
 - When ``canWrite`` is ``true``, it is safe to write to the destination
   cluster.
-- When ``canWrite`` is false, do not write to the destination cluster.
+- When ``canWrite`` is ``false``, do not write to the destination
+  cluster.

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -1,0 +1,5 @@
+Check what phase ``mongosync`` is in by calling the
+:ref:`c2c-api-progress` API endpoint. The ``/progress`` end point
+returns a boolean value, ``canWrite``. When ``canWrite`` is ``true``, it
+is safe to write to the destination cluster. If you write to the
+destination cluster while ``canWrite`` is false, ``mongosync`` exits.

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -1,5 +1,8 @@
-To see what state ``mongosync`` is in, call the :ref:`c2c-api-progress`
-API endpoint. The ``/progress`` end point returns a boolean value,
-``canWrite``. When ``canWrite`` is ``true``, it is safe to write to the
-destination cluster. If you write to the destination cluster while
-``canWrite`` is false, ``mongosync`` exits.
+To see what state ``mongosync`` is in, call the :ref:`/progress
+<c2c-api-progress>` API endpoint. The ``/progress`` output includes a
+boolean value, ``canWrite``.
+
+- When ``canWrite`` is ``true``, it is safe to write to the destination
+  cluster.
+- When ``canWrite`` is false, ``mongosync`` exits if you write to the
+  destination cluster.

--- a/source/includes/fact-write-blocking-check.rst
+++ b/source/includes/fact-write-blocking-check.rst
@@ -1,4 +1,4 @@
-Check what phase ``mongosync`` is in by calling the
+Check what state ``mongosync`` is in by calling the
 :ref:`c2c-api-progress` API endpoint. The ``/progress`` end point
 returns a boolean value, ``canWrite``. When ``canWrite`` is ``true``, it
 is safe to write to the destination cluster. If you write to the

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -5,4 +5,4 @@ When write-blocking is enabled, ``mongosync`` blocks writes:
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``. You cannot enable
-write-blocking the sync starts.
+write-blocking after the sync starts.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,0 +1,7 @@
+When write-blocking is enabled, ``mongosync`` blocks writes:
+
+- On the destination cluster during replication
+- On the source cluster while committing
+
+To enable write-blocking, use the :ref:`start API <c2c-api-start>`
+to set ``enableUserWriteBlocking`` to ``true``.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -4,4 +4,5 @@ When write-blocking is enabled, ``mongosync`` blocks writes:
 - On the source cluster while committing
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
-to set ``enableUserWriteBlocking`` to ``true``.
+to set ``enableUserWriteBlocking`` to ``true``. You cannot enable
+write-blocking the sync starts.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,6 +1,6 @@
 When write-blocking is enabled, ``mongosync`` blocks writes:
 
-- On the destination cluster during replication
+- On the destination cluster during sync
 - On the source cluster while committing
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`

--- a/source/includes/fact-write-blocking-when.rst
+++ b/source/includes/fact-write-blocking-when.rst
@@ -1,3 +1,3 @@
 You can safely write to the source cluster while ``mongosync`` is
 syncing. You should not write to the destination cluster until the
-end of the :ref:`COMMITTING <c2c-state-committing>` state.
+last stages of the :ref:`COMMITTING <c2c-state-committing>` state.

--- a/source/includes/fact-write-blocking-when.rst
+++ b/source/includes/fact-write-blocking-when.rst
@@ -1,3 +1,3 @@
 You can safely write to the source cluster while ``mongosync`` is
-syncing. You should not write to the destination cluster until the
-last stages of the :ref:`COMMITTING <c2c-state-committing>` state.
+syncing. Do not write to the destination cluster until the last stages
+of the :ref:`COMMITTING <c2c-state-committing>` state.

--- a/source/includes/fact-write-blocking-when.rst
+++ b/source/includes/fact-write-blocking-when.rst
@@ -1,3 +1,3 @@
 You can safely write to the source cluster while ``mongosync`` is
-syncing. Do not write to the destination cluster until the last stages
-of the :ref:`COMMITTING <c2c-state-committing>` state.
+syncing. Do not write to the destination cluster unless ``canWrite`` is
+``true``.

--- a/source/includes/fact-write-blocking-when.rst
+++ b/source/includes/fact-write-blocking-when.rst
@@ -1,0 +1,3 @@
+You can safely write to the source cluster while ``mongosync`` is
+syncing. You should not write to the destination cluster until the
+end of the :ref:`COMMITTING <c2c-state-committing>` phase.

--- a/source/includes/fact-write-blocking-when.rst
+++ b/source/includes/fact-write-blocking-when.rst
@@ -1,3 +1,3 @@
 You can safely write to the source cluster while ``mongosync`` is
 syncing. You should not write to the destination cluster until the
-end of the :ref:`COMMITTING <c2c-state-committing>` phase.
+end of the :ref:`COMMITTING <c2c-state-committing>` state.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -41,7 +41,7 @@ To use the ``reverse`` endpoint:
   - ``reversible`` to ``true``
   - ``enableUserWriteBlocking`` to ``true``
   
-  The options cannot be updated after the sync starts.
+  You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
 - :ref:`Unique indexes <index-type-unique>` on the original source

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -35,9 +35,13 @@ Requirements
 
 To use the ``reverse`` endpoint:
 
-- You must have started your original sync operation with the
-  ``reversible`` and ``enableUserWriteBlocking`` options set to
-  ``true``.
+- ``mongosync`` must be configured when the initial sync begins. The
+  call to the :ref:`/start <c2c-api-start>` API endpoint must set:
+  
+  - ``reversible`` to ``true``
+  - ``enableUserWriteBlocking`` to ``true``
+  
+  The options cannot be updated after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
 - :ref:`Unique indexes <index-type-unique>` on the original source

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -101,9 +101,6 @@ Write Operations
 Write-blocking
 ~~~~~~~~~~~~~~
 
-:ref:`Reverse synchronization <c2c-api-reverse>` requires
-write-blocking.
-
 .. include:: /includes/fact-write-blocking-enable.rst
 
 .. include:: /includes/fact-write-blocking-requirement.rst

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -83,20 +83,15 @@ Read Operations
 
 Read operations on the source cluster are always permitted.
 
-``mongosync`` guarantees :term:`eventual consistency <eventual
-consistency>` on the destination cluster. You can read from
-the destination cluster during syncing if your application supports 
-eventual consistency.
-
 When the ``/progress`` endpoint reports ``canWrite`` is ``true``, the
-source and destination clusters are consistent.
+data on the source and destination clusters is consistent.
 
 Write Operations
 ----------------
 
-.. include:: /includes/fact-write-blocking-when.rst
-
 .. include:: /includes/fact-write-blocking-check.rst
+
+.. include:: /includes/fact-write-blocking-when.rst
 
 Write-blocking
 ~~~~~~~~~~~~~~

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -101,6 +101,9 @@ Write Operations
 Write-blocking
 ~~~~~~~~~~~~~~
 
+:ref:`Reverse synchronization <c2c-api-reverse>` requires
+write-blocking.
+
 .. include:: /includes/fact-write-blocking-enable.rst
 
 .. include:: /includes/fact-write-blocking-requirement.rst

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -77,3 +77,28 @@ operations in that state.
    * - ``COMMITTED``
      - The cutover for the sync process is complete.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+Read Operations
+---------------
+
+Read operations on the source cluster are always permitted.
+
+``mongosync`` guarantees :term:`eventual consistent <eventual
+consistency>` on the destination cluster. You can read from
+the destination cluster during synching if your application supports 
+eventual consistency.
+
+When the ``/progress`` endpoint reports ``canWrite`` is ``true``, the
+source and destination clusters are consistent.
+
+Write Operations
+----------------
+
+.. include:: /includes/fact-write-blocking-when.rst
+
+.. include:: /includes/fact-write-blocking-check.rst
+
+.. include:: /includes/fact-write-blocking-enable.rst
+
+.. include:: /includes/fact-write-blocking-requirement.rst
+

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -98,6 +98,9 @@ Write Operations
 
 .. include:: /includes/fact-write-blocking-check.rst
 
+Write-blocking
+~~~~~~~~~~~~~~
+
 .. include:: /includes/fact-write-blocking-enable.rst
 
 .. include:: /includes/fact-write-blocking-requirement.rst

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -83,7 +83,7 @@ Read Operations
 
 Read operations on the source cluster are always permitted.
 
-``mongosync`` guarantees :term:`eventual consistent <eventual
+``mongosync`` guarantees :term:`eventual consistency <eventual
 consistency>` on the destination cluster. You can read from
 the destination cluster during synching if your application supports 
 eventual consistency.

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -85,7 +85,7 @@ Read operations on the source cluster are always permitted.
 
 ``mongosync`` guarantees :term:`eventual consistency <eventual
 consistency>` on the destination cluster. You can read from
-the destination cluster during synching if your application supports 
+the destination cluster during syncing if your application supports 
 eventual consistency.
 
 When the ``/progress`` endpoint reports ``canWrite`` is ``true``, the

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -42,7 +42,9 @@ operations in that state.
      - Description
      - Possible API Operations
 
-   * - ``IDLE``
+   * - .. _c2c-state-idle:
+
+       ``IDLE``
      - ``mongosync`` is initialized and ready for a sync job to
        begin.
      - - ``POST`` :ref:`/start <c2c-api-start>`
@@ -62,7 +64,9 @@ operations in that state.
      - - ``POST`` :ref:`/resume <c2c-api-resume>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
 
-   * - ``COMMITTING``
+   * - .. _c2c-state-committing:
+   
+       ``COMMITTING``
      - The cutover for the sync process has started. The time it takes
        to transition to the ``COMMITTED`` phase depends on
        ``lagTimeSeconds``. To monitor ``lagTimeSeconds`` or to see if

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -219,9 +219,9 @@ User Permissions
 Permissible Writes
 ``````````````````
 
-.. include:: /includes/fact-write-blocking-when.rst
-
 .. include:: /includes/fact-write-blocking-check.rst
+
+.. include:: /includes/fact-write-blocking-when.rst
 
 
 .. _c2c-capped-collections:

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -203,8 +203,18 @@ data on the destination.
 Write Blocking
 ~~~~~~~~~~~~~~
 
-By default, write-blocking is not enabled during synchronization. When
-write-blocking is enabled, ``mongosync`` blocks writes:
+By default, write-blocking is not enabled during synchronization. You
+can safely write to the source cluster while ``mongosync`` is syncing.
+
+You should not write to the destination cluster until the latter phase
+of the :ref:`COMMITTING <c2c-state-committing>` stage. The
+:ref:`c2c-api-progress` API endpoint returns a boolean value,
+``canWrite``. If you write to the destination cluster while ``canWrite``
+is false, ``mongosync`` exits.
+
+To avoid accidental writes on the destination cluster, enable
+write-blocking. When write-blocking is enabled, ``mongosync`` blocks
+writes:
 
 - On the destination cluster during replication
 - On the source cluster while committing

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -203,14 +203,16 @@ data on the destination.
 Write Blocking
 ~~~~~~~~~~~~~~
 
-By default, write-blocking is not enabled during synchronization. You
-can safely write to the source cluster while ``mongosync`` is syncing.
+By default, write-blocking is not enabled during synchronization.
 
-You should not write to the destination cluster until the latter phase
-of the :ref:`COMMITTING <c2c-state-committing>` stage. The
-:ref:`c2c-api-progress` API endpoint returns a boolean value,
-``canWrite``. If you write to the destination cluster while ``canWrite``
-is false, ``mongosync`` exits.
+You can safely write to the source cluster while ``mongosync`` is
+syncing. You should not write to the destination cluster until the
+latter phase of the :ref:`COMMITTING <c2c-state-committing>` phase.
+
+Check what phase ``mongosync`` is in by calling the
+:ref:`c2c-api-progress` API endpoint. The ``/progress`` end point
+returns a boolean value, ``canWrite``. If you write to the destination
+cluster while ``canWrite`` is false, ``mongosync`` exits.
 
 To avoid accidental writes on the destination cluster, enable
 write-blocking. When write-blocking is enabled, ``mongosync`` blocks

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -205,22 +205,18 @@ data on the destination.
 Write Blocking
 ~~~~~~~~~~~~~~
 
-By default, write-blocking is not enabled during synchronization.
+.. include:: /includes/fact-write-blocking-enable.rst
+
+Write-blocking is not enabled by default. You must enable write-blocking
+when you start ``mongosync`` if you want to use :ref:`reverse
+synchronization <c2c-api-reverse>` later.
+
+.. include:: /includes/fact-write-blocking-requirement.rst
 
 .. include:: /includes/fact-write-blocking-when.rst
 
 .. include:: /includes/fact-write-blocking-check.rst
 
-.. include:: /includes/fact-write-blocking-enable.rst
-
-:ref:`Reverse synchronization <c2c-api-reverse>` requires
-write-blocking. To enable reverse synchronization between the source
-and destination clusters, use the ``start API`` to initiate replication
-with ``reversible`` and ``enableUserWriteBlocking`` set to ``true``.
-The options must be set when replication begins, they cannot be updated
-later.
-
-.. include:: /includes/fact-write-blocking-requirement.rst
 
 .. _c2c-capped-collections:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -200,29 +200,18 @@ show an empty ``system.views`` collection in that database. The empty
 ``system.views`` collection will not change the accuracy of user
 data on the destination.
 
+.. c2c-write-blocking:
+
 Write Blocking
 ~~~~~~~~~~~~~~
 
 By default, write-blocking is not enabled during synchronization.
 
-You can safely write to the source cluster while ``mongosync`` is
-syncing. You should not write to the destination cluster until the
-latter phase of the :ref:`COMMITTING <c2c-state-committing>` phase.
+.. include:: /includes/fact-write-blocking-when.rst
 
-Check what phase ``mongosync`` is in by calling the
-:ref:`c2c-api-progress` API endpoint. The ``/progress`` end point
-returns a boolean value, ``canWrite``. If you write to the destination
-cluster while ``canWrite`` is false, ``mongosync`` exits.
+.. include:: /includes/fact-write-blocking-check.rst
 
-To avoid accidental writes on the destination cluster, enable
-write-blocking. When write-blocking is enabled, ``mongosync`` blocks
-writes:
-
-- On the destination cluster during replication
-- On the source cluster while committing
-
-To enable write-blocking, use the :ref:`start API <c2c-api-start>`
-to set ``enableUserWriteBlocking`` to ``true``.
+.. include:: /includes/fact-write-blocking-enable.rst
 
 :ref:`Reverse synchronization <c2c-api-reverse>` requires
 write-blocking. To enable reverse synchronization between the source

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -207,11 +207,17 @@ Write Blocking
 
 .. include:: /includes/fact-write-blocking-enable.rst
 
+Enable Write-blocking
+`````````````````````
+
 Write-blocking is not enabled by default. You must enable write-blocking
 when you start ``mongosync`` if you want to use :ref:`reverse
 synchronization <c2c-api-reverse>` later.
 
 .. include:: /includes/fact-write-blocking-requirement.rst
+
+Permissible Writes
+``````````````````
 
 .. include:: /includes/fact-write-blocking-when.rst
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -207,12 +207,12 @@ Write Blocking
 
 .. include:: /includes/fact-write-blocking-enable.rst
 
-Enable Write-blocking
-`````````````````````
-
 Write-blocking is not enabled by default. You must enable write-blocking
 when you start ``mongosync`` if you want to use :ref:`reverse
 synchronization <c2c-api-reverse>` later.
+
+User Permissions
+````````````````
 
 .. include:: /includes/fact-write-blocking-requirement.rst
 


### PR DESCRIPTION
STAGING
[/progress](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28691-when-to-write-to-dest-v1.2/reference/api/progress/#response)
[/reverse](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28691-when-to-write-to-dest-v1.2/reference/api/reverse/#requirements)
[mongosync](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28691-when-to-write-to-dest-v1.2/reference/mongosync/#write-blocking)
[mongosync states](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28691-when-to-write-to-dest-v1.2/reference/mongosync-states/#read-operations)

[JIRA](https://jira.mongodb.org/browse/DOCSP-28691)
[C2C] Users should not write to dst until canWrite is true

[BUILD - 2023-04-05](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642dc6f8b49106a498aa47b4)