### PR TITLE
DOCSP 33890 updating mongosync limitations bullets

### DIFF
--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -1,7 +1,6 @@
 Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
 collections <manual-capped-collection>` with some limitations.
 
-- The minimum server version is 6.0.
 - :dbcommand:`convertToCapped` is not supported. If you run
   ``convertToCapped``, ``mongosync`` exits with an error.
 - :dbcommand:`cloneCollectionAsCapped` is not supported.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -399,7 +399,10 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
   destination cluster.
 
-The ``sharding.createSupportingIndexes`` option affects all sharded collections.
+The ``sharding.createSupportingIndexes`` option affects all sharded
+collections.
+
+.. _rename-during-sync:
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -98,11 +98,11 @@ Sharded Clusters
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
-  - MongoDB allows users to rename collections included in the
-  ``sharding.shardingEntries`` option for
-    the :ref:`c2c-api-start` command during sync. To see limitations on
-    renaming collections while ``mongosync`` is running, see
-    :ref:`Renaming During Sync <rename-during-sync>`. 
+  - MongoDB allows users to rename collections that the
+    ``sharding.shardingEntries`` option for the :ref:`c2c-api-start`
+    command includes during sync. To see limitations on renaming
+    collections while ``mongosync`` is running, see :ref:`Renaming
+    During Sync <rename-during-sync>`. 
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
     sync. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -134,7 +134,7 @@ Sharded Clusters
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
 - The maximum number of indexes per sharded collection is 63, which is
-  one less than the :ref:`normal limit <limit-index-size>` of 64. 
+  one less than the :ref:`default limit <limit-index-size>` of 64. 
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -73,10 +73,6 @@ General Limitations
 - `Queryable Encryption
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__
   isn't supported.
-- After you replace the ``mongosync`` binary during an upgrade or a
-  downgrade, you should drop all non-system databases in the destination
-  cluster before starting the new binary. Syncing operations will
-  restart from the beginning when you start the new processes.
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 
@@ -103,16 +99,16 @@ Sharded Clusters
   limitations:
 
   - Collections included in the ``sharding.shardingEntries`` option for
-    the :ref:`c2c-api-start` command cannot be renamed to use a
+    the :ref:`c2c-api-start` command can be renamed to use a
     different database while ``mongosync`` is running.
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
-    sync, you cannot create these indexes afterwards on the source
-    cluster.  
+    sync. To see renaming limitations, see :ref:'Renaming During Sync
+    <rename-during-sync>'. 
     
     The index must either exist before ``mongosync`` starts or be
     created after the migration is complete and ``mongosync`` has
-    stopped.
+    stopped.ƒt
 
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
@@ -135,9 +131,8 @@ Sharded Clusters
   syncing.
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
-- The maximum number of :ref:`shard key indexes
-  <sharding-shard-key-indexes>` is one lower than normal, 63 instead of
-  64.
+- The maximum number of index per sharded collection is one lower than
+  normal; 63 instead of 64.
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -105,7 +105,8 @@ Sharded Clusters
     During Sync <rename-during-sync>`. 
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
-    sync. 
+    sync, you cannot create these indexes afterwards on the source
+    cluster.  
     
     The index must either exist before ``mongosync`` starts or be
     created after the migration is complete and ``mongosync`` has

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -98,18 +98,18 @@ Sharded Clusters
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
-  - Collections included in the ``sharding.shardingEntries`` option for
-    the :ref:`c2c-api-start` command can be renamed to use a different
-    database while ``mongosync`` is running. To see limitations on
-    renaming collections, see :ref:`Renaming During Sync
-    <rename-during-sync>`. 
+  - MongoDB allows users to rename collections included in the
+  ``sharding.shardingEntries`` option for
+    the :ref:`c2c-api-start` command during sync. To see limitations on
+    renaming collections while ``mongosync`` is running, see
+    :ref:`Renaming During Sync <rename-during-sync>`. 
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
     sync. 
     
     The index must either exist before ``mongosync`` starts or be
     created after the migration is complete and ``mongosync`` has
-    stopped.ƒt
+    stopped.
 
 - Within a collection, the ``_id`` field must be unique across all of
   the shards in the cluster. See :ref:`sharded-clusters-unique-indexes`
@@ -133,7 +133,7 @@ Sharded Clusters
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
 - The maximum number of indexes per sharded collection is 63, which is
-  one than the :ref:`normal limit <limit-index-size>` of 64. 
+  one less than the :ref:`normal limit <limit-index-size>` of 64. 
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -98,7 +98,7 @@ Sharded Clusters
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
-  - MongoDB allows users to rename collections that the
+  - ``mongosync`` allows users to rename collections that the
     ``sharding.shardingEntries`` option for the :ref:`c2c-api-start`
     command includes during sync. To see limitations on renaming
     collections while ``mongosync`` is running, see :ref:`Renaming
@@ -134,7 +134,8 @@ Sharded Clusters
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
 - The maximum number of indexes per sharded collection is 63, which is
-  one less than the :ref:`default limit <limit-index-size>` of 64. 
+  one less than the :ref:`default limit
+  <limit-number-of-indexes-per-collection>` of 64. 
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -99,12 +99,13 @@ Sharded Clusters
   limitations:
 
   - Collections included in the ``sharding.shardingEntries`` option for
-    the :ref:`c2c-api-start` command can be renamed to use a
-    different database while ``mongosync`` is running.
+    the :ref:`c2c-api-start` command can be renamed to use a different
+    database while ``mongosync`` is running. To see limitations on
+    renaming collections, see :ref:`Renaming During Sync
+    <rename-during-sync>`. 
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
-    sync. To see renaming limitations, see :ref:'Renaming During Sync
-    <rename-during-sync>'. 
+    sync. 
     
     The index must either exist before ``mongosync`` starts or be
     created after the migration is complete and ``mongosync`` has
@@ -131,8 +132,8 @@ Sharded Clusters
   syncing.
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
-- The maximum number of index per sharded collection is one lower than
-  normal; 63 instead of 64.
+- The maximum number of indexes per sharded collection is 63, which is
+  one than the :ref:`normal limit <limit-index-size>` of 64. 
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 


### PR DESCRIPTION
## DESCRIPTION

Updating bullets for mongosync bullets

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-33890/reference/limitations/

## JIRA

https://jira.mongodb.org/browse/DOCSP-33890

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65491080bd8a7a95794e1687

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
