### PR TITLE
DOCSP-29500 Clarify oplog sizing

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,18 +33,6 @@ Should I increase the size of the ``oplog`` in the source cluster?
 
 .. include:: /includes/fact-oplog-background
 
-The proper ``oplog`` size depends on system hardware, network speed,
-and other factors including system workload. However, assuming network
-transfer speeds of 30-50GB per hour, a rough formula to estimate the
-required ``oplog`` size is:
-
-.. code-block:: shell
-
-   minimumRetentionHours = dataSizeInGB / 30
-
-To estimate the size of ``oplog`` needed for initial synchronization,
-see: :ref:`c2c-oplog-sizing`.
-
 To learn more about how to increase the size of the ``oplog``, see:
 :ref:`tutorial-change-oplog-size`. 
 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -1,7 +1,15 @@
-The :term:`oplog` in the source cluster must be large enough to track
-events that happen during the time it takes to complete the initial
-sync to the destination cluster.
+The :term:`oplog` is a special capped collection that keeps a rolling 
+record of all operations that modify the data stored in your databases. 
+If older operations are removed from the source oplog before mongosync 
+has a chance to apply those operations to the destination, mongosync 
+will exit and the migration will fail.
 
-If you anticipate syncing a large data set, or if you plan to pause
-synchronization for an extended period of time, increase the size of the
-replica set ``oplog`` in the source cluster.
+During initial sync, mongosync may apply operations at a slower rate.
+Once initial sync is complete, mongosync may be able to apply operations
+faster to catch up with the source.
+
+If you anticipate that mongosync's replication lag will become larger 
+than the oplog window (the time difference between the newest and the 
+oldest timestamps in the oplog), or if you plan to pause synchronization 
+for an extended period of time, increase the size of the replica set 
+``oplog`` in the source cluster.

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -20,7 +20,7 @@ be within the :term:`oplog` time range.
 
 .. include:: /includes/fact-oplog-background.txt
 
-Estimate ``oplog`` Size Needed for Initial Sync
+Monitor ``oplog`` Size Needed for Initial Sync
 -----------------------------------------------
 
 .. procedure::
@@ -40,55 +40,29 @@ Estimate ``oplog`` Size Needed for Initial Sync
       cluster. If there are multiple shards, the smallest number is the
       minimum ``oplog`` window.
 
-   .. step:: Estimate Copy Rate During Synching
+   .. step:: Determine mongosync replication lag
 
-      .. _c2c-step-est-size:
+      run the  :ref:`/progress <c2c-api-progress>` command to get
+      ``lagTimeSeconds``. This is the time in seconds between the 
+      last event applied by mongosync and time of the current latest 
+      event on the source cluster.
 
-      To gather performance data while synching, start the sync process
-      and monitor how fast data is transferred between clusters.
-      
-      To start syncing, run the :ref:`/start <c2c-api-start>`
-      command.
-
-      To get the ``copy_rate``:
-      
-      - run the  :ref:`/progress <c2c-api-progress>` command to get
-        ``estimatedCopiedBytes_time01``
-      - wait a second or two
-      - run the  :ref:`/progress <c2c-api-progress>` command to get
-        ``estimatedCopiedBytes_time02``
-      
-      The ``copy_rate`` is:
-
-      .. code-block:: shell
-
-         copy_rate = ( estimatedCopiedBytes_time02 - estimatedCopiedBytes_01) / time_between_requests
-
-   .. step:: Estimate Copy Time
-
-      Estimate the time needed to copy the entire collection. The
-      estimated copy time is:
-      
-      .. code-block:: shell
-
-         estimatedCopyTime = estimatedTotalBytes / copy_rate
+      It is a measure of how far behind the source cluster mongosync is.
 
    .. step:: Validate ``oplog`` Size
 
-      If the estimated time is larger than the minimum oplog window you
-      must cancel synchronization. Before restarting, make one of the
-      following changes:
+      If the lag time is approaching the minimum oplog window you
+      should make one of the following changes:
 
       - Increase the oplog window. Use :dbcommand:`replSetResizeOplog`
-        to set ``minRetentionHours`` greater than the estimated copy
-        time.
+        to set ``minRetentionHours`` greater than the current oplog 
+        window.
       - Scale up the ``mongosync`` instance. Add cpu or memory to scale
         up the ``mongosync`` node so that it has a higher copy rate.
 
 .. note::
 
-   The copy rate may vary during synchronization. To monitor progress,
-   repeat the :ref:`steps to estimate the copy rate
-   <c2c-step-est-size>` and verify that the copy rate stays about the
-   same.
+   The oplog window and rate of change of replication lag may vary during 
+   synchronization. Repeat these steps during a migration to monitor the 
+   progress.
 


### PR DESCRIPTION
This is an example of the changes needed for DOCSP-29500. Key points:

- No longer say users need an oplog window large enough for the entirety of initial sync.
- No longer say that the size of the data set determines how large the oplog should be.
- Explain how mongosync operation application may be slower during initial sync and may speed up after initial sync
- Explain how users should check the lagTimesSeconds in the /progress endpoint and compare this with the oplog window to decide if they need to increase the oplog window.

I just wanted to get the main changes down on paper, I'm sure the language and formatting could be improved here. Please feel free to start a new PR. Just wanted to provide this as reference.