### PR TITLE
DOCSP 31207 Clarify mongosync reverse documentation unique index limitation

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -75,12 +75,12 @@ in the original source cluster.  To resync all nodes:
 
    .. step:: Step down the primary node and step up one of the secondary nodes.
    
-   .. step:: Resync the old primary node to the new primary node. 
+   .. step:: Resync the old primary node from the new primary node. 
 
 Alternatively, to avoid resyncing, you can use the
 :method:`db.collection.validate` method with ``full = false`` on each
-collection with unique indexes to determine whether each collection
-contains improperly formatted unique indexes. If
+collection with unique indexes on all nodes to determine whether each
+collection contains improperly formatted unique indexes. If
 :method:`db.collection.validate` does not return a warning about a
 unique index, you can skip resyncing. 
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -86,8 +86,8 @@ contains improperly formatted unique indexes.
 
    db.<collection>.validate()
 
-If the method returns a warning about the unique index, you must
-resync all of the nodes in the original source cluster before reversing sync.
+If the method does not returns a warning about a unique index, you can skip
+resyncing. 
 
 Request
 -------

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -86,8 +86,8 @@ contains improperly formatted unique indexes.
 
    db.<collection>.validate()
 
-If the method does not returns a warning about a unique index, you can skip
-resyncing. 
+If :method:`db.collection.validate` does not return a warning about a
+unique index, you can skip resyncing. 
 
 Request
 -------

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -80,13 +80,8 @@ in the original source cluster.  To resync all nodes:
 Alternatively, to avoid resyncing, you can use the
 :method:`db.collection.validate` method with ``full = false`` on each
 collection with unique indexes to determine whether each collection
-contains improperly formatted unique indexes. 
-
-.. code-block:: javascript
-
-   db.<collection>.validate()
-
-If :method:`db.collection.validate` does not return a warning about a
+contains improperly formatted unique indexes. If
+:method:`db.collection.validate` does not return a warning about a
 unique index, you can skip resyncing. 
 
 Request

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -63,9 +63,25 @@ Clusters that began with MongoDB 4.2 or older and were since
 upgraded may include unique indexes that are not properly formatted.
 
 To correct indexes, you can :ref:`resync <resync-replica-member>` all nodes
-in the original source cluster.  If you don't want to resync the cluster, you
-can use the :method:`db.collection.validate` method on each collection to 
-determine whether it contains improperly formatted unique indexes.
+in the original source cluster.  Follow these steps to resync all nodes. 
+
+ .. procedure::
+   :style: normal
+
+   .. step:: Resync all secondaries, one by one. 
+
+      For a tutorial on resyncing nodes, see  to :ref:`Resync a Member of a
+      Replica Set <resync-replica-member>`. 
+
+   .. step:: Step down the primary node and step up one of the secondary
+   notes.
+   
+   .. step:: Resync the old primary node from the new primary node. 
+
+Alternatively, to avoid resyncing, you can use the
+:method:`db.collection.validate` method with ``full = false`` on each
+collection with unique indexes to determine whether it contains
+improperly formatted unique indexes. 
 
 .. code-block:: javascript
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -63,7 +63,7 @@ Clusters that began with MongoDB 4.2 or older and were since
 upgraded may include unique indexes that are not properly formatted.
 
 To correct indexes, you can :ref:`resync <resync-replica-member>` all nodes
-in the original source cluster.  Follow these steps to resync all nodes. 
+in the original source cluster.  To resync all nodes: 
 
 .. procedure::
    :style: normal
@@ -73,15 +73,14 @@ in the original source cluster.  Follow these steps to resync all nodes.
       For a tutorial on resyncing nodes, see  to :ref:`Resync a Member of a
       Replica Set <resync-replica-member>`. 
 
-   .. step:: Step down the primary node and step up one of the secondary
-             nodes.
+   .. step:: Step down the primary node and step up one of the secondary nodes.
    
-   .. step:: Resync the old primary node from the new primary node. 
+   .. step:: Resync the old primary node to the new primary node. 
 
 Alternatively, to avoid resyncing, you can use the
 :method:`db.collection.validate` method with ``full = false`` on each
-collection with unique indexes to determine whether it contains
-improperly formatted unique indexes. 
+collection with unique indexes to determine whether each collection
+contains improperly formatted unique indexes. 
 
 .. code-block:: javascript
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -65,7 +65,7 @@ upgraded may include unique indexes that are not properly formatted.
 To correct indexes, you can :ref:`resync <resync-replica-member>` all nodes
 in the original source cluster.  Follow these steps to resync all nodes. 
 
- .. procedure::
+.. procedure::
    :style: normal
 
    .. step:: Resync all secondaries, one by one. 
@@ -74,7 +74,7 @@ in the original source cluster.  Follow these steps to resync all nodes.
       Replica Set <resync-replica-member>`. 
 
    .. step:: Step down the primary node and step up one of the secondary
-   notes.
+             nodes.
    
    .. step:: Resync the old primary node from the new primary node. 
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -70,7 +70,7 @@ in the original source cluster.  To resync all nodes:
 
    .. step:: Resync all secondaries, one by one. 
 
-      For a tutorial on resyncing nodes, see  to :ref:`Resync a Member of a
+      For a tutorial on resyncing nodes, see :ref:`Resync a Member of a
       Replica Set <resync-replica-member>`. 
 
    .. step:: Step down the primary node and step up one of the secondary nodes.


### PR DESCRIPTION
## DESCRIPTION

Clarify mongosync reverse documentation unique index limitation with steps on resending all nodes in a source cluster. 

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-31207/reference/api/reverse/#validate-unique-indexes

## JIRA

https://jira.mongodb.org/browse/DOCSP-31207

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=654bdb2d5b686d6bd975ac96

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
