### PR TITLE
DOCSP-34081 collectionsRegex typos

### DIFF
--- a/source/includes/api/requests/start-filtered.sh
+++ b/source/includes/api/requests/start-filtered.sh
@@ -5,7 +5,7 @@ curl -X POST "http://localhost:27182/api/v1/start" --data '
       "includeNamespaces": [
          {
              "database": "sales",
-             "collectionRegex": {
+             "collectionsRegex": {
                 "pattern": "^accounts_.+$",
                 "options": "i"
              }

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -62,7 +62,7 @@ Filters have the following syntax:
              "pattern": "<regex-pattern>",
              "options": "<options>"
           },
-          "collectionRegex": {
+          "collectionsRegex": {
              "pattern": "<regex-pattern>",
              "options": "<options>"
           }
@@ -78,7 +78,7 @@ Filters have the following syntax:
              "pattern": "<regex-pattern>",
              "options": "<options>"
           },
-          "collectionRegex": {
+          "collectionsRegex": {
              "pattern": "<regex-pattern>",
              "options": "<options>"
           }
@@ -89,7 +89,7 @@ Filters must include either the ``database`` field or the ``databaseRegex`` fiel
 
 If you need the filter to match specific collections, you can use either 
 the ``collections`` array to specify collections individually or define 
-a regular expression using the ``collectionRegex`` field.
+a regular expression using the ``collectionsRegex`` field.
 
 .. _c2c-configure-filter:
 
@@ -143,7 +143,7 @@ Configure a Filter
          "includeNamespaces": [
             {
                "database": "sales",
-               "collectionRegex": {
+               "collectionsRegex": {
                   "pattern": "^accounts_.+?$",
                   "options": "ms"
                }

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -30,7 +30,7 @@ you can use regular expressions:
          "pattern": "<string>",
          "options": "<string>"
       },
-      "collectionRegex": {
+      "collectionsRegex": {
          "pattern": "<string>",
          "options": "<string>"
       }
@@ -45,16 +45,16 @@ Regular expressions in filter documents use the following fields:
      - Type
      - Description
 
-   * - ``collectionRegex``
+   * - ``collectionsRegex``
      - document
      - Specifies which collections you want the filter
        to match.
 
-   * - ``collectionRegex.options``
+   * - ``collectionsRegex.options``
      - string
      - Regular expression options to use in the match.
        
-   * - ``collectionRegex.pattern``
+   * - ``collectionsRegex.pattern``
      - string
      - Regular expression pattern to match.
 
@@ -89,7 +89,7 @@ Details
 Regular Expression Options
 --------------------------
 
-``databaseRegex`` and ``collectionRegex`` each supports an ``options`` field,
+``databaseRegex`` and ``collectionsRegex`` each supports an ``options`` field,
 which you can use to configure regular expression options.
 Internally, ``mongosync`` passes the filter and options to the
 :query:`$regex` operator. Options available to that operator can be used
@@ -103,7 +103,7 @@ that begin start with the ``accounts_`` string:
    "includeNamespaces": [
       {
          "database": "sales",
-         "collectionRegex": {
+         "collectionsRegex": {
             "pattern": "^accounts_.+?$",
             "options": "ms"
          }

--- a/source/release-notes/1.6.txt
+++ b/source/release-notes/1.6.txt
@@ -49,7 +49,7 @@ Regular Expression Filters
 
 Both inclusion and exclusion filters in :ref:`c2c-filtered-sync` now 
 support matching databases and collections using Regular Expressions 
-with the ``databaseRegex`` and ``collectionRegex`` fields.
+with the ``databaseRegex`` and ``collectionsRegex`` fields.
 
 For more information, see :ref:`c2c-filter-regex`.
 


### PR DESCRIPTION
## DESCRIPTION
Fixes all instances where `collectionsRegex` was incorrectly documented. 

Correct syntax in `mongosync` repo found here: https://github.com/search?q=repo%3A10gen%2Fmongosync+collectionsRegex&type=code

## STAGING 
- [Regex in Filters page](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-34081-regex-filters-typo/reference/collection-level-filtering/filter-regex/#syntax)
- [Filter syntax](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-34081-regex-filters-typo/reference/collection-level-filtering/#filter-syntax)
- [1.6 release notes](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-34081-regex-filters-typo/release-notes/1.6/#regular-expression-filters)

## JIRA
https://jira.mongodb.org/browse/DOCSP-34081

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6553a3095b686d6bd93c3471