### PR TITLE
DOCSP-33886 Remove 'Stop Balancer on Destination' Step

### DIFF
--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -271,9 +271,9 @@ acts as the source cluster:
 - If you have not already done so, issue the :ref:`commit
   <c2c-api-commit>` command to each ``mongosync`` instance and wait
   until all of the commits to finish. To check if the sync process has been 
-  committed, issue the :ref:`progress <c2c-api-progress>` command to any 
-  ``mongosync`` instance and see if the ``state`` field has the value 
-  ``COMMITTED``.
+  committed, issue the :ref:`progress <c2c-api-progress>` command to all 
+  ``mongosync`` instances and see if each response's ``state`` field contains 
+  the value ``COMMITTED``.
 - Issue the :ref:`reverse <c2c-api-reverse>` command to each
   ``mongosync`` instance.
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -260,12 +260,6 @@ These commands only check progress and commit synchronization for the
 to ``progress`` and  ``commit`` on any other ``mongosync`` instances
 that may be running.
 
-.. code-block:: javascript
-
-   sh.startBalancer()
-
-
-
 .. _c2c-sharded-reverse:
 
 Reverse the Synchronization Direction
@@ -276,10 +270,10 @@ acts as the source cluster:
 
 - If you have not already done so, issue the :ref:`commit
   <c2c-api-commit>` command to each ``mongosync`` instance and wait
-  until all of the commits to finish.
-  - To check if the sync process has been committed, issue the :ref:`progress 
-    <c2c-api-progress>` command to any ``mongosync`` instance and see if the 
-    ``state`` field has the value ``COMMITTED``.
+  until all of the commits to finish. To check if the sync process has been 
+  committed, issue the :ref:`progress <c2c-api-progress>` command to any 
+  ``mongosync`` instance and see if the ``state`` field has the value 
+  ``COMMITTED``.
 - Issue the :ref:`reverse <c2c-api-reverse>` command to each
   ``mongosync`` instance.
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -13,10 +13,10 @@ Use ``mongosync`` on Sharded Clusters
    :class: twocols
 
 There are two ways to synchronize :ref:`sharded clusters
-<sharded-cluster>`. You can use either one ``monogosync`` or several
-``monogosync`` instances. For best performance with large or heavily
-loaded clusters, use multiple ``monogosync`` instances, one
-``monogosync`` for each shard in the cluster.
+<sharded-cluster>`. You can use either one ``mongosync`` or several
+``mongosync`` instances. For best performance with large or heavily
+loaded clusters, use multiple ``mongosync`` instances, one
+``mongosync`` for each shard in the cluster.
 
 .. _c2c-sharded-config-single:
 
@@ -32,7 +32,7 @@ the :urioption:`replicaSet` option or the :option:`id <mongosync --id>`
 option.
 
 The rest of this page addresses cluster to cluster synchronization
-using multiple ``monogosync`` instances.
+using multiple ``mongosync`` instances.
 
 .. _c2c-sharded-config:
 
@@ -56,16 +56,6 @@ To configure multiple ``mongosync`` instances:
       different numbers of shards. However, if you want to reverse the
       sync, the source cluster and destination cluster must have the
       same number of shards.
-
-   .. step:: Stop the Balancer on the Destination
-
-      To stop the balancer on the destination cluster, connect to the
-      destination cluster and call the :method:`sh.stopBalancer` method:
-
-      .. code-block:: javascript
-
-         sh.stopBalancer()
-
 
    .. step:: Determine the shard IDs
 
@@ -179,8 +169,7 @@ instances.
 Check Progress
 --------------
 
-The ``mongosync`` instances do not aggregate progress information
-across shards. To review synchronization progress for a particular
+To review synchronization progress for a particular
 shard, use ``curl`` or another HTTP client to issue the
 :ref:`progress <c2c-api-progress>` command to the ``mongosync``
 instance syncing that shard.
@@ -271,9 +260,6 @@ These commands only check progress and commit synchronization for the
 to ``progress`` and  ``commit`` on any other ``mongosync`` instances
 that may be running.
 
-Once this is done, use :method:`sh.startBalancer` to restart the balancer 
-on the destination cluster:
-
 .. code-block:: javascript
 
    sh.startBalancer()
@@ -291,6 +277,9 @@ acts as the source cluster:
 - If you have not already done so, issue the :ref:`commit
   <c2c-api-commit>` command to each ``mongosync`` instance and wait
   until all of the commits to finish.
+  - To check if the sync process has been committed, issue the :ref:`progress 
+    <c2c-api-progress>` command to any ``mongosync`` instance and see if the 
+    ``state`` field has the value ``COMMITTED``.
 - Issue the :ref:`reverse <c2c-api-reverse>` command to each
   ``mongosync`` instance.
 


### PR DESCRIPTION
## DESCRIPTION 
- Remove “Stop the balancer on the Destination” step
- Remove mention of restarting balancer 
- Fix `mongosync` typos 
- Remove sentence on instances not aggregating process information 
- Add information on checking commit/sync progress

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33886-remove-stop-balancer-on-destination/multiple-mongosyncs/

## JIRA 
https://jira.mongodb.org/browse/DOCSP-33886

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6553e02a5b686d6bd95518b3