### PR TITLE
DOCSP-30831 mongosync Commit Behavior Clarification

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -132,26 +132,6 @@ Global Options
 Behavior
 --------
 
-Commit
-~~~~~~
-
-To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes. By default, 
-``commit`` operations have no effect on writes unless you enable
-:ref:`write blocking <c2c-dr-write-blocking>`. If write blocking is enabled 
-while ``commit`` is running:
-
-- Writes are blocked on the source cluster.
-- Writes are blocked on the destination cluster until ``mongosync``
-  begins index validation.
-
-The ``commit`` operation should take less than a few minutes. To monitor the 
-``commit`` process, use the :ref:`progress <c2c-api-progress>` command:
-
-- The destination cluster is writable when ``canWrite`` is true.
-- Index conversion is complete when ``mongosync`` enters the
-  ``COMMITTED`` state.
-
 .. _c2c-mongosync-config:
 
 Cluster Independence
@@ -237,17 +217,16 @@ Commit
 ~~~~~~
 
 To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes. If you
-enable :ref:`write-blocking <c2c-write-blocking>`:
-
+destination cluster to convert indexes and finalize the changes. By default, 
+``commit`` operations have no effect on writes unless you enable 
+:ref:`write-blocking <c2c-write-blocking>`. If you enable write blocking:
 
 - ``commit`` blocks writes on the source cluster. 
 - ``commit`` blocks writes on the destination cluster until
   ``mongosync`` begins index validation.
 
-
-To monitor the ``commit`` process, use the :ref:`progress
-<c2c-api-progress>` command:
+The ``commit`` operation should take less than a few minutes. To monitor the 
+``commit`` process, use the :ref:`progress <c2c-api-progress>` command:
 
 - The destination cluster is writable when ``canWrite`` is true.
 - Index conversion is complete when ``mongosync`` enters the

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -132,6 +132,25 @@ Global Options
 Behavior
 --------
 
+Commit
+~~~~~~
+
+To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
+destination cluster to convert indexes and finalize the changes. If 
+:ref:`write blocking <c2c-dr-write-blocking>` is enabled while
+``commit`` is running:
+
+- Writes are blocked on the source cluster.
+- Writes are blocked on the destination cluster until ``mongosync``
+  begins index validation.
+
+The ``commit`` operation should take less than a few minutes. To monitor the 
+``commit`` process, use the :ref:`progress <c2c-api-progress>` command:
+
+- The destination cluster is writable when ``canWrite`` is true.
+- Index conversion is complete when ``mongosync`` enters the
+  ``COMMITTED`` state.
+
 .. _c2c-mongosync-config:
 
 Cluster Independence

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -137,7 +137,7 @@ Commit
 
 To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
 destination cluster to convert indexes and finalize the changes. By default, 
-``commit`` operations have no effect on write operations unless you enable
+``commit`` operations have no effect on writes unless you enable
 :ref:`write blocking <c2c-dr-write-blocking>`. If write blocking is enabled 
 while ``commit`` is running:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -136,9 +136,10 @@ Commit
 ~~~~~~
 
 To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes. If 
-:ref:`write blocking <c2c-dr-write-blocking>` is enabled while
-``commit`` is running:
+destination cluster to convert indexes and finalize the changes. By default, 
+``commit`` operations have no effect on write operations unless you enable
+:ref:`write blocking <c2c-dr-write-blocking>`. If write blocking is enabled 
+while ``commit`` is running:
 
 - Writes are blocked on the source cluster.
 - Writes are blocked on the destination cluster until ``mongosync``


### PR DESCRIPTION
## DESCRIPTION 
- clarifies that write blocking behavior is contingent on write blocking being enabled 
- notes that commit operations should take less than a few mins per recommendation 

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-30831-mongosync-commit-operations/reference/mongosync/#commit

## JIRA 
https://jira.mongodb.org/browse/DOCSP-30831

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6553bd095b686d6bd945257f