### PR TITLE
DOCSP-35742 Fixes Mac Extraction

### DIFF
--- a/source/installation/install-on-macos.txt
+++ b/source/installation/install-on-macos.txt
@@ -56,7 +56,7 @@ the ZIP file.
 .. procedure::
    :style: normal
 
-   .. step:: Download the ZIP file;
+   .. step:: Download the ZIP file.
 
       Download the {+c2c-product-name+} ZIP file from the following
       link:

--- a/source/installation/install-on-macos.txt
+++ b/source/installation/install-on-macos.txt
@@ -56,7 +56,7 @@ the ZIP file.
 .. procedure::
    :style: normal
 
-   .. step:: Download the tarball.
+   .. step:: Download the ZIP file;
 
       Download the {+c2c-product-name+} ZIP file from the following
       link:
@@ -73,14 +73,14 @@ the ZIP file.
 
       #. Click :guilabel:`Download`.
 
-   .. step:: Extract the files from the downloaded archive.
+   .. step:: Unzip the files from the downloaded archive.
 
-      To extract ``mongosync``, use the ``tar`` command in a system
+      To unzip ``mongosync``, use the ``unzip`` command in a system
       shell:
 
       .. code-block:: bash
 
-         tar xopf mongosync-*.zip
+         unzip mongosync-*.zip
 
    .. step:: Ensure the binary is in a directory listed in your ``PATH`` environment variable.
 


### PR DESCRIPTION
## Description

Changes extract instructions from tar to unzip.

## Staging

* [Unzip Archive](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-34742-unzip-mac/installation/install-on-macos/#unzip-the-files-from-the-downloaded-archive.)

## Jira

* [DOCSP-35742](https://jira.mongodb.org/browse/DOCSP-34742)

## Build

* [2023-12-12](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6578e38c7a5cb5fef580f91d)