### PR TITLE
DOCSP 32921 Add warning for --loadLevel setting

### DIFF
--- a/source/includes/opts/loadlevel-warning.rst
+++ b/source/includes/opts/loadlevel-warning.rst
@@ -1,4 +1,4 @@
-   .. warning::
+.. warning::
 
-      Setting the ``loadLevel`` higher than the default may negatively impact 
-      the destination cluster performance.
+   Setting the ``loadLevel`` higher than the default may negatively impact 
+   the destination cluster performance.

--- a/source/includes/opts/loadlevel-warning.rst
+++ b/source/includes/opts/loadlevel-warning.rst
@@ -1,0 +1,4 @@
+   .. warning::
+
+      Setting the ``loadLevel`` higher than the default may negatively impact 
+      the destination cluster performance.

--- a/source/includes/opts/loadlevel-warning.rst
+++ b/source/includes/opts/loadlevel-warning.rst
@@ -1,4 +1,4 @@
 .. warning::
 
-   Setting the ``loadLevel`` higher than the default may negatively impact 
-   the destination cluster performance.
+   Setting ``loadLevel`` higher than the default of ``3`` may negatively
+   impact the destination cluster performance.

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -102,7 +102,7 @@ Options
 
    .. warning::
 
-      Setting the ``--loadLevel`` to ``4`` may negatively impact the performance 
+      Setting the ``loadLevel`` to ``4`` may negatively impact the performance 
       of the destination cluster. 
 
 .. setting:: logPath

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -100,11 +100,6 @@ Options
    To set the ``loadLevel`` setting from the command line, see the
    :option:`--loadLevel` option.
 
-   .. warning::
-
-      Setting the ``loadLevel`` higher than the default may negatively impact 
-      the performance of the destination cluster. 
-
    .. include:: /includes/opts/loadlevel-warning.rst
 
 .. setting:: logPath

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -105,6 +105,8 @@ Options
       Setting the ``loadLevel`` higher than the default may negatively impact 
       the performance of the destination cluster. 
 
+   .. include:: /includes/opts/loadLevel-warning.rst
+
 .. setting:: logPath
 
    *Type*: string

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -100,6 +100,11 @@ Options
    To set the ``loadLevel`` setting from the command line, see the
    :option:`--loadLevel` option.
 
+   .. warning::
+
+      Setting the ``--loadLevel`` to ``4`` may negatively impact the performance 
+      of the destination cluster. 
+
 .. setting:: logPath
 
    *Type*: string

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -105,7 +105,7 @@ Options
       Setting the ``loadLevel`` higher than the default may negatively impact 
       the performance of the destination cluster. 
 
-   .. include:: /includes/opts/loadLevel-warning.rst
+   .. include:: /includes/opts/loadlevel-warning.rst
 
 .. setting:: logPath
 

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -102,8 +102,8 @@ Options
 
    .. warning::
 
-      Setting the ``loadLevel`` to ``4`` may negatively impact the performance 
-      of the destination cluster. 
+      Setting the ``loadLevel`` higher than the default may negatively impact 
+      the performance of the destination cluster. 
 
 .. setting:: logPath
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -95,6 +95,11 @@ Global Options
    To set the ``--loadLevel`` option from a configuration file, see the
    :setting:`loadLevel` setting.
 
+   .. warning::
+
+      Setting the ``--loadLevel`` to ``4`` may negatively impact the performance 
+      of the destination cluster. 
+
 .. option:: --logPath <DIR>
 
    .. include:: /includes/opts/logPath.rst

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -95,11 +95,8 @@ Global Options
    To set the ``--loadLevel`` option from a configuration file, see the
    :setting:`loadLevel` setting.
 
-   .. warning::
-
-      Setting the ``loadLevel`` higher than the default may negatively impact 
-      the performance of the destination cluster. 
-
+   .. include:: /includes/opts/loadlevel-warning.rst
+   
 .. option:: --logPath <DIR>
 
    .. include:: /includes/opts/logPath.rst

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -97,7 +97,7 @@ Global Options
 
    .. warning::
 
-      Setting the ``--loadLevel`` to ``4`` may negatively impact the performance 
+      Setting the ``loadLevel`` to ``4`` may negatively impact the performance 
       of the destination cluster. 
 
 .. option:: --logPath <DIR>

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -97,8 +97,8 @@ Global Options
 
    .. warning::
 
-      Setting the ``loadLevel`` to ``4`` may negatively impact the performance 
-      of the destination cluster. 
+      Setting the ``loadLevel`` higher than the default may negatively impact 
+      the performance of the destination cluster. 
 
 .. option:: --logPath <DIR>
 


### PR DESCRIPTION
## DESCRIPTION

Add warning for loadLevel setting

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32921/reference/mongosync/#std-option-mongosync.--loadLevel
https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-32921/reference/configuration/#mongodb-setting-loadLevel

## JIRA

https://jira.mongodb.org/browse/DOCSP-32921

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6500baf224fcc731b4809d7f

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
