### PR TITLE
DOCSP-28834 release notes 1.3

### DIFF
--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -35,8 +35,8 @@ performance, especially with index heavy workloads.
 
 For more information, see :ref:`c2c-api-start`.
 
-Coordinator and Mongosync ID's
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Progress Output
+~~~~~~~~~~~~~~~
 
 Starting in 1.3.0, {+c2c-product-name+} includes the ``mongosyncID`` and
 ``coordinatorID`` in the :ref:`c2c-api-progress` response documents.  This

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -14,7 +14,7 @@ Release Notes for ``mongosync`` 1.3
 
 .. note::
 
-   Upcoming.
+   ``mongosync`` 1.3 Released April 13, 20203
 
 New Features
 -------------

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -45,5 +45,5 @@ helps determine whether the ``mongosync`` instance is serving as a coordinator.
 Bug Fixes
 ----------
 
-* Sync cluster collections on replica sets fail to copy all documents to the
+* Syncing clustered collections on replica sets fails to copy all documents to the
   destination cluster (:issue:`REP-1479`)

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -9,26 +9,41 @@ Release Notes for ``mongosync`` 1.3
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 .. note::
 
-   Upcoming.
+   ``mongosync`` 1.3 Released April 14, 2023
 
+New Features
+-------------
 
 Capped Collections
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
 collections <manual-capped-collection>`. For more information, see
 :ref:`c2c-capped-collections`.
 
 Disable Index Builds
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.3.0, {+c2c-product-name+} supports disabling non-essential
 index builds on the destination cluster.  This can improve migration 
 performance, especially with index heavy workloads.
 
 For more information, see :ref:`c2c-api-start`.
+
+Coordinator and Mongosync ID's
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in 1.3.0, {+c2c-product-name+} includes the ``mongosyncID`` and
+``coordinatorID`` in the :ref:`c2c-api-progress` response documents.  This
+helps determine whether the ``mongosync`` instance is serving as a coordinator.
+
+Bug Fixes
+----------
+
+* Sync cluster collections on replica sets fail to copy all documents to the
+  destination cluster (:issue:`REP-1479`)

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -14,7 +14,7 @@ Release Notes for ``mongosync`` 1.3
 
 .. note::
 
-   ``mongosync`` 1.3 Released April 14, 2023
+   Upcoming.
 
 New Features
 -------------

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -14,7 +14,7 @@ Release Notes for ``mongosync`` 1.3
 
 .. note::
 
-   ``mongosync`` 1.3 Released April 13, 20203
+   ``mongosync`` 1.3 Released April 13, 2023
 
 New Features
 -------------

--- a/source/release-notes/1.3.txt
+++ b/source/release-notes/1.3.txt
@@ -45,5 +45,5 @@ helps determine whether the ``mongosync`` instance is serving as a coordinator.
 Bug Fixes
 ----------
 
-* Syncing clustered collections on replica sets fails to copy all documents to the
-  destination cluster (:issue:`REP-1479`)
+* Fixes a bug that could cause ``mongosync`` to not copy some documents to the
+  destination cluster for clustered collections on replica sets.


### PR DESCRIPTION
## Description

Adds release notes for mongosync 1.3.0/

## Staging

[RN](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-28834-release-notes-1.3/release-notes/1.3/)

## Jira

[DOCSP-28834](https://jira.mongodb.org/browse/DOCSP-28834)

## Build

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64381b74b49106a498b489b7)

