### PR TITLE
DOCS-15946 Documents buildIndexes option

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -103,7 +103,13 @@ Request Body Parameters
          any indexes created during migration on the source cluster.
 
        - ``never`` causes ``mongosync`` to skip building unnecessary indexes 
-         during sync.  
+         during sync.  This can improve migration performance, especially with 
+         index heavy workloads.
+
+         .. warning::
+
+            Do **not** manually build indexes while ``mongosync`` is 
+            performing a migration.  Wait until the migration is complete.
 
          For more information on the indexes it does build, see 
          :ref:`c2c-required-indexes`.
@@ -111,10 +117,8 @@ Request Body Parameters
        ``/start`` returns an error when ``buildIndexes`` is set to ``never``
        and ``reversible`` is set to ``true``.
 
-       .. note::
-
-          If you call ``/start`` without specifying the ``buildIndexes`` option,
-          ``mongosync`` builds indexes on the destination cluster.
+       If you call ``/start`` without specifying the ``buildIndexes`` option,
+       ``mongosync`` builds indexes on the destination cluster.
 
        .. versionadded:: 1.3.0
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -91,6 +91,25 @@ Request Body Parameters
      - Required
      - Name of the destination cluster.
 
+   * - ``buildIndexes``
+     - boolean
+     - Optional
+     - Configures how ``mongosync`` handles index replication during sync.
+
+       Supported Options:
+
+       * If set to ``beforeDataCopy`` (the default), existing indexes and
+         indexes created on the source cluster during migration are built
+         on the destination cluster.
+
+       * ``never`` causes ``mongosync`` to skip building non-essential indexes
+         during sync.
+
+       ``/start`` returns an error when ``buildIndexes`` is set to ``never``
+       and ``reversible`` is set to ``true``
+
+       .. versionadded:: 1.3.0
+
    * - ``enableUserWriteBlocking``
      - boolean
      - Optional
@@ -136,6 +155,8 @@ Request Body Parameters
        * Sync from a replica set to a sharded cluster
 
        * Sync sharded clusters that have different numbers of shards
+
+       * Reversible sync when ``buildIndexes`` is set to ``never``.
        
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        
@@ -144,7 +165,7 @@ Request Body Parameters
    * - ``sharding``
      - document
      - Optional
-     - Configure sync between a replica set and sharded cluster.
+     - Configures sync between a replica set and sharded cluster.
        Sync from a replica set to a sharded cluster requires this
        option.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -453,7 +453,7 @@ Indexes that are always built include:
   collection it syncs.
 
 * Starting in MongoDB 6.0, ``mongosync`` builds indexes for the ``dummy``
-  shard key kindex on sharded collections.
+  shard key index on sharded collections.
   
   The index is built with the shard key and the ``_id`` field.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -94,13 +94,13 @@ Request Body Parameters
    * - ``buildIndexes``
      - boolean
      - Optional
-     - Configures how ``mongosync`` handles index replication during sync.
+     - Configures index builds during sync.
 
        Supported Options:
 
-       * If set to ``beforeDataCopy`` (the default), existing indexes and
-         indexes created on the source cluster during migration are built
-         on the destination cluster.
+       * ``beforeDataCopy`` (the default) causes ``mongosync`` to build indexes
+         on the destination cluster.  These include both existing indexes and
+         any indexes created during migration on the source cluster.
 
        * ``never`` causes ``mongosync`` to skip building non-essential indexes
          during sync.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -452,8 +452,7 @@ Indexes that are always built include:
 * ``mongosync`` automatically builds an index for the ``_id`` field on every
   collection it syncs.
 
-* Starting in MongoDB 6.0, ``mongosync`` builds indexes for a ``dummy``
-  shard key index on sharded collections, which is removed after commit.
+* Starting in MongoDB 6.0, ``mongosync`` builds dummy indexes that support the shard key for each sharded collection, which are removed after commit.
   When ``buildIndexes`` is set to ``never``, ``mongosync`` retains this
   index after commit.
   

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -102,11 +102,19 @@ Request Body Parameters
          on the destination cluster. These include both existing indexes and
          any indexes created during migration on the source cluster.
 
-       - ``never`` causes ``mongosync`` to skip building unnecessary indexes
-         during sync.
+       - ``never`` causes ``mongosync`` to skip building unnecessary indexes 
+         during sync.  
+
+         For more information on the indexes it does build, see 
+         :ref:`c2c-required-indexes`.
 
        ``/start`` returns an error when ``buildIndexes`` is set to ``never``
        and ``reversible`` is set to ``true``.
+
+       .. note::
+
+          If you call ``/start`` without specifying the ``buildIndexes`` option,
+          ``mongosync`` builds indexes on the destination cluster.
 
        .. versionadded:: 1.3.0
 
@@ -427,4 +435,33 @@ To check whether it is safe to rename collections, call the
   Renaming the collection from this point on does not block
   its sharding on the destination cluster, even in the event  of a crash.
 
+.. _c2c-required-indexes:
 
+Required Indexes
+~~~~~~~~~~~~~~~~
+
+When you call ``/start`` with the ``buildIndexes`` option set to ``never``,
+``mongosync`` skips building unnecessary indexes.  
+
+Indexes that are always built include:
+
+* ``mongosync`` automatically builds an index for the ``_id`` field on every
+  collection it syncs.
+
+* Starting in MongoDB 6.0, ``mongosync`` builds an index for the ``dummy``
+  shard key kindex on any sharded collection it syncs.  
+  
+  The index is built with the shard key and the ``_id`` field.
+
+* When syncing unlike topologies with the ``createSupportingIndexes`` option set
+  to ``true`` for a sharded cluster, ``mongosync`` builds an additional index
+  that serves as the shard key on the destination cluster.
+
+  If ``createSupportingIndexes`` is set to ``false``, ``mongosync`` returns an
+  error.
+
+  .. note:: 
+
+     For ``mongosync`` to sync a replica set to a sharded cluster with 
+     ``buildIndexes`` set to ``never``, the ``createSupportingIndexes`` option
+     must be set to ``true``.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -452,7 +452,7 @@ Indexes that are always built include:
 * ``mongosync`` automatically builds an index for the ``_id`` field on every
   collection it syncs.
 
-* Starting in MongoDB 6.0, ``mongosync`` builds indexes for the ``dummy``
+* Starting in MongoDB 6.0, ``mongosync`` builds indexes for a ``dummy``
   shard key index on sharded collections.
   
   The index is built with the shard key and the ``_id`` field.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -98,15 +98,15 @@ Request Body Parameters
 
        Supported Options:
 
-       * ``beforeDataCopy`` (the default) causes ``mongosync`` to build indexes
-         on the destination cluster.  These include both existing indexes and
+       - ``beforeDataCopy`` (the default) causes ``mongosync`` to build indexes
+         on the destination cluster. These include both existing indexes and
          any indexes created during migration on the source cluster.
 
-       * ``never`` causes ``mongosync`` to skip building non-essential indexes
+       - ``never`` causes ``mongosync`` to skip building unnecessary indexes
          during sync.
 
        ``/start`` returns an error when ``buildIndexes`` is set to ``never``
-       and ``reversible`` is set to ``true``
+       and ``reversible`` is set to ``true``.
 
        .. versionadded:: 1.3.0
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -456,7 +456,4 @@ Indexes that are always built include:
   shard key index on sharded collections, which is removed after commit.
   When ``buildIndexes`` is set to ``never``, ``mongosync`` retains this
   index after commit.
-
-  The index is built with the shard key and the ``_id`` field.
-
   

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -448,13 +448,13 @@ Indexes that are always built include:
 * ``mongosync`` automatically builds an index for the ``_id`` field on every
   collection it syncs.
 
-* Starting in MongoDB 6.0, ``mongosync`` builds an index for the ``dummy``
-  shard key kindex on any sharded collection it syncs.  
+* Starting in MongoDB 6.0, ``mongosync`` builds indexes for the ``dummy``
+  shard key kindex on sharded collections.
   
   The index is built with the shard key and the ``_id`` field.
 
 * When syncing unlike topologies with the ``createSupportingIndexes`` option set
-  to ``true`` for a sharded cluster, ``mongosync`` builds an additional index
+  to ``true`` for a sharded cluster, ``mongosync`` builds additional indexes
   that serves as the shard key on the destination cluster.
 
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -457,6 +457,7 @@ Indexes that are always built include:
   to ``true`` for a sharded cluster, ``mongosync`` builds an additional index
   that serves as the shard key on the destination cluster.
 
+
   If ``createSupportingIndexes`` is set to ``false``, ``mongosync`` returns an
   error.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -453,20 +453,10 @@ Indexes that are always built include:
   collection it syncs.
 
 * Starting in MongoDB 6.0, ``mongosync`` builds indexes for a ``dummy``
-  shard key index on sharded collections.
-  
+  shard key index on sharded collections, which is removed after commit.
+  When ``buildIndexes`` is set to ``never``, ``mongosync`` retains this
+  index after commit.
+
   The index is built with the shard key and the ``_id`` field.
 
-* When syncing unlike topologies with the ``createSupportingIndexes`` option set
-  to ``true`` for a sharded cluster, ``mongosync`` builds additional indexes
-  that serves as the shard key on the destination cluster.
-
-
-  If ``createSupportingIndexes`` is set to ``false``, ``mongosync`` returns an
-  error.
-
-  .. note:: 
-
-     For ``mongosync`` to sync a replica set to a sharded cluster with 
-     ``buildIndexes`` set to ``never``, the ``createSupportingIndexes`` option
-     must be set to ``true``.
+  

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -109,7 +109,8 @@ Request Body Parameters
          .. warning::
 
             Do **not** manually build indexes while ``mongosync`` is 
-            performing a migration.  Wait until the migration is complete.
+            performing a migration.  Wait until the migration is fully 
+            committed.
 
          For more information on the indexes it does build, see 
          :ref:`c2c-required-indexes`.
@@ -449,10 +450,12 @@ When you call ``/start`` with the ``buildIndexes`` option set to ``never``,
 
 Indexes that are always built include:
 
-* ``mongosync`` automatically builds an index for the ``_id`` field on every
-  collection it syncs.
+* ``mongosync`` builds an index on the ``_id`` field of every
+  collection it copies.
 
-* Starting in MongoDB 6.0, ``mongosync`` builds dummy indexes that support the shard key for each sharded collection, which are removed after commit.
+* Starting in MongoDB 6.0, ``mongosync`` builds dummy indexes that support 
+  the shard key for each sharded collection, which are removed after commit.
   When ``buildIndexes`` is set to ``never``, ``mongosync`` retains this
   index after commit.
+
   

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -27,6 +27,8 @@ collections <manual-capped-collection>`. For more information, see
 Disable Index Builds
 --------------------
 
-Starting in 1.3.0, {+c2c-product-name+} supports disabling index builds
-on the destination cluster.  This can improve migration performance,
-especially with index heavy workloads.
+Starting in 1.3.0, {+c2c-product-name+} supports disabling non-essential
+index builds on the destination cluster.  This can improve migration 
+performance, especially with index heavy workloads.
+
+For more information, see :ref:`c2c-api-start`.

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -23,3 +23,10 @@ Capped Collections
 Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
 collections <manual-capped-collection>`. For more information, see
 :ref:`c2c-capped-collections`.
+
+Disable Index Builds
+--------------------
+
+Starting in 1.3.0, {+c2c-product-name+} supports disabling index builds
+on the destination cluster.  This can improve migration performance,
+especially with index heavy workloads.


### PR DESCRIPTION
## Description

Documents `buildIndexes` option for `/start`.

## Staging
[`/start`](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-15946-index-toggle/reference/api/start/#request-body-parameters)

## Jira

[DOCS-15946](https://jira.mongodb.org/browse/DOCS-15946)

## Build
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642dc337b49106a498a8c690)
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=643485f1b49106a498eea137)