### PR TITLE
DOCSP-31307 Adds /start API request body to telemetry list

### DIFF
--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -28,7 +28,7 @@ The data ``mongosync`` reports includes:
 - The number of source and destination writes
 - The estimated number of bytes ``mongosync`` copies
 - The estimated number of events ``mongosync`` applies
-- The request body sent to :ref:`c2c-api-start` calls.
+- The request body sent to :ref:`c2c-api-start` calls
 
 ``mongosync`` does not track:
 

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -28,6 +28,7 @@ The data ``mongosync`` reports includes:
 - The number of source and destination writes
 - The estimated number of bytes ``mongosync`` copies
 - The estimated number of events ``mongosync`` applies
+- The request body sent to :ref:`c2c-api-start` calls.
 
 ``mongosync`` does not track:
 


### PR DESCRIPTION
## Description

Adds notice that request bodies sent to the `/start` endpoint are sent as telemetry.

## Staging

* [Telemetry](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-31307-start-telemetry/reference/telemetry/#data-collection)

## Jira

* [DOCSP-31307](https://jira.mongodb.org/browse/DOCSP-31307)

## Build

* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e7bdb324fcc731b43b3e22)