### PR TITLE
DOCSP-33786 clarify number of mongosync instances

### DIFF
--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -16,7 +16,7 @@ There are two ways to synchronize :ref:`sharded clusters
 <sharded-cluster>`. You can use either one ``mongosync`` or several
 ``mongosync`` instances. For best performance with large or heavily
 loaded clusters, use one ``mongosync`` instance for each shard on the
-source cluster. 
+source cluster.
 
 .. _c2c-sharded-config-single:
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -15,8 +15,8 @@ Use ``mongosync`` on Sharded Clusters
 There are two ways to synchronize :ref:`sharded clusters
 <sharded-cluster>`. You can use either one ``mongosync`` or several
 ``mongosync`` instances. For best performance with large or heavily
-loaded clusters, use multiple ``mongosync`` instances, one
-``mongosync`` for each shard in the cluster.
+loaded clusters, use one ``mongosync`` instance for each shard on the
+source cluster. 
 
 .. _c2c-sharded-config-single:
 
@@ -39,7 +39,8 @@ using multiple ``mongosync`` instances.
 Configure Multiple ``mongosync`` Instances
 ------------------------------------------
 
-To configure multiple ``mongosync`` instances:
+The number of ``mongosync`` instances must match the number of shards on
+the source cluster. To configure multiple ``mongosync`` instances:
 
 #. :ref:`Verify cluster configuration <c2c-shard-config-verify>`
 #. :ref:`Determine the shard IDs <c2c-shard-config-determine>`

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -40,7 +40,10 @@ Configure Multiple ``mongosync`` Instances
 ------------------------------------------
 
 The number of ``mongosync`` instances must match the number of shards on
-the source cluster. To configure multiple ``mongosync`` instances:
+the source cluster. For a replica set source, you can only use one
+``mongosync`` instance. 
+
+To configure multiple ``mongosync`` instances:
 
 #. :ref:`Verify cluster configuration <c2c-shard-config-verify>`
 #. :ref:`Determine the shard IDs <c2c-shard-config-determine>`


### PR DESCRIPTION
## DESCRIPTION

clarify that the number of mongosync instances must match the number of shards 

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-33786/multiple-mongosyncs/

## JIRA

https://jira.mongodb.org/browse/DOCSP-33786

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6567afc37a5cb5fef5533820

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
