### PR TITLE
DOCSP-33885 Fix Server Version Requirement References

### DIFF
--- a/source/includes/cross-version-sync.rst
+++ b/source/includes/cross-version-sync.rst
@@ -1,11 +1,11 @@
-Starting in 1.7.0, ``mongosync`` can perform a cross version migration
+Starting in 1.7.0, ``mongosync`` can perform a cross-version migration
 from a lower major version source cluster to a higher major version
 destination cluster. You can migrate up to two major versions ahead. For
 example, you can synchronize a cluster running MongoDB 6.0 with a
 cluster running 7.0.
 
-Cross version migration requires additional preparation and
-configuration when migrating from a pre-6.0 release. To perform a cross
-version migration from a pre-6.0 version of the MongoDB Server using
+Cross-version migration requires additional preparation and
+configuration when migrating from a pre-6.0 release. To perform a cross-version 
+migration from a pre-6.0 version of the MongoDB Server using
 ``mongosync``, please `contact <https://mongodb.com/contact>`__ your
 account team to inquire about Professional Services.

--- a/source/includes/fact-minimum-fcv.rst
+++ b/source/includes/fact-minimum-fcv.rst
@@ -1,0 +1,2 @@
+The minimum supported server :manual:`feature compatibility version <view-fcv>` 
+is 6.0.

--- a/source/includes/fact-minimum-server-version-support.rst
+++ b/source/includes/fact-minimum-server-version-support.rst
@@ -1,0 +1,1 @@
+The minimum supported server versions are MongoDB 6.0.8 and 7.0.0.

--- a/source/includes/fact-minimum-server-version-support.rst
+++ b/source/includes/fact-minimum-server-version-support.rst
@@ -1,1 +1,1 @@
-The minimum supported server versions are MongoDB 6.0.8 and 7.0.0.
+The minimum supported server versions of MongoDB are 6.0.8 and 7.0.0.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -41,7 +41,7 @@ Follow the instructions below to setup {+c2c-product-name+}.
    .. step:: Define a source and a destination cluster
 
       If you already have a MongoDB cluster, either self-managed or
-      hosted in :atlas:`MongodDB Atlas </getting-started?jmp=docs>`, 
+      hosted in :atlas:`MongoDB Atlas </getting-started?jmp=docs>`, 
       use that cluster as the source cluster. If you don't have a
       cluster to work with, you will need to create one.
 
@@ -50,14 +50,10 @@ Follow the instructions below to setup {+c2c-product-name+}.
       sharded cluster, or between sharded clusters, see:
       :ref:`c2c-sharded-clusters`.
 
-      The source and destination clusters must be:
-      
-      - at least MongoDB 6.0.
-      - at least Feature Compatibility Version 6.0
+      .. seealso::
 
-      .. include:: /includes/version-sync-limitation.rst
-
-      .. include:: /includes/cross-version-sync.rst
+         For more information on MongoDB server version compatibility or 
+         cross-version migrations, see :ref:`c2c-server-version-compatibility`.
 
       The number of nodes in the destination replica set does not have
       to equal the number of nodes in the source replica set.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -24,6 +24,11 @@ Limitations
 General Limitations
 -------------------
 
+.. note:: 
+
+  For information on MongoDB server compatility, see 
+  :ref:`c2c-server-version-compatibility`.
+
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -24,30 +24,12 @@ Limitations
 General Limitations
 -------------------
 
-- The minimum supported server versions are MongoDB 6.0.8 and 7.0.0.
+- .. include:: /includes/fact-minimum-server-version-support.rst
 
 - .. include:: /includes/fact-minimum-versions.rst
 
 - ``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or
-  6.2. The minimum supported server version is MongoDB 6.0.5.
-  For more information on MongoDB versioning, see
-  :ref:`release-version-numbers`.
-- In ``mongosync`` versions earlier than 1.7.0, the source and
-  destination clusters must have the same major and minor release
-  version, but can have different patch releases.
-
-  For example:
-
-  - ``mongosync`` can sync from a MongoDB 6.0.8 source cluster to a
-    destination cluster using MongoDB 6.0.9. This is because the patch
-    releases have the same major version.
-  - ``mongosync`` doesn't support a sync from a MongoDB 6.0.9 source
-    cluster to a destination cluster using MongoDB 7.0.0. This is
-    because the releases have different major versions.
-
-- In ``mongosync`` versions earlier than 1.7.0, the source and
-  destination clusters must have the same :dbcommand:`Feature
-  Compatibility Version <setFeatureCompatibilityVersion>`.
+  6.2.
 
 - .. include:: /includes/cross-version-sync.rst
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -24,17 +24,6 @@ Limitations
 General Limitations
 -------------------
 
-- .. include:: /includes/fact-minimum-server-version-support.rst
-
-- .. include:: /includes/fact-minimum-versions.rst
-
-- ``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or
-  6.2.
-
-- .. include:: /includes/cross-version-sync.rst
-
-- The minimum supported :dbcommand:`Feature Compatibility Version
-  <setFeatureCompatibilityVersion>` is 6.0.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured. 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -39,21 +39,7 @@ asked to upgrade in order to receive support.
 MongoDB Server Version Compatibility and Support
 ------------------------------------------------
 
-{+c2c-product-name+} supports the following versions of MongoDB Server:
-
-
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-
-   * - ``mongosync`` Version
-     - MongoDB Server Version
-
-   * - 1.6.0
-     - 7.0.x
-
-   * - 1.0.0
-     - 6.0.x
+.. include:: /includes/fact-minimum-server-version-support.rst
 
 Considerations
 --------------
@@ -63,11 +49,9 @@ Considerations
 Same Server Version
 ~~~~~~~~~~~~~~~~~~~
 
-{+c2c-product-name+} only supports syncing between the same version of
-MongoDB Server. The major and minor :ref:`server version numbers
-<release-version-numbers>` must be the same on both clusters.
-Starting in ``mongosync`` 1.6.0, the source and destination cluster
-can use different patch releases of the same major and minor version.
+.. versionchanged:: 1.7
+
+.. include:: /includes/cross-version-sync.rst
 
 Support Lifecycle 
 ~~~~~~~~~~~~~~~~~
@@ -214,7 +198,7 @@ Major Releases
 
 - Changes that break compatibility with a supported version of MongoDB
   Server.
-- Dropping a version of the REST API. ``mongosync`` may dropping all
+- Dropping a version of the REST API. ``mongosync`` may drop all
   older endpoints in favor of a new version of the API. There will never
   be any other types of backwards incompatible changes in the REST API.
 - Removing support for a previously supported MongoDB Server feature if

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -41,8 +41,7 @@ MongoDB Server Version Compatibility and Support
 
 .. include:: /includes/fact-minimum-server-version-support.rst
 
-``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or
-  6.2.
+``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or 6.2.
 
 .. include:: /includes/fact-minimum-versions.rst
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -41,15 +41,15 @@ MongoDB Server Version Compatibility and Support
 
 .. include:: /includes/fact-minimum-server-version-support.rst
 
-``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or 6.2.
+``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
 
 .. include:: /includes/fact-minimum-versions.rst
 
 .. include:: /includes/cross-version-sync.rst
 
 
-Considerations
---------------
+Version-Related Considerations
+------------------------------
 
 {+c2c-product-name+} has the following version related considerations:
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -48,10 +48,16 @@ version limitations and requirements:
 
 - .. include:: /includes/fact-minimum-fcv.rst 
 
+Synchronize Data Between Clusters Running Older MongoDB Server Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. include:: /includes/fact-minimum-versions.rst
 
-.. include:: /includes/cross-version-sync.rst
 
+Synchronize Data Between Clusters with Different MongoDB Server Major Versions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/cross-version-sync.rst
 
 Version-Related Considerations
 ------------------------------

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -39,9 +39,14 @@ asked to upgrade in order to receive support.
 MongoDB Server Version Compatibility and Support
 ------------------------------------------------
 
-.. include:: /includes/fact-minimum-server-version-support.rst
+Before you run {+c2c-product-name+}, consider the following MongoDB server 
+version limitations and requirements: 
 
-``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
+- .. include:: /includes/fact-minimum-server-version-support.rst
+
+- ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
+
+- .. include:: /includes/fact-minimum-fcv.rst 
 
 .. include:: /includes/fact-minimum-versions.rst
 
@@ -52,13 +57,6 @@ Version-Related Considerations
 ------------------------------
 
 {+c2c-product-name+} has the following version related considerations:
-
-Same Server Version
-~~~~~~~~~~~~~~~~~~~
-
-.. versionchanged:: 1.7
-
-.. include:: /includes/cross-version-sync.rst
 
 Support Lifecycle 
 ~~~~~~~~~~~~~~~~~

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -41,6 +41,14 @@ MongoDB Server Version Compatibility and Support
 
 .. include:: /includes/fact-minimum-server-version-support.rst
 
+``mongosync`` doesn't support MongoDB rapid releases such as 6.1 or
+  6.2.
+
+.. include:: /includes/fact-minimum-versions.rst
+
+.. include:: /includes/cross-version-sync.rst
+
+
 Considerations
 --------------
 


### PR DESCRIPTION
## DESCRIPTION
- Moved versioning information from Limitations section to Server Version Compatibility and Support section
  - Replace server version compatibility table with information from above bullet
- Modified limitations bullet to remove mention of minimum supported server version
- Removed limitation bullet on source and destination clusters allowing different patch releases
- Removed limitation bullet on requiring same fCV
- Fixed typo on Server Version Compatibility and Support list item 
- Added reference to server compatibility section in quickstart#179 

## STAGING 
- [Quickstart](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33885-server-version-rec-references/quickstart/#define-a-source-and-a-destination-cluster)
- [Limitations](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33885-server-version-rec-references/reference/limitations/#general-limitations)
- [MDB Server Version Compatibility and Support](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33885-server-version-rec-references/reference/versioning/#mongodb-server-version-compatibility-and-support)

## JIRA
https://jira.mongodb.org/browse/DOCSP-33885

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65579b305b686d6bd9598608