### PR TITLE
DOCSP-28806 mongosyncID/coordinatorID return fields for /progress calls

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -84,14 +84,17 @@
    * - ``mongosyncID``
      - string
      - The identifier string for the ``mongosync`` instance.
-       To configure this value, see the :setting:`id` setting.
 
    * - ``coordinatorID``
      - string
-     - The identifier string for the coordinator instance.  To change this value,
-       see the :setting:`id` setting on the coordinator instance of ``mongosync``.
+     - The identifier string for the coordinator instance.  
 
-       When the ``mongosync`` instance is the coordinator, this field returns
-       ``null``.
+       - When ``mongosync`` is coordinated by another instance, this field shows
+         the identifier string for the coordinator instance.
 
+       - When ``mongosync`` is a coordinator or runs alone, this field returns
+         the same value as its ``mongosyncID`` field.
+
+       - When ``mongosync`` starts up, this field returns ``null`` until
+         ``mongosync`` identifies the coordinator.
 

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -80,6 +80,7 @@
      - string
      - If an error occurred, gives a detailed description of the error.
        This field is omitted when the call to the endpoint is successful
+
    * - ``mongosyncID``
      - string
      - The identifier string for the ``mongosync`` instance.

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -80,4 +80,17 @@
      - string
      - If an error occurred, gives a detailed description of the error.
        This field is omitted when the call to the endpoint is successful
+   * - ``mongosyncID``
+     - string
+     - The identifier string for the ``mongosync`` instance.
+       To configure this value, see the :setting:`id` setting.
+
+   * - ``coordinatorID``
+     - string
+     - The identifier string for the coordinator instance.  To change this value,
+       see the :setting:`id` setting on the coordinator instance of ``mongosync``.
+
+       When the ``mongosync`` instance is the coordinator, this field returns
+       ``null``.
+
 


### PR DESCRIPTION
## Description

Adds the `mongosyncID` and `coordinatorID` fields to the `/progress` output table.

## Staging
[Response](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28806-coordinatorid/reference/api/progress/#response) (last two items on the table).

## Jira

[DOCSP-28806](https://jira.mongodb.org/browse/DOCSP-28806)

## Build

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6435a05bb49106a49829dd29)
