### PR TITLE
DOCSP-29170 Capped Collections Size Limit Typo

### DIFF
--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -12,7 +12,7 @@ Capped collections on the destination cluster have temporary changes
 during sync:
 
 - There is no maximum number of documents.
-- The maximum document size is 1PB.
+- The maximum collection size is 1PB.
 
 ``mongosync`` restores the original values for maximum number of
 documents and maximum document size during commit.


### PR DESCRIPTION
## DESCRIPTION
Fixed typo that read as "The maximum document size is 1PB" -> fixed to "the maximum **collection** size is 1PB"

## STAGING 
https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29170-capped-collection-document-size-limit/reference/mongosync/#capped-collections

## JIRA 
https://jira.mongodb.org/browse/DOCSP-29170

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6446e5c95f7a7fd956efb8a1