### PR TITLE
DOCSP-28950 capped collections

### DIFF
--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -1,0 +1,19 @@
+Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
+collections <manual-capped-collection>` with some limitations.
+
+- The minimum server version is 6.0.
+- :dbcommand:`convertToCapped` is not supported. If you run
+  ``convertToCapped``, ``mongosync`` exists with an error.
+- :dbcommand:`cloneCollectionAsCapped` is not supported. If you run
+  ``cloneCollectionAsCapped``, ``mongosync`` behavior is undefined.
+
+Capped collections on the source cluster work normally during sync.
+
+On the destination cluster capped collections have temporary changes
+during sync:
+
+- There is no maximum number of documents.
+- The maximum document size is 1PB.
+
+``mongosync`` restores the original values for maximum number of
+documents and maximum document size during commit.

--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -3,9 +3,8 @@ collections <manual-capped-collection>` with some limitations.
 
 - The minimum server version is 6.0.
 - :dbcommand:`convertToCapped` is not supported. If you run
-  ``convertToCapped``, ``mongosync`` exists with an error.
-- :dbcommand:`cloneCollectionAsCapped` is not supported. If you run
-  ``cloneCollectionAsCapped``, the ``mongosync`` behavior is undefined.
+  ``convertToCapped``, ``mongosync`` exits with an error.
+- :dbcommand:`cloneCollectionAsCapped` is not supported.
 
 Capped collections on the source cluster work normally during sync.
 

--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -5,11 +5,11 @@ collections <manual-capped-collection>` with some limitations.
 - :dbcommand:`convertToCapped` is not supported. If you run
   ``convertToCapped``, ``mongosync`` exists with an error.
 - :dbcommand:`cloneCollectionAsCapped` is not supported. If you run
-  ``cloneCollectionAsCapped``, ``mongosync`` behavior is undefined.
+  ``cloneCollectionAsCapped``, the ``mongosync`` behavior is undefined.
 
 Capped collections on the source cluster work normally during sync.
 
-On the destination cluster capped collections have temporary changes
+Capped collections on the destination cluster have temporary changes
 during sync:
 
 - There is no maximum number of documents.

--- a/source/includes/collections/behavior-system-collections.rst
+++ b/source/includes/collections/behavior-system-collections.rst
@@ -1,0 +1,24 @@
+{+c2c-product-name+} does not replicate :ref:`system collections 
+<metadata-system-collections>` to the destination cluster.
+
+If you issue a :dbcommand:`dropDatabase` command on the source cluster,
+this change is not directly applied on the destination cluster. Instead,
+{+c2c-product-name+} drops user collections and views in the database 
+on the destination cluster, but it does not drop system collections 
+on that database.
+
+For example, on the destination cluster:
+
+- The drop operation does not affect a user-created  
+  :data:`system.js <<database>.system.js>` collection. 
+
+- If you enable profiling, the :data:`system.profile 
+  <<database>.system.profile>` collection remains.
+
+- If you create views on the source cluster and then drop the database,
+  replicating the drop removes the views, but leaves an empty
+  :data:`system.views <<database>.system.views>` collection.
+
+In these cases, the replication of ``dropDatabase`` removes all user-created
+collections from the database, but leaves its system collections on the
+destination cluster.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -74,7 +74,6 @@ Unsupported Collection Types
 ----------------------------
 
 - Time-series collections are not supported.
-- Capped collections are not supported.
 - Clustered collections with :ref:`expireAfterSeconds
   <db.createCollection.expireAfterSeconds>` set are not supported.
 
@@ -137,31 +136,12 @@ Filtered Sync
 
 .. include:: /includes/limitations-filtering.rst
 
+Capped Collections
+------------------
+
+.. include:: /includes/collections/behavior-capped-collections.rst
+
 System Collections
 ------------------
 
-{+c2c-product-name+} does not replicate :ref:`system collections 
-<metadata-system-collections>` to the destination cluster.
-
-If you issue a :dbcommand:`dropDatabase` command on the source cluster,
-this change is not directly applied on the destination cluster. Instead,
-{+c2c-product-name+} drops user collections and views in the database 
-on the destination cluster, but it does not drop system collections 
-on that database.
-
-For example, on the destination cluster:
-
-- The drop operation does not affect a user-created  
-  :data:`system.js <<database>.system.js>` collection. 
-
-- If you enable profiling, the :data:`system.profile 
-  <<database>.system.profile>` collection remains.
-
-- If you create views on the source cluster and then drop the database,
-  replicating the drop removes the views, but leaves an empty
-  :data:`system.views <<database>.system.views>` collection.
-
-In these cases, the replication of ``dropDatabase`` removes all user-created
-collections from the database, but leaves its system collections on the
-destination cluster.
-
+.. include:: /includes/collections/behavior-system-collections.rst

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -221,6 +221,20 @@ later.
 
 .. include:: /includes/fact-write-blocking-requirement.rst
 
+.. _c2c-capped-collections:
+
+Capped Collections
+~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/collections/behavior-capped-collections.rst
+
+.. _c2c-system-collections:
+
+System Collections
+~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/collections/behavior-system-collections.rst
+
 Examples
 --------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -12,4 +12,6 @@ Release Notes
    /release-notes/1.0
    /release-notes/1.1
    /release-notes/1.2
+   /release-notes/1.3
+
 

--- a/source/release-notes/1.2.txt
+++ b/source/release-notes/1.2.txt
@@ -1,4 +1,4 @@
-.. _c2c-release-notes-1.1:
+.. _c2c-release-notes-1.2:
 
 ===================================
 Release Notes for ``mongosync`` 1.2

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -1,0 +1,25 @@
+.. _c2c-release-notes-1.3:
+
+===================================
+Release Notes for ``mongosync`` 1.3
+===================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. note::
+
+   Upcoming.
+
+
+Capped Collections
+------------------
+
+Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
+collections <manual-capped-collection>`. For more information, see
+:ref:`c2c-capped-collections`.


### PR DESCRIPTION
STAGING
[limitations](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28950-cappd-collections-v1.3/reference/limitations/#capped-collections)
[mongosync](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28950-cappd-collections-v1.3/reference/mongosync/#capped-collections)
[release notes](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28950-cappd-collections-v1.3/release-notes/1.3/)

[JIRA](https://jira.mongodb.org/browse/DOCSP-28950)
[C2C] Support for Capped Collections

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642f33c6b49106a498f99608)