### PR TITLE
DOCSP-33352 Removes duplicate release note entry from 1.6

### DIFF
--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -37,14 +37,6 @@ with the ``databaseRegex`` and ``collectionRegex`` fields.
 
 For more information, see :ref:`c2c-filter-regex`.
 
-Exclusion Filters
-~~~~~~~~~~~~~~~~~
-
-Starting in 1.6.0, the :ref:`c2c-api-start` API endpoint now supports the
-use of exclusion filters through the ``excludeNamespaces`` parameter.
-
-For more information, see :ref:`c2c-filtered-sync`.
-
 7.0 Support
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Removes duplicate release note from the 1.6 RN page.

* [Staging](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33352-dupliate-rn/release-notes/1.6/)
* [DOCSP-33352](https://jira.mongodb.org/browse/DOCSP-33352)
* [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6515ab10492df295cfb26635)