### PR TITLE
DOCSP-31391 1.5 release notes

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -31,7 +31,7 @@ clusters.
 Should I increase the size of the ``oplog`` in the source cluster?
 ------------------------------------------------------------------
 
-The :term:`oplog` is a special capped collection that keeps a rolling 
+The :term:`oplog` is a capped collection that keeps a rolling 
 record of all operations that modify the data stored in your databases. 
 
 .. include:: /includes/fact-oplog-background

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -31,19 +31,10 @@ clusters.
 Should I increase the size of the ``oplog`` in the source cluster?
 ------------------------------------------------------------------
 
+The :term:`oplog` is a special capped collection that keeps a rolling 
+record of all operations that modify the data stored in your databases. 
+
 .. include:: /includes/fact-oplog-background
-
-The proper ``oplog`` size depends on system hardware, network speed,
-and other factors including system workload. However, assuming network
-transfer speeds of 30-50GB per hour, a rough formula to estimate the
-required ``oplog`` size is:
-
-.. code-block:: shell
-
-   minimumRetentionHours = dataSizeInGB / 30
-
-To estimate the size of ``oplog`` needed for initial synchronization,
-see: :ref:`c2c-oplog-sizing`.
 
 To learn more about how to increase the size of the ``oplog``, see:
 :ref:`tutorial-change-oplog-size`. 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -4,7 +4,7 @@ to the data on the destination cluster.  When operations
 that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
-During the initial sync, ``mongosync`` may not apply operations at a slower
+During the initial sync, ``mongosync`` may apply operations at a slower
 rate. After ``mongosync`` completes the initial sync, it applies changes 
 faster and stays more current in the source cluster ``oplog``.
 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -1,10 +1,10 @@
 
 ``mongosync`` applies operations in the ``oplog`` on the source cluster
-to the data on the destination cluster.  When older operations 
+to the data on the destination cluster.  When operations 
 that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
-During initial sync, ``mongosync`` may apply operations at a slower
+During the initial sync, ``mongosync`` may not apply operations at a slower
 rate. After ``mongosync`` completes the initial sync, it applies changes 
 faster and stays more current in the source cluster ``oplog``.
 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -5,8 +5,10 @@ that ``mongosync`` has not applied roll off the ``oplog``
 on the source cluster, the sync fails and ``mongosync`` exits.
 
 During the initial sync, ``mongosync`` may apply operations at a slower
-rate. After ``mongosync`` completes the initial sync, it applies changes 
-faster and stays more current in the source cluster ``oplog``.
+rate due to the load imposed by copying documents concurrently.
+After ``mongosync`` completes the initial sync, it applies changes 
+faster and is more likely to maintain a position in the ``oplog``
+that is close tothe real-time writes occuring on the source closter.
 
 If you anticipate syncing a large data set, or if you plan to pause
 synchronization for an extended period of time, you might exceed the

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -1,7 +1,15 @@
-The :term:`oplog` in the source cluster must be large enough to track
-events that happen during the time it takes to complete the initial
-sync to the destination cluster.
+
+``mongosync`` applies operations in the ``oplog`` on the source cluster
+to the data on the destination cluster.  When older operations 
+that ``mongosync`` has not applied roll off the ``oplog`` 
+on the source cluster, the sync fails and ``mongosync`` exits.
+
+During initial sync, ``mongosync`` may apply operations at a slower
+rate. After ``mongosync`` completes the initial sync, it applies changes 
+faster and stays more current in the source cluster ``oplog``.
 
 If you anticipate syncing a large data set, or if you plan to pause
-synchronization for an extended period of time, increase the size of the
-replica set ``oplog`` in the source cluster.
+synchronization for an extended period of time, you might exceed the
+:term:`oplog window`. Use the :setting:`~replication.oplogSizeMB` setting
+to increase the size of the ``oplog`` on the source cluster.
+

--- a/source/includes/opts/verbosity.rst
+++ b/source/includes/opts/verbosity.rst
@@ -1,7 +1,7 @@
 .. reference/configuration.txt
 .. reference/mongosync.txt
 
-*Default*: ``INFO``
+*Default*: ``DEBUG``
 
 Sets the verbosity level to use in log messages.
 {+c2c-product-name+} logs all messages at the specified level and

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -1,7 +1,7 @@
 .. _c2c-oplog-sizing:
 
 ================
-``oplog`` Sizing
+oplog Sizing
 ================
 
 .. default-domain:: mongodb
@@ -21,7 +21,7 @@ be within the ``oplog`` time range.
 
 .. include:: /includes/fact-oplog-background
 
-Monitor ``oplog`` Size Needed for Initial Sync
+Monitor oplog Size Needed for Initial Sync
 -----------------------------------------------
 
 .. procedure::
@@ -49,12 +49,12 @@ Monitor ``oplog`` Size Needed for Initial Sync
       last event applied by ``mongosync`` and time of the current
       latest event on the source cluster.
 
-      It is a measure of how far behind the source cluster mongosync is.
+      It is a measure of how far behind the source cluster ``mongosync`` is.
 
    .. step:: Validate ``oplog`` Size
 
-      If the lag time approaches the minimum ``oplog`` window, you
-      should make one of the following changes:
+      If the lag time approaches the minimum ``oplog`` window, make 
+      one of the following changes:
 
       - Increase the ``oplog`` window. Use :dbcommand:`replSetResizeOplog`
         to set ``minRetentionHours`` greater than the current ``oplog`` 
@@ -64,7 +64,7 @@ Monitor ``oplog`` Size Needed for Initial Sync
 
 .. note::
 
-   The ``oplog`` window and rate of change of replication lag may vary during 
-   synchronization. Repeat these steps during a migration to monitor the 
+   The :term:`oplog` window and rate of change for replication lag may vary 
+   during synchronization. Repeat these steps during a migration to monitor the 
    progress.
 

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -27,7 +27,7 @@ Monitor oplog Size Needed for Initial Sync
 .. procedure::
    :style: normal
 
-   .. step:: Determine the ``oplog`` Time Span
+   .. step:: Determine oplog Window
 
       To get the difference in seconds between the first and last entry
       in the ``oplog`` run :method:`db.getReplicationInfo()`. If you
@@ -41,7 +41,7 @@ Monitor oplog Size Needed for Initial Sync
       cluster. If there are multiple shards, the smallest number is the
       minimum ``oplog`` window.
 
-   .. step:: Determine mongosync replication lag
+   .. step:: Determine mongosync Replication Lag
 
       To get the ``lagTimeSeconds`` value, run the  
       :ref:`/progress <c2c-api-progress>` command. 
@@ -51,7 +51,7 @@ Monitor oplog Size Needed for Initial Sync
 
       It is a measure of how far behind the source cluster ``mongosync`` is.
 
-   .. step:: Validate ``oplog`` Size
+   .. step:: Validate oplog Size
 
       If the lag time approaches the minimum ``oplog`` window, make 
       one of the following changes:

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -16,11 +16,12 @@ The :ref:`mongosync <c2c-mongosync>` program uses :ref:`change streams
 <changeStreams>` to synchronize data between source and destination
 clusters. ``mongosync`` does not access the :term:`oplog` directly,
 but when a change stream returns events from the past, the events must
-be within the :term:`oplog` time range. 
+be within the ``oplog`` time range. 
 
-.. include:: /includes/fact-oplog-background.txt
 
-Estimate ``oplog`` Size Needed for Initial Sync
+.. include:: /includes/fact-oplog-background
+
+Monitor ``oplog`` Size Needed for Initial Sync
 -----------------------------------------------
 
 .. procedure::
@@ -40,55 +41,30 @@ Estimate ``oplog`` Size Needed for Initial Sync
       cluster. If there are multiple shards, the smallest number is the
       minimum ``oplog`` window.
 
-   .. step:: Estimate Copy Rate During Synching
+   .. step:: Determine mongosync replication lag
 
-      .. _c2c-step-est-size:
+      To get the ``lagTimeSeconds`` value, run the  
+      :ref:`/progress <c2c-api-progress>` command. 
+      The lag time is the time in seconds between the 
+      last event applied by ``mongosync`` and time of the current
+      latest event on the source cluster.
 
-      To gather performance data while synching, start the sync process
-      and monitor how fast data is transferred between clusters.
-      
-      To start syncing, run the :ref:`/start <c2c-api-start>`
-      command.
-
-      To get the ``copy_rate``:
-      
-      - run the  :ref:`/progress <c2c-api-progress>` command to get
-        ``estimatedCopiedBytes_time01``
-      - wait a second or two
-      - run the  :ref:`/progress <c2c-api-progress>` command to get
-        ``estimatedCopiedBytes_time02``
-      
-      The ``copy_rate`` is:
-
-      .. code-block:: shell
-
-         copy_rate = ( estimatedCopiedBytes_time02 - estimatedCopiedBytes_01) / time_between_requests
-
-   .. step:: Estimate Copy Time
-
-      Estimate the time needed to copy the entire collection. The
-      estimated copy time is:
-      
-      .. code-block:: shell
-
-         estimatedCopyTime = estimatedTotalBytes / copy_rate
+      It is a measure of how far behind the source cluster mongosync is.
 
    .. step:: Validate ``oplog`` Size
 
-      If the estimated time is larger than the minimum oplog window you
-      must cancel synchronization. Before restarting, make one of the
-      following changes:
+      If the lag time approaches the minimum ``oplog`` window, you
+      should make one of the following changes:
 
-      - Increase the oplog window. Use :dbcommand:`replSetResizeOplog`
-        to set ``minRetentionHours`` greater than the estimated copy
-        time.
+      - Increase the ``oplog`` window. Use :dbcommand:`replSetResizeOplog`
+        to set ``minRetentionHours`` greater than the current ``oplog`` 
+        window.
       - Scale up the ``mongosync`` instance. Add cpu or memory to scale
         up the ``mongosync`` node so that it has a higher copy rate.
 
 .. note::
 
-   The copy rate may vary during synchronization. To monitor progress,
-   repeat the :ref:`steps to estimate the copy rate
-   <c2c-step-est-size>` and verify that the copy rate stays about the
-   same.
+   The ``oplog`` window and rate of change of replication lag may vary during 
+   synchronization. Repeat these steps during a migration to monitor the 
+   progress.
 

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -59,7 +59,7 @@ Monitor ``oplog`` Size Needed for Initial Sync
       - Increase the ``oplog`` window. Use :dbcommand:`replSetResizeOplog`
         to set ``minRetentionHours`` greater than the current ``oplog`` 
         window.
-      - Scale up the ``mongosync`` instance. Add cpu or memory to scale
+      - Scale up the ``mongosync`` instance. Add CPU or memory to scale
         up the ``mongosync`` node so that it has a higher copy rate.
 
 .. note::

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -8,6 +8,7 @@ Release Notes
 .. toctree::
    :titlesonly: 
 
+   /release-notes/1.5
    /release-notes/1.4
    /release-notes/1.3
    /release-notes/1.2

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -41,7 +41,7 @@ Bug Fixes
 - Fixes an issue where ``mongosync`` could incorrectly report indexes 
   as mismatched.
 
-- Fixes an issue where the :ref:`/start <api-start>` endpoint would not return
+- Fixes an issue where the :ref:`/start <c2c-api-start>` endpoint would not return
   an error when passed a ``sharding`` object without the ``shardingEntries``
   key.
 

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -18,7 +18,7 @@ Release Notes for mongosync 1.5
 1.5.0 Release
 -------------
 
-**Upcoming**
+**July 25, 2023**
 
 Oplog Rollover Resiliency
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -42,7 +42,7 @@ Bug Fixes
   as mismatched.
 
 - Fixes issue where the :ref:`/start <api-start>` endpoint would not return
-  an error when passed a ``sharding`` object wtihout the ``shardingEntries``
+  an error when passed a ``sharding`` object without the ``shardingEntries``
   key.
 
 - Changes telemetry to send less metadata to Segment.

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -28,7 +28,7 @@ Oplog Rollover Resilience
 Logging Level
 ~~~~~~~~~~~~~
 
-Starting in 1.5.0, the default logging level is ``DEBUG``.  To change
+Starting in 1.5, the default logging level is ``DEBUG``.  To change
 the logging level, see the :setting:`verbosity` setting.
 
 
@@ -50,4 +50,4 @@ Bug Fixes
 Minimum Supported Version
 -------------------------
 
-In 1.5.0, the minimum supported version of MongoDB is 6.0.5.
+In 1.5, the minimum supported version of MongoDB is 6.0.5.

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -50,4 +50,4 @@ Bug Fixes
 Minimum Supported Version
 -------------------------
 
-In 1.5, the minimum supported version of MongoDB is 6.0.5.
+In 1.5, the minimum supported version of MongoDB is 6.0.8.

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -23,7 +23,7 @@ Release Notes for mongosync 1.5
 Oplog Rollover Resiliency
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting in 1.5, ``mongosync`` begins to apply changes while the
+Starting in 1.5.0, ``mongosync`` begins to apply changes while the
 initial sync is still in progress. By starting to apply changes earlier,
 ``mongosync`` maintains a more recent position in the :term:`oplog`.
 This adds resiliency to long running operation, mitigates the risk
@@ -33,7 +33,7 @@ the sync.
 Logging Level
 ~~~~~~~~~~~~~
 
-Starting in 1.5, the default logging level is ``DEBUG``.  To change
+Starting in 1.5.0, the default logging level is ``DEBUG``.  To change
 the logging level, see the :setting:`verbosity` setting.
 
 

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -23,8 +23,6 @@ Release Notes for mongosync 1.5
 Oplog Rollover Resilience
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/fact-oplog-background
-
 Logging Level
 ~~~~~~~~~~~~~
 

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -1,0 +1,22 @@
+.. _c2c-release-notes-1.5:
+
+===================================
+Release Notes for ``mongosync`` 1.5
+===================================
+
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _1.5.0-c2c-release-notes:
+
+1.5.0 Release
+-------------
+
+**Upcoming**
+

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -20,8 +20,15 @@ Release Notes for mongosync 1.5
 
 **Upcoming**
 
-Oplog Rollover Resilience
+Oplog Rollover Resiliency
 ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting in 1.5, ``mongosync`` begins to apply changes while the
+initial sync is still in progress. By starting to apply changes earlier,
+``mongosync`` maintains a more recent position in the :term:`oplog`.
+This adds resiliency to long running operation, mitigates the risk
+of ``oplog`` rollover, and significantly lowers the risk of restarting
+the sync.
 
 Logging Level
 ~~~~~~~~~~~~~

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -26,7 +26,7 @@ Oplog Rollover Resiliency
 Starting in 1.5.0, ``mongosync`` begins to apply changes while the
 initial sync is still in progress. By starting to apply changes earlier,
 ``mongosync`` maintains a more recent position in the :term:`oplog`.
-This adds resiliency to long running operation, mitigates the risk
+This adds resiliency to long-running operations, mitigates the risk
 of ``oplog`` rollover, and significantly lowers the risk of restarting
 the sync.
 

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -25,3 +25,24 @@ Oplog Rollover Resilience
 
 .. include:: /includes/fact-oplog-background
 
+Logging Level
+~~~~~~~~~~~~~
+
+Starting in 1.5.0, the default logging level is ``DEBUG``.  To change
+the logging level, see the :setting:`verbosity` setting.
+
+
+Bug Fixes
+---------
+
+- Fixes issue where very large collections could timeout during 
+  ``mongosync`` initialization. 
+
+- Fixes issue where ``mongosync`` could incorrectly report indexes 
+  as mismatched.
+
+- Fixes issue where the :ref:`/start <api-start>` endpoint would not return
+  an error when passed a ``sharding`` object wtihout the ``shardingEntries``
+  key.
+
+- Changes telemetry to send less metadata to Segment.

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -20,3 +20,8 @@ Release Notes for ``mongosync`` 1.5
 
 **Upcoming**
 
+Oplog Rollover Resilience
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-oplog-background
+

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -1,7 +1,7 @@
 .. _c2c-release-notes-1.5:
 
 ===================================
-Release Notes for ``mongosync`` 1.5
+Release Notes for mongosync 1.5
 ===================================
 
 
@@ -35,13 +35,13 @@ the logging level, see the :setting:`verbosity` setting.
 Bug Fixes
 ---------
 
-- Fixes issue where very large collections could timeout during 
+- Fixes an issue where very large collections could timeout during 
   ``mongosync`` initialization. 
 
-- Fixes issue where ``mongosync`` could incorrectly report indexes 
+- Fixes an issue where ``mongosync`` could incorrectly report indexes 
   as mismatched.
 
-- Fixes issue where the :ref:`/start <api-start>` endpoint would not return
+- Fixes an issue where the :ref:`/start <api-start>` endpoint would not return
   an error when passed a ``sharding`` object without the ``shardingEntries``
   key.
 

--- a/source/release-notes/1.5.txt
+++ b/source/release-notes/1.5.txt
@@ -46,3 +46,8 @@ Bug Fixes
   key.
 
 - Changes telemetry to send less metadata to Segment.
+
+Minimum Supported Version
+-------------------------
+
+In 1.5.0, the minimum supported version of MongoDB is 6.0.5.


### PR DESCRIPTION
## Description

* Adds release notes for 1.5.0.  
* Restores content on oplog sizing, reverted from 1.4.
* Updates verbosity defaults

## Staging

* [RN](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31391-1.5-release-notes/release-notes/1.5/)
* [Oplog Sizing intro](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31391-1.5-release-notes/reference/oplog-sizing/)
* [verbosity defaults](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31391-1.5-release-notes/reference/configuration/#mongodb-setting-verbosity)

## Jira

[DOCSP-31391](https://jira.mongodb.org/browse/DOCSP-31391)

## Build

* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b80e9a87b3b3604604d84d)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bac9b587b3b36046cf51c5)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bf0c3c87b3b36046a33f98)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bfdfb887b3b36046d24931)
