### PR TITLE
(DOCSP-32574): Update minimum MDB version

### DIFF
--- a/source/includes/fact-mongodb-version.rst
+++ b/source/includes/fact-mongodb-version.rst
@@ -1,5 +1,5 @@
 
 {+c2c-product-name+} supports synchronization between clusters.  Both
-the source and destination cluster must use MongoDB 6.0 or later. The
+the source and destination cluster must use MongoDB 6.0.8 or later. The
 :dbcommand:`Feature Compatibility Version
 <setFeatureCompatibilityVersion>` must also be set to 6.0 or later.


### PR DESCRIPTION
## Description

The minimum supported MDB version for c2c is server 6.0.8.

## JIRA

https://jira.mongodb.org/browse/DOCSP-32574

## Build Log

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64ed02b824fcc731b43eea17

## Staging

- [Linux Version Requirements](https://preview-mongodbjeffallenmongo.gatsbyjs.io/cluster-sync/DOCSP-32574/installation/install-on-linux/#version-requirements)
- [macOS Version Requirements](https://preview-mongodbjeffallenmongo.gatsbyjs.io/cluster-sync/DOCSP-32574/installation/install-on-macos/)
- [Windows Version Requirements](https://preview-mongodbjeffallenmongo.gatsbyjs.io/cluster-sync/DOCSP-32574/installation/install-on-windows/#version-requirements)

