### PR TITLE
DOCSP-33581 TTL Index Support

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -139,6 +139,5 @@ fatal log entry.
 Does ``mongosync`` Support TTL Indexes?
 ----------------------------------------
 
-{+ c2c-product-name +} supports the sync of :ref:`index-feature-ttl` from the
-source cluster to the destination.
+{+c2c-product-name+} supports syncing :ref:`index-feature-ttl`.
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -135,3 +135,10 @@ errors and do not signal that you need to stop ``mongosync`` early.
 These logs do not indicate that ``mongosync`` is failing or corrupting
 data. If a fatal error occurs, ``mongosync`` stops the sync and writes a
 fatal log entry. 
+
+Does ``mongosync`` Support TTL Indexes?
+----------------------------------------
+
+{+ c2c-product-name +} supports the sync of :ref:`index-feature-ttl` from the
+source cluster to the destination.
+

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -139,5 +139,6 @@ fatal log entry.
 Does ``mongosync`` Support TTL Indexes?
 ----------------------------------------
 
-{+c2c-product-name+} supports syncing :ref:`index-feature-ttl`.
+{+c2c-product-name+} supports syncing :ref:`index-feature-ttl` from the source
+to the destination cluster.
 


### PR DESCRIPTION
## Description

Adds an FAQ entry for TTL indexes in mongosync.

## Staging

* [FAQ Entry](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33581-ttl-index/faq/#does-mongosync-support-ttl-indexes-)

## Jira

[DOCSP-33581](https://jira.mongodb.org/browse/DOCSP-33581)

## Build

* [2023-11-1 3p](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6542b327bd8a7a9579fe33cd)
* [2024-01-10](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=659f2200dcc0144a511020a3)