### PR TITLE
DOCSP 33887 Updating oplog sizing section

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -49,13 +49,14 @@ clusters.
 Should I increase the size of the ``oplog`` in the source cluster?
 ------------------------------------------------------------------
 
-The :term:`oplog` is a capped collection that keeps a rolling 
-record of all operations that modify the data stored in your databases. 
+If you anticipate that you will sync from a soource cluster with a high
+write rate for an extended period or that you will pause sync for an
+extended period, you might exceed the oplog window. To
+increase the size of the ``oplog`` on the source cluster, use the
+:setting:`~replication.oplogSizeMB` setting. 
 
-.. include:: /includes/fact-oplog-background
-
-To learn more about how to increase the size of the ``oplog``, see:
-:ref:`tutorial-change-oplog-size`. 
+For more information on increasing the size of the oplog, see
+:ref:`Change Oplog Size <tutorial-change-oplog-size>`. 
 
 Which connection string options does ``mongosync`` allow?
 ---------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -49,11 +49,11 @@ clusters.
 Should I increase the size of the ``oplog`` in the source cluster?
 ------------------------------------------------------------------
 
-If you anticipate that you will sync from a soource cluster with a high
+If you anticipate that you will sync from a source cluster with a high
 write rate for an extended period or that you will pause sync for an
-extended period, you might exceed the oplog window. To
-increase the size of the ``oplog`` on the source cluster, use the
-:setting:`~replication.oplogSizeMB` setting. 
+extended period, you might exceed the oplog window. To increase the size
+of the ``oplog`` on the source cluster and prevent oplog rollover, use
+the :setting:`~replication.oplogSizeMB` setting. 
 
 For more information on increasing the size of the oplog, see
 :ref:`Change Oplog Size <tutorial-change-oplog-size>`. 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -4,14 +4,13 @@ to the data on the destination cluster.  When operations
 that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
-During the initial sync, ``mongosync`` may apply operations at a slower
-rate due to the load imposed by copying documents concurrently.
-After ``mongosync`` completes the initial sync, it applies changes 
-faster and is more likely to maintain a position in the ``oplog``
-that is close to the real-time writes occuring on the source cluster.
+Starting in version 1.5.0, {+c2c-product-name+} enables Oplog Rollover
+Resilience (ORR) which allows ``mongosync`` to apply changes to the on
+the source cluster to the destination cluster during the initial sync
+process. ORR increases the resilience of ``mongosync`` to oplog rollover
+but does not prevent it entirely. For more informatino on ORR, see
+:ref:`Oplog Rollover Resilience <.. _1.5.0-c2c-release-notes:>`
 
-If you anticipate syncing a large data set, or if you plan to pause
-synchronization for an extended period of time, you might exceed the
-:term:`oplog window`. Use the :setting:`~replication.oplogSizeMB` setting
+Use the :setting:`~replication.oplogSizeMB` setting
 to increase the size of the ``oplog`` on the source cluster.
 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -8,10 +8,10 @@ Starting in version 1.5.0, {+c2c-product-name+} enables Oplog Rollover
 Resilience (ORR) which allows ``mongosync`` to apply changes on the
 source cluster to the destination cluster during the initial sync. ORR
 increases the resilience of ``mongosync`` to oplog rollover but does not
-prevent rollover entirely. For more information on ORR, see :ref:`Oplog
-Rollover Resilience <1.5.0-c2c-release-notes>`
+prevent rollover entirely. For more information on ORR, see the :ref:`Oplog
+Rollover Resilience release note <1.5.0-c2c-release-notes>`
 
-If you anticipate that you will sync from a soource cluster with a high
+If you anticipate that you will sync from a source cluster with a high
 write rate for an extended period or that you will pause sync for an
 extended period, you might exceed the oplog window, even with ORR. To
 increase the size of the ``oplog`` on the source cluster, use the

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -9,7 +9,7 @@ Resilience (ORR) which allows ``mongosync`` to apply changes on the
 source cluster to the destination cluster during the initial sync. ORR
 increases the resilience of ``mongosync`` to oplog rollover but does not
 prevent rollover entirely. For more information on ORR, see the :ref:`Oplog
-Rollover Resilience release note <1.5.0-c2c-release-notes>`
+Rollover Resilience release note <1.5.0-c2c-release-notes>`.
 
 If you anticipate that you will sync from a source cluster with a high
 write rate for an extended period or that you will pause sync for an

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -5,12 +5,18 @@ that ``mongosync`` has not applied roll off the ``oplog``
 on the source cluster, the sync fails and ``mongosync`` exits.
 
 Starting in version 1.5.0, {+c2c-product-name+} enables Oplog Rollover
-Resilience (ORR) which allows ``mongosync`` to apply changes to the on
-the source cluster to the destination cluster during the initial sync
-process. ORR increases the resilience of ``mongosync`` to oplog rollover
-but does not prevent it entirely. For more informatino on ORR, see
-:ref:`Oplog Rollover Resilience <.. _1.5.0-c2c-release-notes:>`
+Resilience (ORR) which allows ``mongosync`` to apply changes on the
+source cluster to the destination cluster during the initial sync. ORR
+increases the resilience of ``mongosync`` to oplog rollover but does not
+prevent rollover entirely. For more information on ORR, see :ref:`Oplog
+Rollover Resilience <1.5.0-c2c-release-notes>`
 
-Use the :setting:`~replication.oplogSizeMB` setting
-to increase the size of the ``oplog`` on the source cluster.
+If you anticipate that you will sync from a soource cluster with a high
+write rate for an extended period or that you will pause sync for an
+extended period, you might exceed the oplog window, even with ORR. To
+increase the size of the ``oplog`` on the source cluster, use the
+:setting:`~replication.oplogSizeMB` setting. For more information on
+increasing the size of the oplog, see :ref:`Change Oplog Size
+<tutorial-change-oplog-size>`.
+
 


### PR DESCRIPTION
## DESCRIPTION

updating oplog sizing section and faq with Oplog Resistance Rollover

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-33887/reference/oplog-sizing/
https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-33887/faq/

## JIRA

https://jira.mongodb.org/browse/DOCSP-33887

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6570af6c7a5cb5fef5792899
(build error resolved in [DOCSP-34814](https://jira.mongodb.org/browse/DOCSP-34814)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
