### PR TITLE
DOCSP-29449 add telemetry information

### DIFF
--- a/source/includes/opts/disableTelemetry.rst
+++ b/source/includes/opts/disableTelemetry.rst
@@ -1,0 +1,4 @@
+Disables the collection of :ref:`telemetry data <c2c-telemetry>` for
+``mongosync``.
+
+.. include:: /includes/opts/telemetry-statement.rst

--- a/source/includes/opts/telemetry-statement.rst
+++ b/source/includes/opts/telemetry-statement.rst
@@ -1,3 +1,4 @@
 ``mongosync`` collects anonymous aggregated usage data to improve
-MongoDB products. ``mongosync`` collects this information by default,
-but you can disable this data collection when you run ``mongosync``.
+MongoDB products. ``mongosync`` collects this telemetry information by
+default, but you can also disable the data collection when you run
+``mongosync``.

--- a/source/includes/opts/telemetry-statement.rst
+++ b/source/includes/opts/telemetry-statement.rst
@@ -1,0 +1,3 @@
+``mongosync`` collects anonymous aggregated usage data to improve
+MongoDB products. ``mongosync`` collects this information by default,
+but you can disable this data collection when you run ``mongosync``.

--- a/source/includes/opts/telemetry-statement.rst
+++ b/source/includes/opts/telemetry-statement.rst
@@ -1,4 +1,4 @@
-``mongosync`` collects anonymous aggregated usage data to improve
+``mongosync`` collects anonymous, aggregated usage data to improve
 MongoDB products. ``mongosync`` collects this telemetry information by
-default, but you can also disable the data collection when you run
+default, but you can also disable telemetry collection when you run
 ``mongosync``.

--- a/source/includes/opts/telemetry-statement.rst
+++ b/source/includes/opts/telemetry-statement.rst
@@ -1,4 +1,3 @@
-``mongosync`` collects anonymous, aggregated usage data to improve
-MongoDB products. ``mongosync`` collects this telemetry information by
-default, but you can also disable telemetry collection when you run
-``mongosync``.
+By default, ``mongosync`` collects anonymous, aggregated usage data to
+improve MongoDB products. When you run ``mongosync`` you can disable
+collection of this telemetry data.

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -14,12 +14,12 @@ Configuration
 
 You can configure :program:`mongosync` instances at startup using a
 configuration file.  The configuration file contains settings that are
-the equivalent of ``mongosync`` command-line options.
+the equivalent of ``mongosync`` command line options.
 
 Configuration File
 ==================
 
-Most :program:`mongosync` command-line options can be written to a YAML
+Most :program:`mongosync` command line options can be written to a YAML
 file. The configuration file specifies values for each setting using
 YAML format. 
 
@@ -56,8 +56,8 @@ Options
 
    .. include:: /includes/opts/cluster0.rst
 
-   To set the ``cluster0`` setting from the command-line,
-   see the :option:`--cluster0` option.
+   To set the ``cluster0`` setting from the command line, see the
+   :option:`--cluster0` option.
 
 .. setting:: cluster1
 
@@ -65,7 +65,7 @@ Options
 
    .. include:: /includes/opts/cluster1.rst
 
-   To set the ``cluster1`` setting from the command-line,
+   To set the ``cluster1`` setting from the command line,
    see the :option:`--cluster1` option.
 
 .. setting:: disableTelemetry
@@ -76,7 +76,7 @@ Options
 
    .. include:: /includes/opts/disableTelemetry
 
-   To set the ``disableTelemetry`` setting from the command-line,
+   To set the ``disableTelemetry`` setting from the command line,
    see the :option:`--disableTelemetry` option.
 
    For more information see, :ref:`User Data Collection
@@ -88,8 +88,8 @@ Options
 
    .. include:: /includes/opts/id.rst
 
-   To set the ``id`` setting from the command-line,
-   see the :option:`--id` option.
+   To set the ``id`` setting from the command line, see the
+   :option:`--id` option.
 
 .. setting:: loadLevel
 
@@ -97,7 +97,7 @@ Options
 
    .. include:: /includes/opts/loadLevel.rst
 
-   To set the ``loadLevel`` setting from the command-line, see the
+   To set the ``loadLevel`` setting from the command line, see the
    :option:`--loadLevel` option.
 
 .. setting:: logPath
@@ -106,8 +106,8 @@ Options
 
    .. include:: /includes/opts/logPath.rst
 
-   To set the ``logPath`` setting from the command-line,
-   see the :option:`--logPath` option.
+   To set the ``logPath`` setting from the command line, see the
+   :option:`--logPath` option.
 
 .. setting:: port
 
@@ -115,8 +115,8 @@ Options
 
    .. include:: /includes/opts/port.rst
 
-   To set the ``port`` setting from the command-line,
-   see the :option:`--port` option.
+   To set the ``port`` setting from the command line, see the
+   :option:`--port` option.
 
 .. setting:: verbosity 
 
@@ -127,5 +127,5 @@ Options
 
    .. include:: /includes/opts/verbosity.rst
 
-   To set the ``verbosity`` setting from the command-line,
-   see the :option:`--verbosity` option.
+   To set the ``verbosity`` setting from the command line, see the
+   :option:`--verbosity` option.

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -68,6 +68,18 @@ Options
    To set the ``cluster1`` setting from the command-line,
    see the :option:`--cluster1` option.
 
+.. setting:: disableTelemetry
+
+   *Type*: boolean
+
+   .. include:: /includes/opts/disableTelemetry
+
+   To set the ``disableTelemetry`` setting from the command-line,
+   see the :option:`--disableTelemetry` option.
+
+   For more information see, :ref:`User Data Collection
+   <c2c-telemetry>`.
+
 .. setting:: id
 
    *Type*: string

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -72,6 +72,8 @@ Options
 
    *Type*: boolean
 
+   .. versionadded:: 1.4.0
+
    .. include:: /includes/opts/disableTelemetry
 
    To set the ``disableTelemetry`` setting from the command-line,

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -79,7 +79,7 @@ Options
    To set the ``disableTelemetry`` setting from the command line,
    see the :option:`--disableTelemetry` option.
 
-   For more information see, :ref:`User Data Collection
+   For more information, see :ref:`User Data Collection
    <c2c-telemetry>`.
 
 .. setting:: id

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -65,6 +65,8 @@ Global Options
 
 .. option:: --disableTelemetry
 
+   .. versionadded:: 1.4.0
+
    .. include:: /includes/opts/disableTelemetry
 
    To set the ``--disableTelemetry`` option from a configuration file,

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -63,6 +63,16 @@ Global Options
 
    For more information, see :ref:`c2c-mongosync-config`.
 
+.. option:: --disableTelemetry
+
+   .. include:: /includes/opts/disableTelemetry
+
+   To set the ``--disableTelemetry`` option from a configuration file,
+   see the :setting:`disableTelemetry` setting.
+
+   For more information see, :ref:`User Data Collection
+   <c2c-telemetry>`.
+
 .. option:: --help, -h
 
    Prints usage information to stdout.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -72,7 +72,7 @@ Global Options
    To set the ``--disableTelemetry`` option from a configuration file,
    see the :setting:`disableTelemetry` setting.
 
-   For more information see, :ref:`User Data Collection
+   For more information, see :ref:`User Data Collection
    <c2c-telemetry>`.
 
 .. option:: --help, -h

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -35,6 +35,7 @@ The data ``mongosync`` tracks includes:
 - Hostnames
 - Usernames
 - Login credentials
+- Connection strings
 - Data stored in MongoDB deployments
 - Personally identifiable information (PII)
 

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -27,7 +27,7 @@ The data ``mongosync`` tracks includes:
 - Initialization arguments.
 - The number of source and destination writes.
 - The estimated number of bytes ``mongosync`` copies.
-- The estimated number of events ``mongosync`` applies
+- The estimated number of events ``mongosync`` applies.
 
 ``mongosync`` does not track:
 
@@ -44,9 +44,11 @@ For more information, see MongoDB's `Privacy Policy
 Toggle Telemetry Collection
 ---------------------------
 
-To disable telemetry when you start ``mongosync``, set
+To disable telemetry when you start ``mongosync``, set one of the
+following:
 
 - :setting:`disableTelemetry` in the :ref:`configuration file
   <c2c-config>`
 - :option:`--disableTelemetry` on the :ref:`command line
   <c2c-mongosync>`
+

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -20,8 +20,8 @@ Data Collection
 
 The data ``mongosync`` reports includes:
 
-- State information, for example, when when ``mongosync`` starts, starts
-  committing, or passes through intermediate states
+- State information when ``mongosync`` starts, starts committing, or
+  passes through intermediate states
 - Information about the source and destination clusters and the hardware
   that hosts the ``mongosync`` instance
 - Initialization arguments

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -18,10 +18,10 @@ Telemetry
 Data Collection
 ---------------
 
-The data ``mongosync`` tracks includes:
+The data ``mongosync`` reports includes:
 
-- State information like when ``mongosync`` starts, starts committing,
-  or passes through intermediate states
+- State information, for example, when when ``mongosync`` starts, starts
+  committing, or passes through intermediate states
 - Information about the source and destination clusters and the hardware
   that hosts the ``mongosync`` instance
 - Initialization arguments

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -18,11 +18,16 @@ Telemetry
 Data Collection
 ---------------
 
-``mongosync`` tracks:
+The data ``mongosync`` tracks includes:
 
-- Performance statistics
-- Initialization information.
-- If ``mongosync`` is running in an Atlas Cluster.
+- State information like when ``mongosync`` starts, starts committing,
+  or passes through intermediate states.
+- Information about the source and destination clusters and the hardware
+  that hosts the ``mongosync`` instance.
+- Initialization arguments.
+- The number of source and destination writes.
+- The estimated number of bytes ``mongosync`` copies.
+- The estimated number of events ``mongosync`` applies
 
 ``mongosync`` does not track:
 

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -1,8 +1,8 @@
 .. _c2c-telemetry:
 
-====================
-User Data Collection
-====================
+=========
+Telemetry
+=========
 
 .. default-domain:: mongodb
 
@@ -43,5 +43,5 @@ To disable telemetry when you start ``mongosync``, set
 
 - :setting:`disableTelemetry` in the :ref:`configuration file
   <c2c-config>`
-- :option:` --disableTelemetry` on the :ref:`command line
+- :option:`--disableTelemetry` on the :ref:`command line
   <c2c-mongosync>`

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -21,13 +21,13 @@ Data Collection
 The data ``mongosync`` tracks includes:
 
 - State information like when ``mongosync`` starts, starts committing,
-  or passes through intermediate states.
+  or passes through intermediate states
 - Information about the source and destination clusters and the hardware
-  that hosts the ``mongosync`` instance.
-- Initialization arguments.
-- The number of source and destination writes.
-- The estimated number of bytes ``mongosync`` copies.
-- The estimated number of events ``mongosync`` applies.
+  that hosts the ``mongosync`` instance
+- Initialization arguments
+- The number of source and destination writes
+- The estimated number of bytes ``mongosync`` copies
+- The estimated number of events ``mongosync`` applies
 
 ``mongosync`` does not track:
 
@@ -41,11 +41,11 @@ The data ``mongosync`` tracks includes:
 For more information, see MongoDB's `Privacy Policy
 <https://www.mongodb.com/legal/privacy-policy?tck=docs_mongosh>`__.
 
-Toggle Telemetry Collection
----------------------------
+Disable Telemetry Collection
+----------------------------
 
-To disable telemetry when you start ``mongosync``, set one of the
-following:
+To disable telemetry collection when you start ``mongosync``, set one of
+the following:
 
 - :setting:`disableTelemetry` in the :ref:`configuration file
   <c2c-config>`

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -1,0 +1,47 @@
+.. _c2c-telemetry:
+
+====================
+User Data Collection
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+
+.. include:: /includes/opts/telemetry-statement.rst
+
+Data Collection
+---------------
+
+``mongosync`` tracks:
+
+- Performance statistics
+- Initialization information.
+- If ``mongosync`` is running in an Atlas Cluster.
+
+``mongosync`` does not track:
+
+- IP addresses
+- Hostnames
+- Usernames
+- Login credentials
+- Data stored in MongoDB deployments
+- Personally identifiable information (PII)
+
+For more information, see MongoDB's `Privacy Policy
+<https://www.mongodb.com/legal/privacy-policy?tck=docs_mongosh>`__.
+
+Toggle Telemetry Collection
+---------------------------
+
+To disable telemetry when you start ``mongosync``, set
+
+- :setting:`disableTelemetry` in the :ref:`configuration file
+  <c2c-config>`
+- :option:` --disableTelemetry` on the :ref:`command line
+  <c2c-mongosync>`


### PR DESCRIPTION
[command line](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29449-add-telemetry/reference/mongosync/#std-option-mongosync.--disableTelemetry)
[config file](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29449-add-telemetry/reference/configuration/#mongodb-setting-disableTelemetry)
[telemetry](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-29449-add-telemetry/reference/telemetry/#std-label-c2c-telemetry)

[JIRA](https://jira.mongodb.org/browse/DOCSP-29499) [REP] Add Telemetry to mongosync

( Replaces and expands [DOCSP-28563](https://jira.mongodb.org/browse/DOCSP-28563), [PR 122](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/122/) )

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=647e1cda67a273b816871b7e)