### PR TITLE
 DOCS-15476 minSnapshotHistoryWindowInSeconds Recommendation

### DIFF
--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -45,6 +45,11 @@ Behavior
 
 .. include:: /includes/fact-behavior-initial-state
 
+Performance Considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-destination-cluster-latency-parameter.rst
+
 Example
 -------
 

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -4,7 +4,6 @@
 Connect a Self-Managed Cluster to Atlas
 =======================================
 
-
 .. default-domain:: mongodb
 
 .. contents:: On this page
@@ -52,6 +51,12 @@ Behavior
 .. include:: /includes/fact-behavior-hosting
 
 .. include:: /includes/fact-behavior-initial-state
+
+Performance Considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-destination-cluster-latency-parameter.rst
+
 
 Example
 -------

--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -44,6 +44,12 @@ Behavior
 
 .. include:: /includes/fact-behavior-initial-state
 
+Performance Considerations
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-destination-cluster-latency-parameter.rst
+
+
 Example
 -------
 

--- a/source/includes/fact-destination-cluster-latency-parameter.rst
+++ b/source/includes/fact-destination-cluster-latency-parameter.rst
@@ -1,0 +1,3 @@
+To minimize latency after ``mongosync`` completes, set 
+:parameter:`minSnapshotHistoryWindowInSeconds` to ``0`` when creating your 
+destination cluster. 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -57,6 +57,10 @@ To configure multiple ``mongosync`` instances:
       sync, the source cluster and destination cluster must have the
       same number of shards.
 
+      .. note:: 
+
+         .. include:: /includes/fact-destination-cluster-latency-parameter.rst
+
    .. step:: Stop the Balancer on the Destination
 
       To stop the balancer on the destination cluster, connect to the
@@ -277,8 +281,6 @@ on the destination cluster:
 .. code-block:: javascript
 
    sh.startBalancer()
-
-
 
 .. _c2c-sharded-reverse:
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -73,6 +73,12 @@ Follow the instructions below to setup {+c2c-product-name+}.
       <create-new-cluster>` or to create a :ref:`self-managed cluster
       <server-replica-set-deploy>`.
 
+      .. note:: 
+
+         To minimize latency after sync completes, set 
+         :parameter:`minSnapshotHistoryWindowInSeconds` to ``0`` when creating 
+         your destination cluster. 
+
    .. step:: Define administrative users
 
       If either cluster is hosted in Atlas, or if either of them

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -75,9 +75,7 @@ Follow the instructions below to setup {+c2c-product-name+}.
 
       .. note:: 
 
-         To minimize latency after sync completes, set 
-         :parameter:`minSnapshotHistoryWindowInSeconds` to ``0`` when creating 
-         your destination cluster. 
+         .. include:: /includes/fact-destination-cluster-latency-parameter.rst
 
    .. step:: Define administrative users
 


### PR DESCRIPTION
## DESCRIPTION 
- Adds recommendation to set `minSnapshotHistoryWindowInSeconds=0` to avoid latency issues on the destination cluster after sync 

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCS-15476-set-minsnapshothistorywindowseconds-c2c/quickstart/#define-a-source-and-a-destination-cluster:~:text=managed%20cluster.-,NOTE,-To%20minimize%20latency

## JIRA
https://jira.mongodb.org/browse/DOCS-15476

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6541755ebd8a7a9579b11e30