### PR TITLE
DOCS-16353 Double Quotes for mongosync Connection Strings

### DIFF
--- a/source/includes/example-connect.rst
+++ b/source/includes/example-connect.rst
@@ -44,8 +44,8 @@ following command on one line:
 .. code-block:: shell
 
    mongosync \
-         --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
-         --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
+         --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
+         --cluster1 "mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020"
 
 Atlas clusters require TLS connections. To use ``mongosync`` with Atlas
 clusters, you add the :urioption:`tls=true <tls>` option. For example,
@@ -54,8 +54,8 @@ to connect to the ``admin`` database on ``cluster0`` and ``cluster1``:
 .. code-block:: shell
 
    mongosync \
-      --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/admin?tls=true' \
-      --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/admin?tls=true'
+      --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/admin?tls=true" \
+      --cluster1 "mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020/admin?tls=true"
 
 You can also use ``mongodb+srv`` connection strings with ``mongosync``.
 You do not need to add the :urioption:`tls=true <tls>` option to a
@@ -64,8 +64,8 @@ You do not need to add the :urioption:`tls=true <tls>` option to a
 .. code-block:: shell
 
    mongosync \
-      --cluster0 'mongodb+srv://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020/' \
-      --cluster1 'mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/'
+      --cluster0 "mongodb+srv://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020/" \
+      --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020/"
 
 For more details about ``mongodb+srv`` connection strings, see
 :ref:`connections-dns-seedlist`.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -165,8 +165,8 @@ command is reformated here for clarity):
 .. code-block:: shell
 
    ./bin/mongosync \
-         --cluster0 'mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020' \
-         --cluster1 'mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020'
+         --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
+         --cluster1 "mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020"
 
 Initialization Notes
 ~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -263,8 +263,8 @@ Examples
    .. code-block:: bash
 
       mongosync \
-           --cluster0 'mongodb://192.0.2.10:27017,192.0.2.11:27017,192.0.2.12:27017' \
-           --cluster1 'mongodb://192.0.2.20:27017,192.0.2.21:27017,192.0.2.22:27017'
+           --cluster0 "mongodb://192.0.2.10:27017,192.0.2.11:27017,192.0.2.12:27017" \
+           --cluster1 "mongodb://192.0.2.20:27017,192.0.2.21:27017,192.0.2.22:27017"
 
    Use the appropriate connection strings for the :option:`--cluster0`
    and :option:`--cluster1` options so that they can connect to your


### PR DESCRIPTION
## DESCRIPTION 
Updated all `mongosync command` connection strings to use double quotes instead of single quotes. 

## STAGING 
- [Quickstart](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-16353-windows-shell-quotes/quickstart/#initialize-mongosync)
- [Connect Two Atlas Clusters](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-16353-windows-shell-quotes/connecting/atlas-to-atlas/#:~:text=on%20one%20line%3A-,mongosync,-%5C)
- [Connect Two Self-Managed Clusters](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-16353-windows-shell-quotes/connecting/onprem-to-onprem/#connect-the-source-and-destination-clusters-with-mongosync)
- [Connect a Self-Managed Cluster to Atlas](https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCS-16353-windows-shell-quotes/connecting/onprem-to-atlas/#connect-the-source-and-destination-clusters-with-mongosync)

## JIRA
https://jira.mongodb.org/browse/DOCS-16353

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64f0b25524fcc731b42602aa