### PR TITLE
DOCSP-34744 fixes c2c installation procedure

### DIFF
--- a/source/installation/install-on-linux.txt
+++ b/source/installation/install-on-linux.txt
@@ -94,8 +94,3 @@ the ``.tgz``.
       .. include:: /includes/step-update-path.rst
 
 .. bug in constant parser DOP-3025
-
-Run {+c2c-product-name+}
----------------------------
-
-.. include:: /includes/run-c2c.rst

--- a/source/installation/install-on-macos.txt
+++ b/source/installation/install-on-macos.txt
@@ -56,7 +56,7 @@ the ZIP file.
 .. procedure::
    :style: normal
 
-   .. step:: Download the tarball.
+   .. step:: Download the ZIP file.
 
       Download the {+c2c-product-name+} ZIP file from the following
       link:
@@ -80,16 +80,10 @@ the ZIP file.
 
       .. code-block:: bash
 
-         tar xopf mongosync-*.zip
+         unzip mongosync-*.zip
 
    .. step:: Ensure the binary is in a directory listed in your ``PATH`` environment variable.
 
       .. include:: /includes/step-update-path.rst
 
 .. bug in constant parser DOP-3025
-
-Run {+c2c-product-name+}
----------------------------
-
-.. include:: /includes/run-c2c.rst
-

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -242,9 +242,9 @@ process:
 For a one time sync, verify that the ``progress`` response includes the
 following field values:
 
-  - ``state: "RUNNING"``
-  - ``canCommit: true``
-  - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
+- ``state: "RUNNING"``
+- ``canCommit: true``
+- ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
 
 Then, call the :ref:`commit <c2c-api-commit>` endpoint to commit the
 synchronization operation to the destination cluster and stop continuous


### PR DESCRIPTION
## DESCRIPTION

_Primary fix_: Updates installation procedure for Mac OS.
_Secondary fix_: This PR removes the **Run Cluster-to-Cluster Sync** sections of the install pages. 

Ratika points out that the page linked to in the **Run Cluster-to-Cluster Sync** sections of both the Linux and Mac OS install pages is a placeholder page. See screenshot below. (Note that "**Cluster-to-Cluster Sync ->**" points to the homepage and is auto-generated footer content.)

These sections can later be reinstated when the placeholder page is populated with content.

<img width="771" alt="Screenshot 2023-12-05 at 4 41 28 PM" src="https://github.com/mongodb/docs-cluster-to-cluster-sync/assets/73852296/a88bc911-87f5-4910-9028-2b8fa9f9cf8b">


## STAGING

- https://preview-mongodbjmdmongo.gatsbyjs.io/cluster-sync/DOCSP-34744/installation/install-on-macos/
- https://preview-mongodbjmdmongo.gatsbyjs.io/cluster-sync/DOCSP-34744/installation/install-on-linux/

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6601d2626fc5f04850d028ba
