### PR TITLE
DOCSP-32408 Fixes --cluster1 reference

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -56,7 +56,7 @@ Global Options
 
 .. option:: --cluster1 <URI>
 
-   .. include:: /includes/opts/cluster0.rst
+   .. include:: /includes/opts/cluster1.rst
 
    To set the ``--cluster1`` option from a configuration file,
    see the :setting:`cluster1` setting.


### PR DESCRIPTION
## Description

Fixes an include for the mongosync --cluster1 option.

## Staging

[--clusteer1](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP32408-cluster-ref/reference/mongosync/#std-option-mongosync.--cluster1)

## Jira
* [DOCSP-32408](https://jira.mongodb.org/browse/DOCSP-32408)


## Build

* [2023-11-27](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65652bd013dc9d16ea9d7746)
* ]2023-11-28](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=656682db7a5cb5fef5ff760d)