### PR TITLE
DOCSP-31028 sharding warning

### DIFF
--- a/source/includes/sharding-warning.rst
+++ b/source/includes/sharding-warning.rst
@@ -1,7 +1,7 @@
 
 .. warning::
 
-   Syncing large document to a sharded destination cluster can cause 
+   Syncing large documents to a sharded destination cluster can cause 
    the destination cluster to initiate chunk migration.  When the destination
    cluster migrates chunks during sync, it may trigger a bug that can result
    in data loss.

--- a/source/includes/sharding-warning.rst
+++ b/source/includes/sharding-warning.rst
@@ -1,8 +1,10 @@
 
 .. warning::
+
    Syncing large document to a sharded destination cluster can cause 
-   the destination cluster to initiate chunk migration, which may trigger 
-   a bug that can result in data loss on that chunk.
+   the destination cluster to initiate chunk migration.  When the destination
+   cluster migrates chunks during sync, it may trigger a bug that can result
+   in data loss.
 
    To avoid this, it is recommended that you run the :dbcommand:`balancerStop`
    command on the destination cluster before starting a sync.  Once ``mongosync``

--- a/source/includes/sharding-warning.rst
+++ b/source/includes/sharding-warning.rst
@@ -1,0 +1,11 @@
+
+.. warning::
+   Syncing large document to a sharded destination cluster can cause 
+   the destination cluster to initiate chunk migration, which may trigger 
+   a bug that can result in data loss on that chunk.
+
+   To avoid this, it is recommended that you run the :dbcommand:`balancerStop`
+   command on the destination cluster before starting a sync.  Once ``mongosync``
+   completes the sync, you can restart the balancer with the 
+   :dbcommand:`balancerStart` command.
+

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -61,7 +61,7 @@ To configure multiple ``mongosync`` instances:
 
    .. step:: Stop the Balancer on the Destination
 
-      To stop the balancer on the destinaiton cluster, connect to the
+      To stop the balancer on the destination cluster, connect to the
       destination cluster and call the :method:`sh.stopBalancer` method:
 
       .. code-block:: javascript

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -273,6 +273,15 @@ These commands only check progress and commit synchronization for the
 to ``progress`` and  ``commit`` on any other ``mongosync`` instances
 that may be running.
 
+Once this is done, use :method:`sh.startBalancer` to restart the balancer 
+on the destination cluster:
+
+.. code-block:: javascript
+
+   sh.startBalancer()
+
+
+
 .. _c2c-sharded-reverse:
 
 Reverse the Synchronization Direction

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -18,6 +18,8 @@ There are two ways to synchronize :ref:`sharded clusters
 loaded clusters, use multiple ``monogosync`` instances, one
 ``monogosync`` for each shard in the cluster.
 
+.. include:: /includes/sharding-warning
+
 .. _c2c-sharded-config-single:
 
 Configure a Single ``mongosync`` Instance
@@ -56,6 +58,16 @@ To configure multiple ``mongosync`` instances:
       different numbers of shards. However, if you want to reverse the
       sync, the source cluster and destination cluster must have the
       same number of shards.
+
+   .. step:: Stop the Balancer on the Destination
+
+      To stop the balancer on the destinaiton cluster, connect to the
+      destination cluster and call the :method:`sh.stopBalancer` method:
+
+      .. code-block:: javascript
+
+         sh.stopBalancer()
+
 
    .. step:: Determine the shard IDs
 


### PR DESCRIPTION
## Description

Request for the addition of a warning and some steps for when syncing to a sharded destination cluster.

## Staging

* [Intro Warning](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31028-sharding-warning/multiple-mongosyncs/#use-mongosync-on-sharded-clusters)
* [Step: Stop Balancer](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31028-sharding-warning/multiple-mongosyncs/#stop-the-balancer-on-the-destination)
* [Restart Balancer after commit](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31028-sharding-warning/multiple-mongosyncs/#commit-synchronization-from--multiple-mongosync-instances)

## Jira

[DOCSP-31028](https://jira.mongodb.org/browse/DOCSP-31028)

## Build

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=649c563b423952aeb9427c10)