### PR TITLE
DOCSP-32282 API Security

### DIFF
--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,7 +1,7 @@
 
 .. note::
 
-   ``mongosync`` does not protect the |endpoint| endpoint.  By default, 
+   ``mongosync`` does not protect the |endpoint| endpoint.  However, by default 
    the API binds to localhost only and does not accept calls from other sources.
    Additionally, the |endpoint| call does not expose connection credentials 
    or user data.

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -2,7 +2,7 @@
 .. note::
 
    ``mongosync`` does not protect the |endpoint| endpoint.  By default, 
-   the API binds to localhost and does not accept calls from other sources.
+   the API binds to localhost only and does not accept calls from other sources.
    Additionally, the |endpoint| call does not expose connection credentials 
    or user data.
 

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,0 +1,10 @@
+
+.. note::
+
+   The |endpoint| endpoint is not secured.  But, the ``mongosync`` API is bound
+   to localhost only by default.  
+   
+   Additionally, the |endpoint| call does not expose connection credentials or
+   user data.
+
+

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,10 +1,8 @@
 
 .. note::
 
-   The |endpoint| endpoint is not secured.  But, the ``mongosync`` API is bound
-   to localhost only by default.  
-   
-   Additionally, the |endpoint| call does not expose connection credentials or
-   user data.
+   While the |endpoint| endpoint is unprotected, the ``mongosync`` API binds
+   to localhost only, by default.  Additionally, the |endpoint| call does not
+   expose connection credentials or user data.
 
 

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,7 +1,7 @@
 
 .. note::
 
-   ``mongosync`` does not protect the |endpoint| endpoint.  By default, however,
+   ``mongosync`` does not protect the |endpoint| endpoint.  By default, 
    the API binds to localhost and does not accept calls from other sources.
    Additionally, the |endpoint| call does not expose connection credentials 
    or user data.

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,9 +1,8 @@
 
-.. note::
 
-   ``mongosync`` does not protect the |endpoint| endpoint.  However, by default 
-   the API binds to localhost only and does not accept calls from other sources.
-   Additionally, the |endpoint| call does not expose connection credentials 
-   or user data.
+``mongosync`` does not protect the |endpoint| endpoint.  However, by default 
+the API binds to localhost only and does not accept calls from other sources.
+Additionally, the |endpoint| call does not expose connection credentials 
+or user data.
 
 

--- a/source/includes/fact-api-endpoint.rst
+++ b/source/includes/fact-api-endpoint.rst
@@ -1,8 +1,9 @@
 
 .. note::
 
-   While the |endpoint| endpoint is unprotected, the ``mongosync`` API binds
-   to localhost only, by default.  Additionally, the |endpoint| call does not
-   expose connection credentials or user data.
+   ``mongosync`` does not protect the |endpoint| endpoint.  By default, however,
+   the API binds to localhost and does not accept calls from other sources.
+   Additionally, the |endpoint| call does not expose connection credentials 
+   or user data.
 
 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -49,6 +49,9 @@ characteristics that ``mongosync`` alters during the synchronization process.
        which ``mongosync`` set to the maximum allowable size on the
        destination cluster.
 
+.. |endpoint| replace:: ``commit``
+.. include:: /includes/fact-api-endpoint
+
 Requirements
 ------------
 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -49,9 +49,6 @@ characteristics that ``mongosync`` alters during the synchronization process.
        which ``mongosync`` set to the maximum allowable size on the
        destination cluster.
 
-.. |endpoint| replace:: ``commit``
-.. include:: /includes/fact-api-endpoint
-
 Requirements
 ------------
 
@@ -158,7 +155,6 @@ State
 ~~~~~
 
 If the ``commit`` request is successful, ``mongosync`` enters the
-``COMMITTING`` state, then automatically transitions to the
 ``COMMITTED`` state. Once ``mongosync`` enters the ``COMMITTED`` state,
 continuous sync between the clusters stops. 
 
@@ -166,5 +162,12 @@ Data Verification
 ~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/fact-verification
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``commit``
+.. include:: /includes/fact-api-endpoint
+
 
 

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -18,9 +18,6 @@ Description
 
 Pauses the current synchronization operation. 
 
-.. |endpoint| replace:: ``pause``
-.. include:: /includes/fact-api-endpoint
-
 Requirement
 -----------
 
@@ -80,3 +77,12 @@ Behavior
   increase the size of the replica set :term:`oplog` in the source
   cluster. To learn more, see :ref:`Frequently Asked Questions
   <c2c-faq-increase-oplog>`. 
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``pause``
+.. include:: /includes/fact-api-endpoint
+
+
+

--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -18,6 +18,9 @@ Description
 
 Pauses the current synchronization operation. 
 
+.. |endpoint| replace:: ``pause``
+.. include:: /includes/fact-api-endpoint
+
 Requirement
 -----------
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -17,7 +17,7 @@ Description
 
 Returns either an updated status of the synchronization process or an error.
 
-.. |endpoint| replace:: ``start``
+.. |endpoint| replace:: ``progress``
 .. include:: /includes/fact-api-endpoint
 
 Request

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -17,6 +17,9 @@ Description
 
 Returns either an updated status of the synchronization process or an error.
 
+.. |endpoint| replace:: ``start``
+.. include:: /includes/fact-api-endpoint
+
 Request
 -------
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -17,9 +17,6 @@ Description
 
 Returns either an updated status of the synchronization process or an error.
 
-.. |endpoint| replace:: ``progress``
-.. include:: /includes/fact-api-endpoint
-
 Request
 -------
 
@@ -61,6 +58,13 @@ Behavior
 
 - The endpoint does not auto-refresh. To get updated status, call the
   ``progress`` endpoint again.
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``progress``
+.. include:: /includes/fact-api-endpoint
+
 
 Example
 -------

--- a/source/reference/api/resume.txt
+++ b/source/reference/api/resume.txt
@@ -19,6 +19,9 @@ Description
 Resumes a paused synchronization session based on data stored on the
 destination cluster.
 
+.. |endpoint| replace:: ``resume``
+.. include:: /includes/fact-api-endpoint
+
 Requirement
 -----------
 

--- a/source/reference/api/resume.txt
+++ b/source/reference/api/resume.txt
@@ -19,9 +19,6 @@ Description
 Resumes a paused synchronization session based on data stored on the
 destination cluster.
 
-.. |endpoint| replace:: ``resume``
-.. include:: /includes/fact-api-endpoint
-
 Requirement
 -----------
 
@@ -76,3 +73,11 @@ Behavior
 
 If the ``resume`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``resume``
+.. include:: /includes/fact-api-endpoint
+
+

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -30,9 +30,6 @@ For example:
 In this scenario, you can use the ``reverse`` endpoint to sync writes
 from ``cluster1`` to ``cluster0``.
 
-.. |endpoint| replace:: ``reverse``
-.. include:: /includes/fact-api-endpoint
-
 Requirements
 ------------
 
@@ -143,4 +140,11 @@ entire sync process to copy the original data.
 To view the mapping direction for the synchronization of the source and
 destination clusters, use the :ref:`progress <c2c-api-progress>`
 endpoint and check the ``directionMapping`` object.
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``reverse``
+.. include:: /includes/fact-api-endpoint
+
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -30,6 +30,9 @@ For example:
 In this scenario, you can use the ``reverse`` endpoint to sync writes
 from ``cluster1`` to ``cluster0``.
 
+.. |endpoint| replace:: ``reverse``
+.. include:: /includes/fact-api-endpoint
+
 Requirements
 ------------
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -18,9 +18,6 @@ Description
 
 Starts the synchronization between a source and destination cluster.
 
-.. |endpoint| replace:: ``start``
-.. include:: /includes/fact-api-endpoint
-
 Requirements
 ------------
 
@@ -477,4 +474,11 @@ Indexes that are always built include:
   sharded collection, which are removed after commit. When ``buildIndexes`` is
   set to ``never``, ``mongosync`` retains this index after commit.
 
-  
+
+Endpoint Protection
+~~~~~~~~~~~~~~~~~~~
+
+.. |endpoint| replace:: ``start``
+.. include:: /includes/fact-api-endpoint
+
+

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -18,6 +18,9 @@ Description
 
 Starts the synchronization between a source and destination cluster.
 
+.. |endpoint| replace:: ``/start``
+.. include:: /includes/fact-api-endpoint
+
 Requirements
 ------------
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -18,7 +18,7 @@ Description
 
 Starts the synchronization between a source and destination cluster.
 
-.. |endpoint| replace:: ``/start``
+.. |endpoint| replace:: ``start``
 .. include:: /includes/fact-api-endpoint
 
 Requirements


### PR DESCRIPTION
## Description

Adds a notice to each mongosync API endpoint indicating that mongosync does not protect the endpoint, but notes that by default it is bound to localhost only and that it doesn't expose connection details or user data.

## Staging

Note added to the descriptions of these pages:
* [start](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/start/)
* [progress](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/progress/)
* [pause](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/pause/)
* [resume](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/resume/)
* [commit](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/commit/)
* [reverse](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32282-api-security/reference/api/reverse/)

## Jira

* [DOCSP-32282](https://jira.mongodb.org/browse/DOCSP-32282)

## Build
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660c34c63a5920a2914a21bd)