### PR TITLE
DOCSP-34646 Fix 404 fCV Link

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -116,7 +116,7 @@ source and destination clusters.  If the clusters are underprovisioned for your
 needs, consider upgrading the cluster hardware.
 
 Should I stop a migration if the logs contain the word "error" or "failure"?
---------------------------------------------------------------------------
+----------------------------------------------------------------------------
 
 No, logs that contain the word "error" or "failure" show non-fatal
 errors and do not signal that you need to stop ``mongosync`` early.

--- a/source/includes/fact-minimum-fcv.rst
+++ b/source/includes/fact-minimum-fcv.rst
@@ -1,2 +1,2 @@
-The minimum supported server :manual:`feature compatibility version <view-fcv>` 
+The minimum supported server :ref:`feature compatibility version <view-fcv>` 
 is 6.0.


### PR DESCRIPTION
## DESCRIPTION
- Fixed 404 link that references fCV page on server docs

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-34646-fcv-404/reference/versioning/#mongodb-server-version-compatibility-and-support:~:text=6.1%20or%206.2.-,The%20minimum%20supported%20server,is%206.0.,-Synchronize%20Data%20Between

## JIRA 
https://jira.mongodb.org/browse/DOCSP-34646

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=656611ee13dc9d16ead2d49b