### PR TITLE
DOCSP 33890 updating mongosync limitations bullets (#178)

### DIFF
--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -1,7 +1,6 @@
 Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
 collections <manual-capped-collection>` with some limitations.
 
-- The minimum server version is 6.0.
 - :dbcommand:`convertToCapped` is not supported. If you run
   ``convertToCapped``, ``mongosync`` exits with an error.
 - :dbcommand:`cloneCollectionAsCapped` is not supported.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -399,7 +399,10 @@ When ``sharding.createSupportingIndexes`` is ``true``:
 * If the supporting indexes don't exist, ``mongosync`` creates them on the
   destination cluster.
 
-The ``sharding.createSupportingIndexes`` option affects all sharded collections.
+The ``sharding.createSupportingIndexes`` option affects all sharded
+collections.
+
+.. _rename-during-sync:
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -73,10 +73,6 @@ General Limitations
 - `Queryable Encryption
   <https://www.mongodb.com/docs/v6.0/core/queryable-encryption/>`__
   isn't supported.
-- After you replace the ``mongosync`` binary during an upgrade or a
-  downgrade, you should drop all non-system databases in the destination
-  cluster before starting the new binary. Syncing operations will
-  restart from the beginning when you start the new processes.
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 
@@ -102,9 +98,11 @@ Sharded Clusters
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
-  - Collections included in the ``sharding.shardingEntries`` option for
-    the :ref:`c2c-api-start` command cannot be renamed to use a
-    different database while ``mongosync`` is running.
+  - ``mongosync`` allows users to rename collections that the
+    ``sharding.shardingEntries`` option for the :ref:`c2c-api-start`
+    command includes during sync. To see limitations on renaming
+    collections while ``mongosync`` is running, see :ref:`Renaming
+    During Sync <rename-during-sync>`. 
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
     sync, you cannot create these indexes afterwards on the source
@@ -135,9 +133,9 @@ Sharded Clusters
   syncing.
 - The shard key cannot be modified using :dbcommand:`reshardCollection`
   during syncing.
-- The maximum number of :ref:`shard key indexes
-  <sharding-shard-key-indexes>` is one lower than normal, 63 instead of
-  64.
+- The maximum number of indexes per sharded collection is 63, which is
+  one less than the :ref:`default limit
+  <limit-number-of-indexes-per-collection>` of 64. 
 - ``mongosync`` only supports syncing sharded collections that have 
   default :ref:`collation <collation>` settings. 
 


### PR DESCRIPTION
Ports [#178](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/178) to v1.7 

[Build log](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=654a81de5b686d6bd916c12f)