### PR TITLE
DOCSP-32048 process Error Response

### DIFF
--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,5 +1,7 @@
 
 .. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
 
    * - ``errorDescription``
      - string

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -2,6 +2,11 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
+   :widths: 20 20 60
+
+   * - Field
+     - Type
+     - Description
 
    * - ``errorDescription``
      - string

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,7 +1,7 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 20 60
+   :stub-columns: 1
 
    * - ``errorDescription``
      - string

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,3 +1,4 @@
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,0 +1,10 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 20 60
+
+   * - ``errorDescription``
+     - string
+     - If an error occurred, gives a detailed description of the error.
+       This field is omitted when the call to the endpoint is successful
+

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,1 +1,8 @@
-T
+
+.. list-table::
+
+   * - ``errorDescription``
+     - string
+     - If an error occurred, gives a detailed description of the error.
+       This field is omitted when the call to the endpoint is successful
+

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -8,7 +8,7 @@
      - Type
      - Description
 
-   * - ``errorDescription``
+   * - ``error``
      - string
      - If an error occurred, gives a detailed description of the error.
        This field is omitted when the call to the endpoint is successful

--- a/source/includes/api/tables/progress-error-response.rst
+++ b/source/includes/api/tables/progress-error-response.rst
@@ -1,11 +1,1 @@
-
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :widths: 20 20 60
-
-   * - ``errorDescription``
-     - string
-     - If an error occurred, gives a detailed description of the error.
-       This field is omitted when the call to the endpoint is successful
-
+T

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -1,7 +1,7 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 25 55
+   :widths: 20 20 60
 
    * - Field
      - Type
@@ -47,11 +47,13 @@
      - Describes the total amount of data being copied and the
        amount that has already been copied to the destination cluster.
 
-   * - ``collectionCopy.estimatedTotalBytes``
+   * - ``collectionCopy``
+       ``.estimatedTotalBytes``
      - integer
      - Estimated total number of bytes to be copied.
 
-   * - ``collectionCopy.estimatedCopiedBytes``
+   * - ``collectionCopy``
+       ``.estimatedCopiedBytes``
      - integer
      - Estimated number of bytes which have been copied to the
        destination cluster.
@@ -61,12 +63,14 @@
      - Describes the mapping direction for the synchronization, namely
        the source and destination clusters.
 
-   * - ``directionMapping.Source``
+   * - ``directionMapping``
+       ``.Source``
      - string
      - Source cluster. Returned in the form
        ``<cluster name>: <host>:<port>``.
 
-   * - ``directionMapping.Destination``
+   * - ``directionMapping``
+       ``.Destination``
      - string
      - Destination cluster. Returned in the form
        ``<cluster name>: <host>:<port>``.

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -1,3 +1,4 @@
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
@@ -74,16 +75,6 @@
      - string
      - Destination cluster. Returned in the form
        ``<cluster name>: <host>:<port>``.
-
-   * - ``error``
-     - string
-     - If an error occurred, indicates the name of the error. This field
-       is omitted when the call to the endpoint is successful.
-
-   * - ``errorDescription``
-     - string
-     - If an error occurred, gives a detailed description of the error.
-       This field is omitted when the call to the endpoint is successful
 
    * - ``mongosyncID``
      - string

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -1,7 +1,7 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 60
+   :widths: 20 25 55
 
    * - Field
      - Type

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -44,6 +44,7 @@ Error Response
 If ``mongosync`` encounters an error, the ``progress`` endpoint instead
 returns an ``error`` object with the following field:
 
+.. include:: /includes/api/tables/progress-error-response.rst
 
 Behavior
 --------

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -28,10 +28,17 @@ Request
 Response
 --------
 
-All response fields are wrapped in a top-level ``progress`` object. The
-endpoint returns either an updated status or an error.
+The ``progress`` endpoint returns etiher an updated status or an error.
+
+On a successful return, all response fields are wrapped in a top-level
+``progress`` object with the following fields:
 
 .. include:: /includes/api/tables/progress-response.rst
+
+If ``mongosync`` encounters an error, the ``progress`` endpoint instead
+returns an ``error`` object with the following field:
+
+.. include:: /includes/api/tables/progress-error-response.rst
 
 Behavior
 --------

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -33,16 +33,17 @@ The ``progress`` endpoint returns etiher an updated status or an error.
 Successful Response
 ~~~~~~~~~~~~~~~~~~~
 
-On a successful return, all response fields are wrapped in a top-level
-``progress`` object with the following fields:
+If ``mongosync`` successfully gets the status of the sync process, 
+all response fields are wrapped in a top-level ``progress`` object 
+with the following fields:
 
 .. include:: /includes/api/tables/progress-response.rst
 
 Error Response
 ~~~~~~~~~~~~~~
 
-If ``mongosync`` encounters an error, the ``progress`` endpoint instead
-returns an ``error`` object with the following field:
+If ``mongosync`` encounters an error, the ``progress`` endpoint returns 
+an ``error`` object with the following field:
 
 .. include:: /includes/api/tables/progress-error-response.rst
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -43,7 +43,7 @@ Error Response
 ~~~~~~~~~~~~~~
 
 If ``mongosync`` encounters an error, the ``progress`` endpoint returns 
-an ``error`` object with the following field:
+the following field:
 
 .. include:: /includes/api/tables/progress-error-response.rst
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -30,10 +30,16 @@ Response
 
 The ``progress`` endpoint returns etiher an updated status or an error.
 
+Successful Response
+~~~~~~~~~~~~~~~~~~~
+
 On a successful return, all response fields are wrapped in a top-level
 ``progress`` object with the following fields:
 
 .. include:: /includes/api/tables/progress-response.rst
+
+Error Response
+~~~~~~~~~~~~~~
 
 If ``mongosync`` encounters an error, the ``progress`` endpoint instead
 returns an ``error`` object with the following field:

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -44,7 +44,6 @@ Error Response
 If ``mongosync`` encounters an error, the ``progress`` endpoint instead
 returns an ``error`` object with the following field:
 
-.. include:: /includes/api/tables/progress-error-response.rst
 
 Behavior
 --------


### PR DESCRIPTION
## Description

Fix the `progress` documentation to indicate that the error response is different from a successful completion.  Also,
modifies the response table to allow for better wrapping.

## Staging

* [progress response](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32048-process-clarification/reference/api/progress/#response)

## Jira

* [DOCSP-32048](https://jira.mongodb.org/browse/DOCSP-32048)

## Build

* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64dcf85f67dbe910102ca0f8)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e4da3757e37806c5411521)
