### PR TITLE
DOCSP-33760 Read Write Sync FAQ

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -17,6 +17,18 @@ This page provides answers to some frequently asked questions we have
 encountered. If you have additional questions please contact MongoDB
 Support.
 
+Can I perform read or write with my destination cluster while sync is in progress?
+----------------------------------------------------------------------------------
+
+As long as you are not concerned with :term:`eventual consistency`, you can 
+perform reads once ``canCommit`` is set to ``true``.
+
+You can write to any non-synced namespaces as much as you want. If you write to 
+a namespace before issuing ``commit`` and waiting for ``canWrite:true``, the 
+behavior is undefined. You can safeguard against this undefined behavior by 
+enabling :ref:`write blocking <c2c-dr-write-blocking>`.
+
+
 Can ``mongosync`` run on its own hardware? 
 ------------------------------------------
 


### PR DESCRIPTION
## DESCRIPTION 
Add new FAQ entry on performing reads/writes on a destination cluster while sync is in progress. 

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33760-read-write-sync-faq/faq/#can-i-perform-read-or-write-with-my-destination-cluster-while-sync-is-in-progress-

## JIRA 
https://jira.mongodb.org/browse/DOCSP-33760

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6553ef665b686d6bd959550d