### PR TITLE
DOCSP-33577 progress output clarification

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -60,9 +60,10 @@
      - Estimated number of bytes which have been copied to the
        destination cluster by this ``mongosync`` instance. 
        
-       To calculate the total estimated progress, add the value of  the
-       ``estimatedCopiedBytes`` field for each ``mongosync`` instance and
-       divide the result by the value of the ``estimatedTotalBytes`` field.
+       To calculate the total estimated progress as a percentage, add the value
+       of the ``estimatedCopiedBytes`` field for each ``mongosync`` instance
+       and divide the result by the value of the ``estimatedTotalBytes`` field
+       and then multiply the result by 100.
 
    * - ``directionMapping``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -51,16 +51,17 @@
    * - ``collectionCopy``
        ``.estimatedTotalBytes``
      - integer
-     - Estimated total number of bytes globally to be copied.
+     - Estimated total number of bytes to be copied globally by all ``mongosync``
+       instances.
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
      - integer
      - Estimated number of bytes which have been copied to the
-       destination cluster by this instance of ``mongosync``.  
+       destination cluster by this ``mongosync`` instance. 
        
        To calculate the total estimated progress, add the value of  the
-       ``estimatedCopiedBytes`` field for each instance of ``mongosync`` and
+       ``estimatedCopiedBytes`` field for each ``mongosync`` instance and
        divide the result by the value of the ``estimatedTotalBytes`` field.
 
    * - ``directionMapping``

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -41,7 +41,7 @@
    * - ``lagTimeSeconds``
      - integer
      - Time in seconds between the last applied event and time of the
-       current latest event.
+       current latest event for this instance of ``mongosync``
 
    * - ``collectionCopy``
      - object
@@ -51,13 +51,17 @@
    * - ``collectionCopy``
        ``.estimatedTotalBytes``
      - integer
-     - Estimated total number of bytes to be copied.
+     - Estimated total number of bytes globally to be copied.
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
      - integer
      - Estimated number of bytes which have been copied to the
-       destination cluster.
+       destination cluster by this instance of ``mongosync``.  
+       
+       To calculate the total estimated progress, add the value of  the
+       ``estimatedCopiedBytes`` field for each instance of ``mongosync`` and
+       divide the result by the value of the ``estimatedTotalBytes`` field.
 
    * - ``directionMapping``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -41,7 +41,7 @@
    * - ``lagTimeSeconds``
      - integer
      - Time in seconds between the last applied event and time of the
-       current latest event for this instance of ``mongosync``
+       current latest event for this instance of ``mongosync``.
 
    * - ``collectionCopy``
      - object
@@ -63,7 +63,7 @@
        To calculate the total estimated progress as a percentage, add the value
        of the ``estimatedCopiedBytes`` field for each ``mongosync`` instance
        and divide the result by the value of the ``estimatedTotalBytes`` field
-       and then multiply the result by 100.
+       . Then, multiply the result by 100.
 
    * - ``directionMapping``
      - object


### PR DESCRIPTION
## Description

Adds notes on `progress` output to note where field is global or per-mongosync.

## Staging

[Output](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33577-progress-updates/reference/api/progress/#successful-response)

## Jira

[DOCSP-33577](https://jira.mongodb.org/browse/DOCSP-33577)

## Build

* [2023-11-1 4p](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6542c4e6bd8a7a9579038a5a)
* [2024-01-10](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=659f231adcc0144a51107de7)
* [2024-01-11](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65a075f2dcc0144a5171345f)