### PR TITLE
DOCSP-33176 restore 1.6 Content

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -24,7 +24,7 @@ toc_landing_pages = ["/quickstart",
                     ]
 
 [constants]
-version = "1.0"
+version = "1.6"
 c2c-product-name = "Cluster-to-Cluster Sync"
 c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"
 mdb-download-center = "`MongoDB Download Center <https://www.mongodb.com/try/download/mongosync>`__"

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -143,6 +143,15 @@ Request Body Parameters
 
        .. versionadded:: 1.1
 
+   * - ``excludeNamespaces``
+     - array
+     - Optional
+     - Filters the databases or collections to exclude from sync.
+
+       .. include:: /includes/api/facts/namespace-explanation.rst
+
+       .. versionadded:: 1.6
+
    * - ``reversible``
      - boolean
      - Optional

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -108,11 +108,13 @@ Configure a Filter
    .. step:: Identify Databases and Collections.
 
       Identify the databases and collections that you want to sync to
-      the destination cluster. When you add a set of databases to the
-      filter, you also exclude any other databases in the cluster.
+      the destination cluster. 
+
+      - When you add a set of databases to the filter, you also exclude any
+        other databases in the cluster.
       
-      When you specify a collection in your filter, you also exclude any
-      other collections that are in the same database.
+      - When you specify a collection in your filter, you also exclude any
+        other collections that are in the same database.
 
    .. step:: Create a Filter.
 
@@ -142,7 +144,7 @@ Configure a Filter
             {
                "database": "sales",
                "collectionRegex": {
-                  "pattern": "^accounts_.+$",
+                  "pattern": "^accounts_.+?$",
                   "options": "ms"
                }
          ],

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -18,10 +18,16 @@ Filtered Sync
 .. include:: /includes/api/facts/filtering-intro.rst
 
 Starting in 1.1, ``mongosync`` supports inclusion filters to specify which
-databases and collections to include in sync.  
+databases and collections to include in sync.  Starting in 1.6, ``mongosync``
+also supports exclusion filters and regular expressions.
 
 - With inclusion filters, ``mongosync`` syncs matching
   databases and collections.
+- With exclusion filters, ``mongosync`` syncs all databases
+  and collections, except for those that match the filters.
+- With both inclusion and exclusion filters, ``mongosync`` only syncs
+  databases and collections that match the inclusion filters then excludes
+  any that also match the exclusion filters.
 - With no filters, ``mongosync`` syncs all databases and collections.
 
 .. _c2c-filter-syntax:
@@ -29,9 +35,17 @@ databases and collections to include in sync.
 Filter Syntax
 -------------
 
-The :ref:`c2c-api-start` API endpoint accepts one field to configure filtered
-sync: ``includeNamespaces``.  This field takes an array of filters to specify
-the databases and collections to include in the sync.
+The :ref:`c2c-api-start` API endpoint accepts two fields that configure 
+filtered sync: ``includeNamespaces`` and ``excludeNamespaces``.
+Each field takes an array of filters that specify the databases and collections 
+to include or exclude from sync.
+
+.. note::
+
+   If the :ref:`c2c-api-start` call uses both ``includeNamespaces`` and 
+   ``excludeNamespaces`` parameters, ``mongosync`` first matches databases
+   and collections from the inclusion filters, then excludes those that
+   also match an exclusion filter.
 
 Filters have the following syntax:
 
@@ -44,10 +58,38 @@ Filters have the following syntax:
           "collections": [
              "<collection-name>"
           ]
+          "databaseRegex": {
+             "pattern": "<regex-pattern>",
+             "options": "<options>"
+          },
+          "collectionRegex": {
+             "pattern": "<regex-pattern>",
+             "options": "<options>"
+          }
+       }
+    ],
+    "excludeNamespaces": [
+       {
+          "database": "<database-name>",
+          "collections": [
+             "<collection-name>"
+          ]
+          "databaseRegex": {
+             "pattern": "<regex-pattern>",
+             "options": "<options>"
+          },
+          "collectionRegex": {
+             "pattern": "<regex-pattern>",
+             "options": "<options>"
+          }
        }
     ]
 
-Filters must include the ``database`` field. 
+Filters must include either the ``database`` field or the ``databaseRegex`` field.
+
+If you need the filter to match specific collections, you can use either 
+the ``collections`` array to specify collections individually or define 
+a regular expression using the ``collectionRegex`` field.
 
 .. _c2c-configure-filter:
 
@@ -74,33 +116,43 @@ Configure a Filter
 
    .. step:: Create a Filter.
 
-      The :ref:`c2c-api-start` API accepts a parameter to configure a series of
+      The :ref:`c2c-api-start` API accepts two parameters that configure
       optional filters: 
       
       - The ``includeNamespaces`` parameter takes an array of filters, which
         are used to determines which databases and collections ``mongosync`` 
         should include in the sync.
+      - The ``excludeNamespaces`` parameter takes an array of filters, which
+        are used to determine which databases and collections ``mongosync``
+        should exclude from the sync.
      
       If you don't specify a filter, ``mongosync`` performs a full cluster
       sync.
 
-      Create inclusion filters to identify the databases and
+      Create inclusion and/or exclusion filters to identify the databases and
       collections you want to sync.
 
       For example, this inclusion filter would configure ``mongosync`` to only
-      sync ``accounts_us`` and ``accounts_eu`` collections in the ``sales`` 
-      database.
+      sync collections whose names begin with ``accounts_`` from the ``sales`` 
+      database, except for the ``accounts_old`` collection:
 
       .. code-block:: json
 
          "includeNamespaces": [
             {
                "database": "sales",
-               "collections": [
-                   "accounts_us",
-                   "accounts_eu",
-               ]
-            }
+               "collectionRegex": {
+                  "pattern": "^accounts_.+$",
+                  "options": "ms"
+               }
+         ],
+         "excludeNamespaces": [
+             {
+                 "database": "sales",
+                 "collections": [
+                     "accounts_old"
+                 ]
+             }
          ]
 
       For more information on filters, see :ref:`c2c-filter-syntax`. 
@@ -297,4 +349,9 @@ Adding and Renaming Collections While Syncing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/example-filter-collection-with-renaming.rst
+
+.. toctree::
+   :hidden:
+
+   /reference/collection-level-filtering/filter-regex
 

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -104,7 +104,7 @@ that begin start with the ``accounts_`` string:
       {
          "database": "sales",
          "collectionRegex": {
-            "pattern": "^accounts_.+?",
+            "pattern": "^accounts_.+?$",
             "options": "ms"
          }
       }

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -1,0 +1,116 @@
+.. _c2c-filter-regex:
+
+##############################
+Regular Expressions in Filters
+##############################
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: twocols
+
+.. versionadded:: 1.6
+
+.. include:: /includes/api/facts/filter-regex
+
+Syntax
+======
+
+To match databases and collections for ``mongosync`` to use :ref:`c2c-filtered-sync`,
+you can use regular expressions:
+
+.. code-block:: json
+   :copyable: false
+
+   {
+      "databaseRegex": {
+         "pattern": "<string>",
+         "options": "<string>"
+      },
+      "collectionRegex": {
+         "pattern": "<string>",
+         "options": "<string>"
+      }
+   }
+
+Regular expressions in filter documents use the following fields:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Type
+     - Description
+
+   * - ``collectionRegex``
+     - document
+     - Specifies which collections you want the filter
+       to match.
+
+   * - ``collectionRegex.options``
+     - string
+     - Regular expression options to use in the match.
+       
+   * - ``collectionRegex.pattern``
+     - string
+     - Regular expression pattern to match.
+
+
+   * - ``databaseRegex``
+     - document
+     - Specifies which databases you want the filter 
+       to match.
+
+   * - ``databaseRegex.options``
+     - string
+     - Regular expression options to use in the match.
+
+   * - ``databaseRegex.pattern``
+     - string
+     - Regular expression pattern to match.
+
+These options are available to use with both the ``includeNamespaces``
+and ``excludeNamespaces`` parameters.
+
+Use Cases
+=========
+
+Regular expressions allow you match multiple databases or collections with a
+single pattern.  If you want to match multiple similarly named 
+databases or collections, a regular expression may be easier to match than
+creating a series of filters for individual databases or groups of collections.
+
+Details
+=======
+
+Regular Expression Options
+--------------------------
+
+``databaseRegex`` and ``collectionRegex`` each supports an ``options`` field,
+which you can use to configure regular expression options.
+Internally, ``mongosync`` passes the filter and options to the
+:query:`$regex` operator. Options available to that operator can be used
+with Filtred Sync.
+
+For example, this filter would match collections in the ``sales`` database
+that begin start with the ``accounts_`` string:
+
+.. code-block:: json
+
+   "includeNamespaces": [
+      {
+         "database": "sales",
+         "collectionRegex": {
+            "pattern": "^accounts_.+?",
+            "options": "ms"
+         }
+      }
+   ]
+
+Learn More
+==========
+
+* :ref:`c2c-filtered-sync`

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -36,6 +36,7 @@ General Limitations
   release version, but can have different patch releases.
 
   For example,
+
   - ``mongosync`` supports sync from a MongoDB 6.0.8 source cluster to a
     destination cluster using MongoDB 6.0.9, since these are patch releases 
     of the same major release.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -32,7 +32,16 @@ General Limitations
   6.2. The minimum supported server version is MongoDB 6.0.5.
   For more information on MongoDB versioning, see
   :ref:`release-version-numbers`.
-- The source and destination clusters must have the same release version.
+- The source and destination clusters must have the same major and minor
+  release version, but can have different patch releases.
+
+  For example,
+  - ``mongosync`` supports sync from a MongoDB 6.0.8 source cluster to a
+    destination cluster using MongoDB 6.0.9, since these are patch releases 
+    of the same major release.
+  - ``mongosync`` does not support sync from a MongoDB 6.0.9 source cluster to 
+    a destination cluster using MongoDB 7.0.0, since they have different major
+    versions.
 - The minimum supported :dbcommand:`Feature Compatibility Version
   <setFeatureCompatibilityVersion>` is 6.0.
 - The source and destination clusters must have the same Feature

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -38,10 +38,10 @@ General Limitations
   For example,
 
   - ``mongosync`` supports sync from a MongoDB 6.0.8 source cluster to a
-    destination cluster using MongoDB 6.0.9, since these are patch releases 
+     MongoDB 6.0.9 destination cluster, since these are patch releases 
     of the same major release.
   - ``mongosync`` does not support sync from a MongoDB 6.0.9 source cluster to 
-    a destination cluster using MongoDB 7.0.0, since they have different major
+    a MongoDB 7.0.0 destination cluster, since they have different major
     versions.
 - The minimum supported :dbcommand:`Feature Compatibility Version
   <setFeatureCompatibilityVersion>` is 6.0.

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -60,9 +60,10 @@ Same Server Version
 ~~~~~~~~~~~~~~~~~~~
 
 {+c2c-product-name+} only supports syncing between the same version of
-MongoDB Server. All three :ref:`server version numbers
-<release-version-numbers>`, including the patch number, must be the
-same on both servers.
+MongoDB Server. The major and minor :ref:`server version numbers
+<release-version-numbers>` must be the same on both clusters.
+Starting in ``mongosync`` 1.6.0, the source and destination cluster
+can use different patch releases of the same major and minor version.
 
 Support Lifecycle 
 ~~~~~~~~~~~~~~~~~

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -8,6 +8,7 @@ Release Notes
 .. toctree::
    :titlesonly: 
 
+   /release-notes/1.6
    /release-notes/1.5
    /release-notes/1.4
    /release-notes/1.3

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -84,22 +84,22 @@ New Features:
 Issues Fixed:
 
 - Fixed a bug introduced in 1.5, where ``mongosync`` could fail to apply change
-  events for a document if they occur shortly after the document is copied during
-  the Collection Copy phase.
+  events for a document if they occur shortly after the document is copied
+  during the Collection Copy phase.
 
-- Fixed a bug where ``mongosync`` could crash due to the source cluster containing
-  legacy indexes with unknown index options.
+- Fixed a bug where ``mongosync`` could crash due to the source cluster
+  containing legacy indexes with unknown index options.
 
-- Fixed a bug where ``mongosync`` could crash with an error during change event 
+- Fixed a bug where ``mongosync`` could crash with an error during change event
   application, if the application fails to read 500 documents within 5 minutes
-  or reaches the end of the oplog when reading from change streams on the source
-  cluster.
+  or reaches the end of the oplog when reading from change streams on the
+  source cluster.
 
-- Fixed a bug where ``mongosync`` could crash when indexes apply constraints 
-  to collection documents.
+- Fixed a bug where ``mongosync`` could crash when indexes apply constraints to
+  collection documents.
 
   This crash occured when such an index was added or dropped at nearly the same
-  time as an index that violated these constrains was deleted or inserted.  It 
+  time as an index that violated these constrains was deleted or inserted.  It
   would manifest with an error like:
 
   .. code-block:: text
@@ -110,11 +110,11 @@ Issues Fixed:
   or a similar error. This fix makes this crash less likely, but it does not
   elimiate the possibility that it will occur.
 
-
-
-- Fixed a bug where ``mongosync`` can fail to copy certain documents if 
-  the insertion of documents causes duplicate key errors at the same time 
-  as a write concern error. This bug has been present in mongosync since its first release and may have arisen if the destination cluster logs reported a write concern error alongside a duplicate key error.
+- Fixed a bug where ``mongosync`` can fail to copy certain documents if the
+  insertion of documents causes duplicate key errors at the same time as a
+  write concern error. This bug has been present in mongosync since its first
+  release and may have arisen if the destination cluster logs reported a write
+  concern error alongside a duplicate key error.
 
 Minimum Supported Version
 -------------------------

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -37,6 +37,23 @@ with the ``databaseRegex`` and ``collectionRegex`` fields.
 
 For more information, see :ref:`c2c-filter-regex`.
 
+Exclusion Filters
+~~~~~~~~~~~~~~~~~
+
+Starting in 1.6.0, the :ref:`c2c-api-start` API endpoint now supports the
+use of exclusion filters through the ``excludeNamespaces`` parameter.
+
+For more information, see :ref:`c2c-filtered-sync`.
+
+Regular Expression Filters
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both inclusion and exclusion filters in :ref:`c2c-filtered-sync` now 
+support matching databases and collections using Regular Expressions 
+with the ``databaseRegex`` and ``collectionRegex`` fields.
+
+For more information, see :ref:`c2c-filter-regex`.
+
 7.0 Support
 ~~~~~~~~~~~
 

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -45,15 +45,6 @@ use of exclusion filters through the ``excludeNamespaces`` parameter.
 
 For more information, see :ref:`c2c-filtered-sync`.
 
-Regular Expression Filters
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Both inclusion and exclusion filters in :ref:`c2c-filtered-sync` now 
-support matching databases and collections using Regular Expressions 
-with the ``databaseRegex`` and ``collectionRegex`` fields.
-
-For more information, see :ref:`c2c-filter-regex`.
-
 7.0 Support
 ~~~~~~~~~~~
 
@@ -83,9 +74,19 @@ New Features:
 
 Issues Fixed:
 
-- Fixed a bug introduced in 1.5, where ``mongosync`` could fail to apply change
-  events for a document if they occur shortly after the document is copied
-  during the Collection Copy phase.
+- Fixed a bug introduced in ``mongosync`` v1.5.0 and discovered by our internal
+  testing where in an unlikely edge case ``mongosync`` can miss a change event 
+  to be applied during the Collection Copy phase. 
+  
+  In order for this bug to occur, the change event must fall between a specific 
+  ``_id`` range that ``mongosync`` is in the process of copying, must occur and 
+  be processed while that specific ``_id`` range is being copied, and must not 
+  be followed by another change event for the same ``_id`` throughout the rest 
+  of the migration. 
+  
+  This bug only occurs when ``mongosync`` is processing change events with near
+  zero replication lag during Collection Copy.
+
 
 - Fixed a bug where ``mongosync`` could crash due to the source cluster
   containing legacy indexes with unknown index options.
@@ -120,23 +121,33 @@ Issues Fixed:
   skipped during the Collection Copy phase when there is little write activity
   on the source cluster.
 
-- Fixed a bug introduced in 1.5 where ``mongosync`` could cause data
-  consistency errors in collections with non-default collation. 
+- Fixed a rare bug introduced in ``mongosync`` v1.5.0 and discovered by our
+  internal testing where there may be a small continuity gap between Oplog
+  Rollover Resilience (ORR) cycles in a specific situation, causing the ORR
+  mechanism to potentially miss a change event to be applied during the
+  Collection Copy phase. 
 
-  This issue only affects collections with non-simple collation that are present
-  during ``mongosync`` initialization. Collections with non-simple collation
-  created after ``mongosync`` initialization are not affected.
+  This is an extreme case as it requires consistently
+  little write activity on the source cluster (i.e. ``mongosync`` replication
+  lag is consistently near zero during Collection Copy) as well as the change
+  event to fall in specific ``_id`` ranges between ORR cycles.
+
+- Fixed a bug introduced in v1.5.0 where ``mongosync`` could cause data
+  consistency errors in collections with non-default collation. 
+  
+  This issue only affects collections with non-simple collation that are
+  present during ``mongosync`` initialization and contain documents with string
+  ``_id`` values. Any collections with non-simple collation created after
+  ``mongosync`` initialization or whose documents have all non-string ``_id``
+  values are unaffected.
 
   .. note::
 
-     Users who used Oplog Rollover Resilience with at least one collection with
-     non-simple collation and string _id fields may have been affected by this
-     issue. 
+     In order to mitigate this issue, ``mongosync`` v1.6.0 automatically
+     disables Oplog Rollover Resilience if it finds at least one collection
+     with non-simple collation during Mongosync initialization. 
      
-     In order to mitigate this issue, ``monogsync`` 1.6.0 automatically
-     disables Oplog Rollover Resilience if it finds at least one collection with
-     non-simple collation during initialization. We will investigate a
-     more permanent solution for future releases.
+     We will investigate a more permanent solution for future releases.
 
 Minimum Supported Version
 -------------------------

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -1,0 +1,105 @@
+.. _c2c-release-notes-1.6:
+
+===================================
+Release Notes for mongosync 1.6
+===================================
+
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. _1.6.0-c2c-release-notes:
+
+1.6.0 Release
+-------------
+
+**September 18, 2023**
+
+Exclusion Filters
+~~~~~~~~~~~~~~~~~
+
+Starting in 1.6.0, the :ref:`c2c-api-start` API endpoint now supports the
+use of exclusion filters through the ``excludeNamespaces`` parameter.
+
+For more information, see :ref:`c2c-filtered-sync`.
+
+Regular Expression Filters
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both inclusion and exclusion filters in :ref:`c2c-filtered-sync` now 
+support matching databases and collections using Regular Expressions 
+with the ``databaseRegex`` and ``collectionRegex`` fields.
+
+For more information, see :ref:`c2c-filter-regex`.
+
+7.0 Support
+~~~~~~~~~~~
+
+Starting in 1.6.0, ``mongosync`` supports sync with MongoDB 7.0.
+
+Other Notes
+~~~~~~~~~~~
+
+New Features:
+
+- Sped up the commit process by parallelizing metadata cleanup. 
+
+- Reduced memory allocation during change event application by approximately 
+  30% for pre-6.0 releases of MongoDB Server versions.
+
+- Changed telemetry to also send error messages to Segment when ``mongosync``
+  exits with a fatal error.
+
+- Added support for ``mongosync`` to sync between source and destination 
+  clusters that have the same major and minor versions, but different 
+  patch versions.
+
+- Upgraded build to use Go 1.20.
+
+- ``mongosync`` now periodically logs when server operations take a longer 
+  than expected time.
+
+Issues Fixed:
+
+- Fixed a bug introduced in 1.5, where ``mongosync`` could fail to apply change
+  events for a document if they occur shortly after the document is copied during
+  the Collection Copy phase.
+
+- Fixed a bug where ``mongosync`` could crash due to the source cluster containing
+  legacy indexes with unknown index options.
+
+- Fixed a bug where ``mongosync`` could crash with an error during change event 
+  application, if the application fails to read 500 documents within 5 minutes
+  or reaches the end of the oplog when reading from change streams on the source
+  cluster.
+
+- Fixed a bug where ``mongosync`` could crash when indexes apply constraints 
+  to collection documents.
+
+  This crash occured when such an index was added or dropped at nearly the same
+  time as an index that violated these constrains was deleted or inserted.  It 
+  would manifest with an error like:
+
+  .. code-block:: text
+     :copyable: false
+
+     Ambiguous field name found in array (do not use numeric field names in embedded elements in an array)
+
+  or a similar error. This fix makes this crash less likely, but it does not
+  elimiate the possibility that it will occur.
+
+
+
+- Fixed a bug where ``mongosync`` can fail to copy certain documents if 
+  the insertion of documents causes duplicate key errors at the same time 
+  as a write concern error. This bug has been present in mongosync since its first release and may have arisen if the destination cluster logs reported a write concern error alongside a duplicate key error.
+
+Minimum Supported Version
+-------------------------
+
+In 1.6, the minimum supported versions of MongoDB are 6.0.8 and 7.0.0.

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -18,7 +18,7 @@ Release Notes for mongosync 1.6
 1.6.0 Release
 -------------
 
-**September 18, 2023**
+**September 22, 2023**
 
 Exclusion Filters
 ~~~~~~~~~~~~~~~~~
@@ -120,3 +120,4 @@ Minimum Supported Version
 -------------------------
 
 In 1.6, the minimum supported versions of MongoDB are 6.0.8 and 7.0.0.
+

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -116,6 +116,28 @@ Issues Fixed:
   release and may have arisen if the destination cluster logs reported a write
   concern error alongside a duplicate key error.
 
+- Fixed a bug introduced in ``mongosync`` 1.5 where change events may be
+  skipped during the Collection Copy phase when there is little write activity
+  on the source cluster.
+
+- Fixed a bug introduced in 1.5 where ``mongosync`` could cause data
+  consistency errors in collections with non-default collation. 
+
+  This issue only affects collections with non-simple collation that are present
+  during ``mongosync`` initialization. Collections with non-simple collation
+  created after ``mongosync`` initialization are not affected.
+
+  .. note::
+
+     Users who used Oplog Rollover Resilience with at least one collection with
+     non-simple collation and string _id fields may have been affected by this
+     issue. 
+     
+     In order to mitigate this issue, ``monogsync`` 1.6.0 automatically
+     disables Oplog Rollover Resilience if it finds at least one collection with
+     non-simple collation during initialization. We will investigate a
+     more permanent solution for future releases.
+
 Minimum Supported Version
 -------------------------
 


### PR DESCRIPTION
## Description 

Restores 1.6 release content that was previously removed.  Adds new bug fixes to release notes.

## Staging

* [start](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33176-restore-1.6/reference/api/start/#request-body-parameters), restores``excludeNamespaces`
* [Filtered Sync](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33176-restore-1.6/reference/collection-level-filtering/), restores intro and restores the FIlter Syntax section and `excludeNamespaces` back into the example
* Restores [Regex in Filters](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33176-restore-1.6/reference/collection-level-filtering/filter-regex/)
* [RN](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33176-restore-1.6/release-notes/1.6/)

## Jira
* [DOCSP-33176](https://jira.mongodb.org/browse/DOCSP-33176)

## Build

* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=650cc4a8492df295cfa84ee7)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=650db89e492df295cfdd29ee)