### PR TITLE
DOCSP-28563 Adds telemetry option and setting

### DIFF
--- a/source/includes/opts/disableTelemetry.rst
+++ b/source/includes/opts/disableTelemetry.rst
@@ -1,4 +1,4 @@
 
-Disables the collection and sharing of ``mongosync`` telemetry with MongoDB. 
+Disables the collection and sharing of ``mongosync`` telemetry data with MongoDB. 
 
 

--- a/source/includes/opts/disableTelemetry.rst
+++ b/source/includes/opts/disableTelemetry.rst
@@ -1,0 +1,4 @@
+
+Disables the collection and sharing of ``mongosync`` telemetry with MongoDB. 
+
+

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -69,6 +69,15 @@ Options
    To set the ``cluster1`` setting from the command-line,
    see the :option:`--cluster1` option.
 
+.. setting:: disableTelemetry
+
+   *Type*: boolean
+
+   .. include:: /includes/opts/disableTelemetry
+
+   To set the ``disableTelemetry`` setting from the command-line,
+   see the :option:`--disableTelemetry` option.
+
 .. setting:: id
 
    *Type*: string

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -65,6 +65,12 @@ Global Options
 
    For more information, see :ref:`c2c-mongosync-config`.
 
+.. option:: --disableTelemetry
+
+   .. include:: /includes/opts/disableTelemetry
+
+   To set the ``--disableTelemetry`` option from a configuration file,
+   see the :setting:`disableTelemetry` setting.
 
 .. option:: --help, -h
 


### PR DESCRIPTION
## Description

Adds the `--disableTelemetry` option and setting for `mongosync`.

## Staging

* [`--disableTelemtry` option](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28563-telemetry-toggle/reference/mongosync/#std-option-mongosync.--disableTelemetry)

* [`disableTelemetry` setting](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28563-telemetry-toggle/reference/configuration/#mongodb-setting-disableTelemetry)

## Jira

[DOCSP-28563](https://jira.mongodb.org/browse/DOCSP-28563)

## Build
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64307673b49106a498392f36)
