### PR TITLE
DOCSP-32087 reverse req

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,9 +44,9 @@ To use the ``reverse`` endpoint:
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
-- :ref:`index-type-unique` requires proper formatting.
-
-  For more information, see :ref:`c2c-validate-unique-index`.
+- :ref:`index-type-unique` requires proper formatting.  To validate
+  that collection indexes use the proper formatting, see
+  :ref:`c2c-validate-unique-index`.
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -111,7 +111,7 @@ Validate Unique Indexes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to reverse direction, ``mongosync`` requires that all
-:ref:`unique <index-type-unique>` indexes use the formatting. 
+:ref:`unique <index-type-unique>` indexes use the correct formatting. 
 Clusters of servers that began using MongoDB 4.2 or older and were since
 upgraded may include unique indexes that are not properly formatted.
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -93,9 +93,6 @@ Response
 Behavior
 --------
 
-Final State
-~~~~~~~~~~~
-
 If the ``reverse`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state. The synchronization continues in the reverse
 direction from the original sync job. You do not need to restart the
@@ -120,7 +117,7 @@ use the :method:`db.collection.validate` method on each collection.
 
 .. code-block:: javascript
 
-   db.names.validate()
+   db.<collection>.validate()
 
 If the method returns a warning about the unique index, you must
 :ref:`resync <resync-replica-member>` all of the nodes in the

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,15 +44,9 @@ To use the ``reverse`` endpoint:
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
-- :ref:`index-type-unqie` requires proper formatting.
+- :ref:`index-type-unique` requires proper formatting.
 
-  For information on validation, see :ref:`c2c-validate-unique-index`.
-- :ref:`Unique indexes <index-type-unique>` on the original source
-  cluster must be formatted properly. If an upgraded cluster has unique
-  indexes that were created in MongoDB 4.2 or earlier, you must
-  :ref:`resync <resync-replica-member>` all of the nodes in the
-  original source cluster before reversing.
-
+  For more information, see :ref:`c2c-validate-unique-index`.
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,13 +44,15 @@ To use the ``reverse`` endpoint:
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
+- :ref:`index-type-unqie` requires proper formatting.
+
+  For information on validation, see :ref:`c2c-validate-unique-index`.
 - :ref:`Unique indexes <index-type-unique>` on the original source
   cluster must be formatted properly. If an upgraded cluster has unique
   indexes that were created in MongoDB 4.2 or earlier, you must
   :ref:`resync <resync-replica-member>` all of the nodes in the
   original source cluster before reversing.
 
-  For more information, see :ref:`c2c-validate-unique-index`.
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -62,16 +62,17 @@ In order to reverse direction, ``mongosync`` requires that all
 Clusters that began with MongoDB 4.2 or older and were since
 upgraded may include unique indexes that are not properly formatted.
 
-To ensure that ``mongosync`` can reverse sync on databases in these clusters,
-use the :method:`db.collection.validate` method on each collection.
+To correct indexes, you can :ref:`rsync <resync-replica-member>` all nodes
+in the original source cluster.  If you don't want to resync the cluster, you
+can use the :method:`db.collection.validate` method on each collection to 
+determine whether it contains improperly formatted unique indexes.
 
 .. code-block:: javascript
 
    db.<collection>.validate()
 
 If the method returns a warning about the unique index, you must
-:ref:`resync <resync-replica-member>` all of the nodes in the
-original source cluster before reversing.
+resync all of the nodes in the original source cluster before reversing sync.
 
 Request
 -------

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -49,6 +49,8 @@ To use the ``reverse`` endpoint:
   indexes that were created in MongoDB 4.2 or earlier, you must
   :ref:`resync <resync-replica-member>` all of the nodes in the
   original source cluster before reversing.
+
+  For more information, see :ref:`c2c-validate-unique-index`.
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst
 
@@ -103,8 +105,10 @@ To view the mapping direction for the synchronization of the source and
 destination clusters, use the :ref:`progress <c2c-api-progress>`
 endpoint and check the ``directionMapping`` object.
 
-Unique Indexes
-~~~~~~~~~~~~~~
+.. _c2c-validate-unique-index:
+
+Validate Unique Indexes
+~~~~~~~~~~~~~~~~~~~~~~~
 
 In order to reverse direction, ``mongosync`` requires that all
 :ref:`unique <index-type-unique>` indexes use the formatting. 
@@ -114,4 +118,11 @@ upgraded may include unique indexes that are not properly formatted.
 To ensure that ``mongosync`` can reverse sync on databases in these clusters,
 use the :method:`db.collection.validate` method on each collection.
 
+.. code-block:: javascript
+
+   db.names.validate()
+
+If the method returns a warning about the unique index, you must
+:ref:`resync <resync-replica-member>` all of the nodes in the
+original source cluster before reversing.
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -62,7 +62,7 @@ In order to reverse direction, ``mongosync`` requires that all
 Clusters that began with MongoDB 4.2 or older and were since
 upgraded may include unique indexes that are not properly formatted.
 
-To correct indexes, you can :ref:`rsync <resync-replica-member>` all nodes
+To correct indexes, you can :ref:`resync <resync-replica-member>` all nodes
 in the original source cluster.  If you don't want to resync the cluster, you
 can use the :method:`db.collection.validate` method on each collection to 
 determine whether it contains improperly formatted unique indexes.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -91,6 +91,9 @@ Response
 Behavior
 --------
 
+Final State
+~~~~~~~~~~~
+
 If the ``reverse`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state. The synchronization continues in the reverse
 direction from the original sync job. You do not need to restart the
@@ -99,3 +102,16 @@ entire sync process to copy the original data.
 To view the mapping direction for the synchronization of the source and
 destination clusters, use the :ref:`progress <c2c-api-progress>`
 endpoint and check the ``directionMapping`` object.
+
+Unique Indexes
+~~~~~~~~~~~~~~
+
+In order to reverse direction, ``mongosync`` requires that all
+:ref:`unique <index-type-unique>` indexes use the formatting. 
+Clusters of servers that began using MongoDB 4.2 or older and were since
+upgraded may include unique indexes that are not properly formatted.
+
+To ensure that ``mongosync`` can reverse sync on databases in these clusters,
+use the :method:`db.collection.validate` method on each collection.
+
+

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,8 +44,10 @@ To use the ``reverse`` endpoint:
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - Source and destination clusters must be MongoDB 6.0 or later.
-- :ref:`index-type-unique` requires proper formatting.  To validate
-  that collection indexes use the proper formatting, see
+- :ref:`index-type-unique` require proper formatting.  Collections with indexes
+  initially created on MongoDB 4.2 may not have the proper formatting. 
+  
+  To validate that collection indexes use the proper formatting, see
   :ref:`c2c-validate-unique-index`.
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -50,6 +50,27 @@ To use the ``reverse`` endpoint:
 - .. include:: /includes/fact-reverse-limitation.rst
 - .. include:: /includes/fact-permissions-body.rst
 
+.. _c2c-validate-unique-index:
+
+Validate Unique Indexes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In order to reverse direction, ``mongosync`` requires that all
+:ref:`unique <index-type-unique>` indexes use the correct formatting. 
+Clusters that began with MongoDB 4.2 or older and were since
+upgraded may include unique indexes that are not properly formatted.
+
+To ensure that ``mongosync`` can reverse sync on databases in these clusters,
+use the :method:`db.collection.validate` method on each collection.
+
+.. code-block:: javascript
+
+   db.<collection>.validate()
+
+If the method returns a warning about the unique index, you must
+:ref:`resync <resync-replica-member>` all of the nodes in the
+original source cluster before reversing.
+
 Request
 -------
 
@@ -97,25 +118,4 @@ entire sync process to copy the original data.
 To view the mapping direction for the synchronization of the source and
 destination clusters, use the :ref:`progress <c2c-api-progress>`
 endpoint and check the ``directionMapping`` object.
-
-.. _c2c-validate-unique-index:
-
-Validate Unique Indexes
-~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to reverse direction, ``mongosync`` requires that all
-:ref:`unique <index-type-unique>` indexes use the correct formatting. 
-Clusters of servers that began using MongoDB 4.2 or older and were since
-upgraded may include unique indexes that are not properly formatted.
-
-To ensure that ``mongosync`` can reverse sync on databases in these clusters,
-use the :method:`db.collection.validate` method on each collection.
-
-.. code-block:: javascript
-
-   db.<collection>.validate()
-
-If the method returns a warning about the unique index, you must
-:ref:`resync <resync-replica-member>` all of the nodes in the
-original source cluster before reversing.
 


### PR DESCRIPTION
## Description

Documents how to validate collections to ensure that unique indexes are correctly formatted.

## Staging

* [Validate Unique Indexes](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32087-reverse-req/reference/api/reverse/#validate-unique-indexes)

## Jira

* [DOCSP-32087](https://jira.mongodb.org/browse/DOCSP-32087)

## Build
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64dbadda67dbe91010e005f9)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e4ed0b57e37806c546d247)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6532e5673ede3ec111b1bb13)