### PR TITLE
DOCSP38407  read and write concern info for mongosync

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -213,6 +213,18 @@ Write Blocking
 You must enable write-blocking when you start ``mongosync`` if you want
 to use :ref:`reverse synchronization <c2c-api-reverse>` later.
 
+User Permissions
+````````````````
+
+.. include:: /includes/fact-write-blocking-requirement.rst
+
+Permissible Writes
+``````````````````
+
+.. include:: /includes/fact-write-blocking-check.rst
+
+.. include:: /includes/fact-write-blocking-when.rst
+
 Commit
 ~~~~~~
 
@@ -232,18 +244,16 @@ The ``commit`` operation should take less than a few minutes. To monitor the
 - Index conversion is complete when ``mongosync`` enters the
   ``COMMITTED`` state.
 
-User Permissions
-````````````````
+Read and Write Concern
+~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/fact-write-blocking-requirement.rst
+By default, ``mongosync`` sets the read concern level to
+:readconcern:`"majority"` for reads on the source cluster. For writes on
+the destination cluster, ``mongosync`` sets the write concern level to
+:writeconcern:`"majority"` with :ref:`j: true <wc-j>`. 
 
-Permissible Writes
-``````````````````
-
-.. include:: /includes/fact-write-blocking-check.rst
-
-.. include:: /includes/fact-write-blocking-when.rst
-
+For more information on read and write concern configuration and
+behavior, see :ref:`read-concern` and :ref:`write-concern`. 
 
 .. _c2c-capped-collections:
 


### PR DESCRIPTION
## DESCRIPTION

- adding info on default read and write concern settings for mongosync
- reorganized write blocking section that was incorrectly split up

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-38407/reference/mongosync/#read-and-write-concern

## JIRA

https://jira.mongodb.org/browse/DOCSP-28407

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6565137a13dc9d16ea96c4e0

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
