### PR TITLE
DOCSP 33761 - adding to C2C quickstart

### DIFF
--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -180,9 +180,6 @@ Initialization Notes
 Synchronize Data Between Clusters
 ---------------------------------
 
-The command interface for ``mongosync`` is an HTTP server that
-publishes an HTTP API. To control ``mongosync``, use the API endpoints.
-
 The :ref:`start <c2c-api-start>` command initiates data synchronization.
 To start syncing, use ``curl`` or a similar program to issue the
 :ref:`start <c2c-api-start>` command:
@@ -197,7 +194,9 @@ the source cluster with the destination cluster. At this point,
 source cluster are applied to the destination cluster. The destination
 cluster is in continuous replication with the source cluster. 
 
-The API documentation provides details on using the following endpoints:
+The command interface for ``mongosync`` is an HTTP server that publishes
+an HTTP API. To control ``mongosync``, use the API endpoints.The API
+documentation provides details on using the following endpoints:
 
 .. list-table::
    :header-rows: 1
@@ -221,7 +220,7 @@ The API documentation provides details on using the following endpoints:
    * - :ref:`c2c-api-reverse`
      - Reverses the direction of a committed sync operation.
 
-One-time Sync
+One-Time Sync
 -------------
 
 For a one-time sync, use the ``progress`` endpoint to verify that the

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -191,8 +191,12 @@ If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
 returns ``{ "success": true }`` and starts to synchronize existing data on
 the source cluster with the destination cluster. At this point,
 ``mongosync`` enters the ``RUNNING`` state and applies subsequent source
-cluster writes to the destination cluster. The destination cluster
-continuously replicates data from the source cluster.
+cluster writes to the destination cluster. 
+
+To check the status of the sync, call the :ref:`progress
+<c2c-api-progress>` endpoint. If the ``progress`` response includes the
+field ``canCommit: true``, the clusters are in sync and the destination
+cluster continuously replicates data from the source cluster.
 
 The command interface for ``mongosync`` is an HTTP server that publishes
 an HTTP API. To control ``mongosync``, use the API endpoints. The API

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -223,9 +223,9 @@ documentation provides details on using the following endpoints:
 One-Time Sync
 -------------
 
-For a one-time sync, after initializing data synchronization, call the
-:ref:`progress <c2c-api-progress>` endpoint to see the status of the
-synchronization process: 
+After initializing data synchronization, call the :ref:`progress
+<c2c-api-progress>` endpoint to see the status of the synchronization
+process: 
 
 .. literalinclude:: /includes/api/requests/progress.sh
    :language: shell

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -223,7 +223,7 @@ documentation provides details on using the following endpoints:
 One-Time Sync
 -------------
 
-For a one-time sync, run the :ref:`progredss <c2c-api-progress>` command
+For a one-time sync, use the :ref:`progress <c2c-api-progress>` command
 to see the status of the synchronization process: 
 
 .. literalinclude:: /includes/api/requests/progress.sh
@@ -235,7 +235,7 @@ The following requirements must be met for a one-time sync:
   - ``canCommit: true``
   - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
-Then, run the :ref:`commit <c2c-api-commit>` command to commit the
+Then, use the :ref:`commit <c2c-api-commit>` command to commit the
 synchronization operation to the destination cluster and stop continuous
 replication:
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -190,9 +190,9 @@ To start syncing, use ``curl`` or a similar program to issue the
 If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
 returns ``{"success":true}`` and starts to synchronize existing data on
 the source cluster with the destination cluster. At this point,
-``mongosync`` is in the ``RUNNING`` state and subsequent writes to the
-source cluster are applied to the destination cluster. The destination
-cluster is in continuous replication with the source cluster. 
+``mongosync`` is in the ``RUNNING`` state and applies subsequent source
+cluster writes to the destination cluster. The destination cluster is in
+continuous replication with the source cluster. 
 
 The command interface for ``mongosync`` is an HTTP server that publishes
 an HTTP API. To control ``mongosync``, use the API endpoints. The API
@@ -230,7 +230,7 @@ following requirements are met:
   - ``canCommit: true``
   - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
-Then, run the :ref:`commit <c2c-api-commit>` to commit the
+Then, run the :ref:`commit <c2c-api-commit>` command to commit the
 synchronization operation to the destination cluster and stop continuous
 replication.
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -223,8 +223,9 @@ documentation provides details on using the following endpoints:
 One-Time Sync
 -------------
 
-For a one-time sync, use the :ref:`progress <c2c-api-progress>` command
-to see the status of the synchronization process: 
+For a one-time sync, after initializing data synchronization, use the
+:ref:`progress <c2c-api-progress>` command to see the status of the
+synchronization process: 
 
 .. literalinclude:: /includes/api/requests/progress.sh
    :language: shell

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -234,10 +234,10 @@ Then, run the :ref:`commit <c2c-api-commit>` command to commit the
 synchronization operation to the destination cluster and stop continuous
 replication.
 
-If the ``commit`` request is sucessful, ``mongosync`` returns
-``{"success":true}`` and enters the ``COMMITTING`` state. After the sync
-is complete, ``mongosync`` is in the ``COMMITTED`` state and the
-clusters are no longer in continuous sync. 
+If the :ref:`commit <c2c-api-commit>` request is sucessful,
+``mongosync`` returns ``{"success":true}`` and enters the ``COMMITTING``
+state. After the sync is complete, ``mongosync`` is in the ``COMMITTED``
+state and the clusters are no longer in continuous sync. 
 
 Synchronization Notes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -195,6 +195,12 @@ source cluster with the destination cluster. After the initial sync has
 completed, new writes to the source cluster will be synced with the
 destination cluster.
 
+If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
+returns ``TRUE`` and starts to synchronize existing data on the source
+cluster with the destination cluster. At this point, ``mongosync`` is in
+the ``RUNNING`` state and subsequent writes to the source cluster are
+applied to the destination cluster. 
+
 The API documentation provides details on using the following endpoints:
 
 .. list-table::
@@ -218,6 +224,23 @@ The API documentation provides details on using the following endpoints:
        cluster.
    * - :ref:`c2c-api-reverse`
      - Reverses the direction of a committed sync operation.
+
+One-time Sync
+-------------
+
+For a one-time sync, use the ``commit`` endpoint to commit the
+synchronization operation to the destination cluster and stop continuous
+replication. Before running a ``commit`` request, use the ``progress``
+endpoint to verify that the following requirements are met:
+
+  - ``state: "RUNNING"``
+  - ``canCommit: true``
+  - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
+
+Once  the ``commit`` endpoint is run and the ``commit`` request is
+successful, ``mongosync`` returns ``true`` and enters the ``COMMITTING``
+state. Once the sync is complete, ``mongosync`` enters the ``COMMITTED``
+state and the clusters are no longer in continuous sync. 
 
 Synchronization Notes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -191,11 +191,11 @@ To start syncing, use ``curl`` or a similar program to issue the
    :language: shell
 
 If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
-returns ``TRUE`` and starts to synchronize existing data on the source
-cluster with the destination cluster. At this point, ``mongosync`` is in
-the ``RUNNING`` state and subsequent writes to the source cluster are
-applied to the destination cluster. The desintation cluster is in
-continuous replication with the source cluster. 
+returns ``{"success":true}`` and starts to synchronize existing data on
+the source cluster with the destination cluster. At this point,
+``mongosync`` is in the ``RUNNING`` state and subsequent writes to the
+source cluster are applied to the destination cluster. The destination
+cluster is in continuous replication with the source cluster. 
 
 The API documentation provides details on using the following endpoints:
 
@@ -224,7 +224,7 @@ The API documentation provides details on using the following endpoints:
 One-time Sync
 -------------
 
-For a one-time sync, use the ``progress``endpoint to verify that the
+For a one-time sync, use the ``progress`` endpoint to verify that the
 following requirements are met:
 
   - ``state: "RUNNING"``
@@ -236,9 +236,10 @@ synchronization operation to the destination cluster and stop continuous
 replication.
 
 Once you run the ``commit`` endpoint and the ``commit`` request is
-successful, ``mongosync`` returns ``true`` and enters the ``COMMITTING``
-state. After the sync is complete, ``mongosync`` enters the ``COMMITTED``
-state and the clusters are no longer in continuous sync. 
+successful, ``mongosync`` returns ``{"success":true}`` and enters the
+``COMMITTING`` state. After the sync is complete, ``mongosync`` enters
+the ``COMMITTED`` state and the clusters are no longer in continuous
+sync. 
 
 Synchronization Notes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -190,16 +190,12 @@ To start syncing, use ``curl`` or a similar program to issue the
 .. literalinclude:: /includes/api/requests/start.sh
    :language: shell
 
-Once started, ``mongosync`` will synchronize existing data on the
-source cluster with the destination cluster. After the initial sync has
-completed, new writes to the source cluster will be synced with the
-destination cluster.
-
 If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
 returns ``TRUE`` and starts to synchronize existing data on the source
 cluster with the destination cluster. At this point, ``mongosync`` is in
 the ``RUNNING`` state and subsequent writes to the source cluster are
-applied to the destination cluster. 
+applied to the destination cluster. The desintation cluster is in
+continuous replication with the source cluster. 
 
 The API documentation provides details on using the following endpoints:
 
@@ -228,18 +224,20 @@ The API documentation provides details on using the following endpoints:
 One-time Sync
 -------------
 
-For a one-time sync, use the ``commit`` endpoint to commit the
-synchronization operation to the destination cluster and stop continuous
-replication. Before running a ``commit`` request, use the ``progress``
-endpoint to verify that the following requirements are met:
+For a one-time sync, use the ``progress``endpoint to verify that the
+following requirements are met:
 
   - ``state: "RUNNING"``
   - ``canCommit: true``
   - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
-Once  the ``commit`` endpoint is run and the ``commit`` request is
+Then, use the ``commit`` endpoint to commit the
+synchronization operation to the destination cluster and stop continuous
+replication.
+
+Once you run the ``commit`` endpoint and the ``commit`` request is
 successful, ``mongosync`` returns ``true`` and enters the ``COMMITTING``
-state. Once the sync is complete, ``mongosync`` enters the ``COMMITTED``
+state. After the sync is complete, ``mongosync`` enters the ``COMMITTED``
 state and the clusters are no longer in continuous sync. 
 
 Synchronization Notes

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -188,11 +188,11 @@ To start syncing, use ``curl`` or a similar program to issue the
    :language: shell
 
 If the :ref:`start <c2c-api-start>` request is successful, ``mongosync``
-returns ``{"success":true}`` and starts to synchronize existing data on
+returns ``{ "success": true }`` and starts to synchronize existing data on
 the source cluster with the destination cluster. At this point,
-``mongosync`` is in the ``RUNNING`` state and applies subsequent source
-cluster writes to the destination cluster. The destination cluster is in
-continuous replication with the source cluster. 
+``mongosync`` enters the ``RUNNING`` state and applies subsequent source
+cluster writes to the destination cluster. The destination cluster
+continuously replicates data from the source cluster.
 
 The command interface for ``mongosync`` is an HTTP server that publishes
 an HTTP API. To control ``mongosync``, use the API endpoints. The API
@@ -223,33 +223,34 @@ documentation provides details on using the following endpoints:
 One-Time Sync
 -------------
 
-For a one-time sync, after initializing data synchronization, use the
-:ref:`progress <c2c-api-progress>` command to see the status of the
+For a one-time sync, after initializing data synchronization, call the
+:ref:`progress <c2c-api-progress>` endpoint to see the status of the
 synchronization process: 
 
 .. literalinclude:: /includes/api/requests/progress.sh
    :language: shell
 
-The following requirements must be met for a one-time sync: 
+For a one time sync, verify that the ``progress`` response includes the
+following field values:
 
   - ``state: "RUNNING"``
   - ``canCommit: true``
   - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
-Then, use the :ref:`commit <c2c-api-commit>` command to commit the
+Then, call the :ref:`commit <c2c-api-commit>` endpoint to commit the
 synchronization operation to the destination cluster and stop continuous
 replication:
 
 .. literalinclude:: /includes/api/requests/commit.sh
    :language: shell
 
-If the :ref:`commit <c2c-api-commit>` request is sucessful,
-``mongosync`` returns ``{"success":true}`` and enters the ``COMMITTING``
-state. After the sync is complete, ``mongosync`` is in the ``COMMITTED``
-state and the clusters are no longer in continuous sync. 
+If the ``commit`` request is successful, ``mongosync`` returns 
+``{ "success": true }`` and enters the ``COMMITTING`` state. After the sync
+is complete, ``mongosync`` enters the ``COMMITTED`` state and the
+clusters are no longer in continuous sync. 
 
 Synchronization Notes
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 - The default port for the HTTP API is ``27182``.  Use the ``--port``
   option with ``mongosync`` to :ref:`configure another port

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -194,7 +194,7 @@ the source cluster with the destination cluster. At this point,
 cluster writes to the destination cluster. 
 
 To check the status of the sync, call the :ref:`progress
-<c2c-api-progress>` endpoint.
+<c2c-api-progress>` endpoint:
 
 .. literalinclude:: /includes/api/requests/progress.sh
    :language: shell

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -194,7 +194,12 @@ the source cluster with the destination cluster. At this point,
 cluster writes to the destination cluster. 
 
 To check the status of the sync, call the :ref:`progress
-<c2c-api-progress>` endpoint. If the ``progress`` response includes the
+<c2c-api-progress>` endpoint.
+
+.. literalinclude:: /includes/api/requests/progress.sh
+   :language: shell
+   
+If the ``progress`` response includes the
 field ``canCommit: true``, the clusters are in sync and the destination
 cluster continuously replicates data from the source cluster.
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -180,9 +180,9 @@ Initialization Notes
 Synchronize Data Between Clusters
 ---------------------------------
 
-The :ref:`start <c2c-api-start>` command initiates data synchronization.
+The :ref:`start <c2c-api-start>` endpoint initiates data synchronization.
 To start syncing, use ``curl`` or a similar program to issue the
-:ref:`start <c2c-api-start>` command:
+:ref:`start <c2c-api-start>` request:
 
 .. literalinclude:: /includes/api/requests/start.sh
    :language: shell

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -223,8 +223,13 @@ documentation provides details on using the following endpoints:
 One-Time Sync
 -------------
 
-For a one-time sync, use the ``progress`` endpoint to verify that the
-following requirements are met:
+For a one-time sync, run the :ref:`progredss <c2c-api-progress>` command
+to see the status of the synchronization process: 
+
+.. literalinclude:: /includes/api/requests/progress.sh
+   :language: shell
+
+The following requirements must be met for a one-time sync: 
 
   - ``state: "RUNNING"``
   - ``canCommit: true``
@@ -232,7 +237,10 @@ following requirements are met:
 
 Then, run the :ref:`commit <c2c-api-commit>` command to commit the
 synchronization operation to the destination cluster and stop continuous
-replication.
+replication:
+
+.. literalinclude:: /includes/api/requests/commit.sh
+   :language: shell
 
 If the :ref:`commit <c2c-api-commit>` request is sucessful,
 ``mongosync`` returns ``{"success":true}`` and enters the ``COMMITTING``

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -195,7 +195,7 @@ source cluster are applied to the destination cluster. The destination
 cluster is in continuous replication with the source cluster. 
 
 The command interface for ``mongosync`` is an HTTP server that publishes
-an HTTP API. To control ``mongosync``, use the API endpoints.The API
+an HTTP API. To control ``mongosync``, use the API endpoints. The API
 documentation provides details on using the following endpoints:
 
 .. list-table::
@@ -230,15 +230,14 @@ following requirements are met:
   - ``canCommit: true``
   - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
-Then, use the ``commit`` endpoint to commit the
+Then, run the :ref:`commit <c2c-api-commit>` to commit the
 synchronization operation to the destination cluster and stop continuous
 replication.
 
-Once you run the ``commit`` endpoint and the ``commit`` request is
-successful, ``mongosync`` returns ``{"success":true}`` and enters the
-``COMMITTING`` state. After the sync is complete, ``mongosync`` enters
-the ``COMMITTED`` state and the clusters are no longer in continuous
-sync. 
+If the ``commit`` request is sucessful, ``mongosync`` returns
+``{"success":true}`` and enters the ``COMMITTING`` state. After the sync
+is complete, ``mongosync`` is in the ``COMMITTED`` state and the
+clusters are no longer in continuous sync. 
 
 Synchronization Notes
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION

adding info on one time sync and continuous replication on the C2C quickstart page

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-33761/quickstart/#synchronize-data-between-clusters

## JIRA

https://jira.mongodb.org/browse/DOCSP-33761

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=656758f27a5cb5fef530c914

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
