### PR TITLE
DOCS-16422 clarifying write blocking behavior

### DIFF
--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,4 +1,4 @@
-MongoDB does not enable write-blocking by default. If you enable
+``mongosync`` does not enable write-blocking by default. If you enable
 write-blocking, ``mongosync`` blocks writes:
 
 - On the destination cluster during sync.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -2,7 +2,7 @@ When write-blocking is enabled, ``mongosync`` blocks writes:
 
 - On the destination cluster during sync.
 - On the source cluster while ``commit`` is running.
-- On the destination cluster while ``commit`` is running until
+- On the destination cluster while ``commit`` is running, until
   ``mongosync`` begins index validation. 
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,5 +1,5 @@
-Write-blocking is not enabled by default. If you enable write-blocking,
-``mongosync`` blocks writes:
+MongoDB does not enable write-blocking by default. If you enable
+write-blocking, ``mongosync`` blocks writes:
 
 - On the destination cluster during sync.
 - On the source cluster while ``commit`` is running.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,7 +1,9 @@
 When write-blocking is enabled, ``mongosync`` blocks writes:
 
 - On the destination cluster during sync
-- On the source cluster while committing
+- On the source cluster while ``commit`` is running
+- On the destination cluster while ``commit`` is running until
+``mongosync`` begins index validation. 
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``. You cannot enable

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,9 +1,9 @@
 When write-blocking is enabled, ``mongosync`` blocks writes:
 
-- On the destination cluster during sync
-- On the source cluster while ``commit`` is running
+- On the destination cluster during sync.
+- On the source cluster while ``commit`` is running.
 - On the destination cluster while ``commit`` is running until
-``mongosync`` begins index validation. 
+  ``mongosync`` begins index validation. 
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``. You cannot enable

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,9 +1,8 @@
-When write-blocking is enabled, ``mongosync`` blocks writes:
+Write-blocking is not enabled by default. If you enable write-blocking,
+``mongosync`` blocks writes:
 
 - On the destination cluster during sync.
 - On the source cluster while ``commit`` is running.
-- On the destination cluster while ``commit`` is running, until
-  ``mongosync`` begins index validation. 
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``. You cannot enable

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -203,7 +203,7 @@ show an empty ``system.views`` collection in that database. The empty
 ``system.views`` collection will not change the accuracy of user
 data on the destination.
 
-.. c2c-write-blocking:
+.. _c2c-write-blocking:
 
 Write Blocking
 ~~~~~~~~~~~~~~

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -139,9 +139,11 @@ To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
 destination cluster to convert indexes and finalize the changes. While
 ``commit`` is running:
 
-- Writes are blocked on the source cluster.
-- Writes are blocked on the destination cluster until ``mongosync``
-  begins index validation.
+- If you enable write-blocking, :ref:`commit <c2c-api-commit>` blocks
+  writes on the source cluster. 
+- If you enable write-blocking, :ref:`commit <c2c-api-commit>` blocks
+  writes on the destination cluster until ``mongosync``begins index
+  validation.
 
 To monitor the ``commit`` process, use the :ref:`progress
 <c2c-api-progress>` command:

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -218,7 +218,7 @@ Commit
 
 To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
 destination cluster to convert indexes and finalize the changes. If you
-enable ref:`write-blocking <c2c-write-blocking>`:
+enable :ref:`write-blocking <c2c-write-blocking>`:
 
 
 - ``commit`` blocks writes on the source cluster. 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -139,10 +139,10 @@ To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
 destination cluster to convert indexes and finalize the changes. While
 ``commit`` is running:
 
-- If you enable write-blocking, ``commit`` blocks
-  writes on the source cluster. 
-- If you enable write-blocking, ``commit`` blocks
-  writes on the destination cluster until ``mongosync``begins index
+- If you enable write-blocking, ``commit`` blocks writes on the source
+  cluster. 
+- If you enable write-blocking, ``commit`` blocks writes on the
+  destination cluster until ``mongosync`` begins index
   validation.
 
 To monitor the ``commit`` process, use the :ref:`progress

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -136,14 +136,7 @@ Commit
 ~~~~~~
 
 To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes. While
-``commit`` is running:
-
-- If you enable write-blocking, ``commit`` blocks writes on the source
-  cluster. 
-- If you enable write-blocking, ``commit`` blocks writes on the
-  destination cluster until ``mongosync`` begins index
-  validation.
+destination cluster to convert indexes and finalize the changes.
 
 To monitor the ``commit`` process, use the :ref:`progress
 <c2c-api-progress>` command:

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -139,9 +139,9 @@ To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
 destination cluster to convert indexes and finalize the changes. While
 ``commit`` is running:
 
-- If you enable write-blocking, :ref:`commit <c2c-api-commit>` blocks
+- If you enable write-blocking, ``commit`` blocks
   writes on the source cluster. 
-- If you enable write-blocking, :ref:`commit <c2c-api-commit>` blocks
+- If you enable write-blocking, ``commit`` blocks
   writes on the destination cluster until ``mongosync``begins index
   validation.
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -132,19 +132,6 @@ Global Options
 Behavior
 --------
 
-Commit
-~~~~~~
-
-To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes.
-
-To monitor the ``commit`` process, use the :ref:`progress
-<c2c-api-progress>` command:
-
-- The destination cluster is writable when ``canWrite`` is true.
-- Index conversion is complete when ``mongosync`` enters the
-  ``COMMITTED`` state.
-
 .. _c2c-mongosync-config:
 
 Cluster Independence
@@ -223,9 +210,28 @@ Write Blocking
 
 .. include:: /includes/fact-write-blocking-enable.rst
 
-Write-blocking is not enabled by default. You must enable write-blocking
-when you start ``mongosync`` if you want to use :ref:`reverse
-synchronization <c2c-api-reverse>` later.
+You must enable write-blocking when you start ``mongosync`` if you want
+to use :ref:`reverse synchronization <c2c-api-reverse>` later.
+
+Commit
+~~~~~~
+
+To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
+destination cluster to convert indexes and finalize the changes. If you
+enable ref:`write-blocking <c2c-write-blocking>`:
+
+
+- ``commit`` blocks writes on the source cluster. 
+- ``commit`` blocks writes on the destination cluster until
+  ``mongosync`` begins index validation.
+
+
+To monitor the ``commit`` process, use the :ref:`progress
+<c2c-api-progress>` command:
+
+- The destination cluster is writable when ``canWrite`` is true.
+- Index conversion is complete when ``mongosync`` enters the
+  ``COMMITTED`` state.
 
 User Permissions
 ````````````````


### PR DESCRIPTION
## DESCRIPTION

Clarifying when writes are blocked with mongosync 

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCS-16422/reference/mongosync/#write-blocking

## JIRA

https://jira.mongodb.org/browse/DOCS-16422

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=654becfe5b686d6bd97d3f7f

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
