### PR TITLE
DOCSP-29498 throttle-options

### DIFF
--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -6,7 +6,7 @@
 Sets the cluster workload level used for data synchronization between
 the source and destination clusters:
 
-- ``4`` (highest setting) maximizes cluster workload and
-  synchronizes data the fastest.
-- ``1`` (lowest setting) minimizes cluster workload and
-  synchronizes data the slowest.
+- ``4`` (highest setting) maximizes cluster workload and synchronizes
+  data the fastest.
+- ``1`` (lowest setting) minimizes cluster workload and synchronizes
+  data the slowest.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -4,8 +4,8 @@
 *Default*: ``3``
 
 An integer value between ``1`` and ``4`` inclusive that sets the cluster
-workload level for data synchronization between the source and
-destination clusters.
+workload level and controls the data synchronization speed between the
+source and destination clusters.
 
 ``4`` causes maximum cluster workload and the fastest data
 synchronization. ``1`` causes minimum cluster workload and the slowest

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -1,0 +1,12 @@
+.. reference/configuration.txt
+.. reference/mongosync.txt
+
+*Default*: ``3``
+
+An integer value between ``1`` and ``4`` inclusive that sets the cluster
+workload level for data synchronization between the source and
+destination clusters.
+
+``4`` causes the maximum workload on the clusters and the fastest data
+synchronization. ``1`` causes minimum workload and slowest
+synchronization.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,8 +3,8 @@
 
 *Default*: ``3``
 
-Sets the cluster workload level used for data synchronization between
-the source and destination clusters:
+Sets the cluster workload level used for synchronizing data between the
+source and destination clusters:
 
 - ``4`` (highest setting) maximizes cluster workload and synchronizes
   data the fastest.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -9,4 +9,4 @@ destination clusters.
 
 ``4`` causes the maximum workload on the clusters and the fastest data
 synchronization. ``1`` causes minimum workload and slowest
-synchronization.
+data synchronization.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,10 +3,9 @@
 
 *Default*: ``3``
 
-Integer between ``1`` and ``4`` inclusive that sets the cluster workload
-level and controls the data synchronization speed between the source and
-destination clusters.
+Sets the cluster workload level and controls the data synchronization
+speed between the source and destination clusters.
 
-``4`` causes maximum cluster workload and the fastest data
-synchronization. ``1`` causes minimum cluster workload and the slowest
-data synchronization.
+The highest setting of ``4`` causes maximum cluster workload and the
+fastest data synchronization. The lowest setting of ``1`` causes minimum
+cluster workload and the slowest data synchronization.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -7,6 +7,6 @@ An integer value between ``1`` and ``4`` inclusive that sets the cluster
 workload level for data synchronization between the source and
 destination clusters.
 
-``4`` causes the maximum workload on the clusters and the fastest data
-synchronization. ``1`` causes minimum workload and slowest
+``4`` causes maximum cluster workload and the fastest data
+synchronization. ``1`` causes minimum cluster workload and the slowest
 data synchronization.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,10 +3,10 @@
 
 *Default*: ``3``
 
-Sets the cluster workload level for synchronizing data between the
-source and destination clusters:
+Sets the cluster workload level for syncing data between the source and
+destination clusters:
 
-- ``4``, the highest setting, maximizes cluster workload and
-  synchronizes data the fastest.
-- ``1``, the lowest setting, minimizes cluster workload and synchronizes
-  data the slowest.
+- ``4``, the highest setting, maximizes cluster workload and syncs data
+  the fastest.
+- ``1``, the lowest setting, minimizes cluster workload and syncs data
+  the slowest.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,9 +3,9 @@
 
 *Default*: ``3``
 
-An integer value between ``1`` and ``4`` inclusive that sets the cluster
-workload level and controls the data synchronization speed between the
-source and destination clusters.
+Integer between ``1`` and ``4`` inclusive that sets the cluster workload
+level and controls the data synchronization speed between the source and
+destination clusters.
 
 ``4`` causes maximum cluster workload and the fastest data
 synchronization. ``1`` causes minimum cluster workload and the slowest

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,10 +3,10 @@
 
 *Default*: ``3``
 
-Sets the cluster workload level used for synchronizing data between the
+Sets the cluster workload level for synchronizing data between the
 source and destination clusters:
 
-- ``4`` (highest setting) maximizes cluster workload and synchronizes
-  data the fastest.
-- ``1`` (lowest setting) minimizes cluster workload and synchronizes
+- ``4``, the highest setting, maximizes cluster workload and
+  synchronizes data the fastest.
+- ``1``, the lowest setting, minimizes cluster workload and synchronizes
   data the slowest.

--- a/source/includes/opts/loadLevel.rst
+++ b/source/includes/opts/loadLevel.rst
@@ -3,9 +3,10 @@
 
 *Default*: ``3``
 
-Sets the cluster workload level and controls the data synchronization
-speed between the source and destination clusters.
+Sets the cluster workload level used for data synchronization between
+the source and destination clusters:
 
-The highest setting of ``4`` causes maximum cluster workload and the
-fastest data synchronization. The lowest setting of ``1`` causes minimum
-cluster workload and the slowest data synchronization.
+- ``4`` (highest setting) maximizes cluster workload and
+  synchronizes data the fastest.
+- ``1`` (lowest setting) minimizes cluster workload and
+  synchronizes data the slowest.

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -59,7 +59,6 @@ Options
    To set the ``cluster0`` setting from the command-line,
    see the :option:`--cluster0` option.
 
-
 .. setting:: cluster1
 
    *Type*: string
@@ -105,7 +104,6 @@ Options
    To set the ``port`` setting from the command-line,
    see the :option:`--port` option.
 
-
 .. setting:: verbosity 
 
    *Type*: string
@@ -117,4 +115,3 @@ Options
 
    To set the ``verbosity`` setting from the command-line,
    see the :option:`--verbosity` option.
-

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -78,6 +78,15 @@ Options
    To set the ``id`` setting from the command-line,
    see the :option:`--id` option.
 
+.. setting:: loadLevel
+
+   *Type*: integer
+
+   .. include:: /includes/opts/loadLevel.rst
+
+   To set the ``loadLevel`` setting from the command-line,
+   see the :option:`--loadLevel` option.
+
 .. setting:: logPath
 
    *Type*: string

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -84,8 +84,8 @@ Options
 
    .. include:: /includes/opts/loadLevel.rst
 
-   To set the ``loadLevel`` setting from the command-line,
-   see the :option:`--loadLevel` option.
+   To set the ``loadLevel`` setting from the command-line, see the
+   :option:`--loadLevel` option.
 
 .. setting:: logPath
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -50,7 +50,6 @@ Global Options
    To set the ``--cluster0`` option from a configuration file,
    see the :setting:`cluster0` setting.
 
-
 .. option:: --cluster1 <URI>
 
    .. include:: /includes/opts/cluster0.rst
@@ -58,18 +57,15 @@ Global Options
    To set the ``--cluster1`` option from a configuration file,
    see the :setting:`cluster1` setting.
 
-
 .. option:: --config <filename>
 
    Sets the path to the configuration file.
 
    For more information, see :ref:`c2c-mongosync-config`.
 
-
 .. option:: --help, -h
 
    Prints usage information to stdout.
-
 
 .. option:: --id <ID>
 
@@ -78,13 +74,13 @@ Global Options
    To set the ``--id`` option from a configuration file,
    see the :setting:`id` setting.
 
-.. option:: loadLevel <level>
+.. option:: --loadLevel <level>
 
    *Type*: integer
 
    .. include:: /includes/opts/loadLevel.rst
 
-   To set the ``loadLevel`` setting from a configuration file, see the
+   To set the ``--loadLevel`` option from a configuration file, see the
    :setting:`--loadLevel` setting.
 
 .. option:: --logPath <DIR>
@@ -98,10 +94,8 @@ Global Options
 
    .. include:: /includes/opts/port.rst
 
-
    To set the ``--port`` option from a configuration file,
    see the :setting:`port` setting.
-
 
 .. option:: --verbosity <level>
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -81,7 +81,7 @@ Global Options
    .. include:: /includes/opts/loadLevel.rst
 
    To set the ``--loadLevel`` option from a configuration file, see the
-   :setting:`--loadLevel` setting.
+   :setting:`loadLevel` setting.
 
 .. option:: --logPath <DIR>
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -78,6 +78,15 @@ Global Options
    To set the ``--id`` option from a configuration file,
    see the :setting:`id` setting.
 
+.. option:: loadLevel <level>
+
+   *Type*: integer
+
+   .. include:: /includes/opts/loadLevel.rst
+
+   To set the ``loadLevel`` setting from a configuration file, see the
+   :setting:`--loadLevel` setting.
+
 .. option:: --logPath <DIR>
 
    .. include:: /includes/opts/logPath.rst

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -19,12 +19,12 @@ Release Notes for ``mongosync`` 1.4
 New Features
 -------------
 
-Set Cluster Load Level
-~~~~~~~~~~~~~~~~~~~~~~
+Set Cluster Workload Level
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level for data synchronization between the source and
-destination clusters. For more information, see the
+workload level and control the data synchronization speed between the
+source and destination clusters. For more information, see the
 :option:`--loadLevel` option.
 
 Minimum Supported Version

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -30,4 +30,4 @@ destination clusters. For more information, see the
 Minimum Supported Version
 -------------------------
 
-Starting in 1.4.0, the minimum supported version of MongoDB is <<TBD>.
+In 1.4.0, the minimum supported version of MongoDB is 6.0.5.

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -23,9 +23,8 @@ Set Cluster Workload Level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level used for synchronizing data between the source and
-destination clusters. For more information, see the
-:option:`--loadLevel` option.
+workload level for synchronizing data between the source and destination
+clusters. For more information, see the :option:`--loadLevel` option.
 
 Minimum Supported Version
 -------------------------

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -22,9 +22,10 @@ New Features
 Set Cluster Workload Level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level for syncing data between the source and destination
-clusters. For more information, see the :option:`--loadLevel` option.
+Starting in 1.4.0, you can set the workload level that
+{+c2c-product-name+} uses to sync data between the source and
+destination clusters. For more information, see the
+:option:`--loadLevel` option.
 
 Minimum Supported Version
 -------------------------

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -23,7 +23,7 @@ Set Cluster Workload Level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level for synchronizing data between the source and destination
+workload level for syncing data between the source and destination
 clusters. For more information, see the :option:`--loadLevel` option.
 
 Minimum Supported Version

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -23,7 +23,7 @@ Set Cluster Workload Level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level used for data synchronization between the source and
+workload level used for synchronizing data between the source and
 destination clusters. For more information, see the
 :option:`--loadLevel` option.
 

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -1,0 +1,33 @@
+.. _c2c-release-notes-1.4:
+
+===================================
+Release Notes for ``mongosync`` 1.4
+===================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. note::
+
+   ``mongosync`` 1.4 Released <<TBD>>, 2023
+
+New Features
+-------------
+
+Set Cluster Load Level
+~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
+workload level for data synchronization between the source and
+destination clusters. For more information, see the
+:option:`--loadLevel` option.
+
+Minimum Supported Version
+-------------------------
+
+Starting in 1.4.0, the minimum supported version of MongoDB is <<TBD>.

--- a/source/release-notes/1.4.txt
+++ b/source/release-notes/1.4.txt
@@ -23,8 +23,8 @@ Set Cluster Workload Level
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting in 1.4.0, {+c2c-product-name+} allows you to set the cluster
-workload level and control the data synchronization speed between the
-source and destination clusters. For more information, see the
+workload level used for data synchronization between the source and
+destination clusters. For more information, see the
 :option:`--loadLevel` option.
 
 Minimum Supported Version


### PR DESCRIPTION
JIRA:

https://jira.mongodb.org/browse/DOCSP-29498

Staging:

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29498-throttle-options/reference/mongosync/#std-option-mongosync.--loadLevel

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29498-throttle-options/reference/configuration/#mongodb-setting-loadLevel

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29498-throttle-options/release-notes/1.4/#set-cluster-workload-level
