### PR TITLE
DOCSP-31612 Fixes typo

### DIFF
--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -8,7 +8,7 @@ During the initial sync, ``mongosync`` may apply operations at a slower
 rate due to the load imposed by copying documents concurrently.
 After ``mongosync`` completes the initial sync, it applies changes 
 faster and is more likely to maintain a position in the ``oplog``
-that is close tothe real-time writes occuring on the source closter.
+that is close to the real-time writes occuring on the source cluster.
 
 If you anticipate syncing a large data set, or if you plan to pause
 synchronization for an extended period of time, you might exceed the


### PR DESCRIPTION
Fixes typo

[Staging](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31612-typo/reference/oplog-sizing/)

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64c000f587b3b36046df5aff)