### PR TITLE
Docsp 30395 adding index consistency limitations 

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -119,10 +119,10 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards. 
 
-  .. note:
+.. note:
 
-    To check for index inconsistencies, see :ref:`Find Inconsistent
-    Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.
+  To check for index inconsistencies, see :ref:`Find Inconsistent
+  Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.
 
 - The shard key cannot be :ref:`refined <shard-key-refine>` while
   syncing.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -115,7 +115,15 @@ Sharded Clusters
 - There is no replication for zone configuration. ``mongosync``
   replicates data, it does not inherit zones.
 - Shards cannot be added or removed while syncing.
-- Only indexes which exist on all shards are synced.
+- ``mongosync`` only syncs indexes that exist on all shards. 
+- ``mongosync`` only syncs indexes that have consistent index
+  specifications on all shards. 
+
+  .. note:
+
+    To check for index inconsistencies, see :ref:`Find Inconsistent
+    Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.
+
 - The shard key cannot be :ref:`refined <shard-key-refine>` while
   syncing.
 - The shard key cannot be modified using :dbcommand:`reshardCollection`

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -119,7 +119,7 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards. 
 
-.. note:
+.. note::
 
   To check for index inconsistencies, see :ref:`Find Inconsistent
   Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.


### PR DESCRIPTION
## DESCRIPTION

adding mongosync limitation about consistent index specifications

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-30395/reference/limitations/#sharded-clusters

## JIRA

https://jira.mongodb.org/browse/DOCSP-30395

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=651f15a8885de6b26bd335a4

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
