### PR TITLE
DOCSP 28174 adding info to commit page

### DIFF
--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -29,9 +29,8 @@ characteristics that ``mongosync`` alters during the synchronization process.
    * - Collection Characteristic
      - Impact of ``commit`` 
    * - :ref:`Unique Indexes <c2c-dr-unique>`
-     - ``commit`` resets unique indexes that
-       ``mongosync`` replicated as non-unique on the destination
-       cluster.
+     - ``commit`` resets unique indexes that``mongosync`` replicated as
+       non-unique on the destination cluster.
 
    * - :ref:`TTL Indexes <c2c-dr-ttl>`
      - ``commit`` resets ``expireAfterSeconds`` that ``mongosync`` set
@@ -42,13 +41,13 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - if ``mongosync`` disabled writes on the destination cluster,
-     ``commit`` disables the Write Block Mode. 
+     - If ``mongosync`` disabled writes on the destination cluster,
+       ``commit`` disables the Write Block Mode. 
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections
-        that ``mongosync`` set to the maximum allowable size on the
-        destination cluster.
+       that ``mongosync`` set to the maximum allowable size on the
+       destination cluster.
 
 Requirements
 ------------

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -15,8 +15,7 @@
 Description
 -----------
 
-Commits the synchronization operation to the destination cluster.
-``commit`` finalizes the sync between the source cluster and the
+Finalizes the sync between the source cluster and the
 destination cluster and stops continuous sync between clusters. 
 
 Requirements

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -17,7 +17,7 @@ Description
 
 Commits the synchronization operation to the destination cluster.
 ``commit`` finalizes the sync between the source cluster and destination
-cluster and ends the continuous sync between the clusters. 
+cluster and stops the continuous sync between the clusters. 
 
 Requirements
 ------------
@@ -116,5 +116,5 @@ Behavior
 
 If the ``commit`` request is successful, ``mongosync`` enters the
 ``COMMITTING`` state, then automatically transitions to the
-``COMMITTED`` state. Once ``mongosync`` enters the ``COMMITTED`` stte,
-the clusters are no lonegr in continuous sync. 
+``COMMITTED`` state. Once ``mongosync`` enters the ``COMMITTED`` state,
+continuous sync between the clusters stops. 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -16,8 +16,8 @@ Description
 -----------
 
 Commits the synchronization operation to the destination cluster.
-``commit`` finalizes the sync between the source cluster and destination
-cluster and stops the continuous sync between the clusters. 
+``commit`` finalizes the sync between the source cluster and the
+destination cluster and stops continuous sync between clusters. 
 
 Requirements
 ------------

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -16,6 +16,8 @@ Description
 -----------
 
 Commits the synchronization operation to the destination cluster.
+``commit`` finalizes the sync between the source cluster and destination
+cluster and ends the continuous sync between the clusters. 
 
 Requirements
 ------------
@@ -114,4 +116,5 @@ Behavior
 
 If the ``commit`` request is successful, ``mongosync`` enters the
 ``COMMITTING`` state, then automatically transitions to the
-``COMMITTED`` state.
+``COMMITTED`` state. Once ``mongosync`` enters the ``COMMITTED`` stte,
+the clusters are no lonegr in continuous sync. 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -15,8 +15,8 @@
 Description
 -----------
 
-Finalizes the sync between the source cluster and the
-destination cluster and stops continuous sync between clusters. 
+Finalizes the sync between the source cluster and the destination
+cluster and stops continuous sync between clusters. 
 
 Requirements
 ------------

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -16,7 +16,38 @@ Description
 -----------
 
 Finalizes the sync between the source cluster and the destination
-cluster and stops continuous sync between clusters. 
+cluster and stops continuous sync between clusters. ``commit`` also
+restores collection characteristics that ``mongosync`` temporarily
+alters during synchronization. 
+
+The following table illustrates the impact of ``commit`` on collection
+characteristics that were altered during the synchronization process.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Collection Characteristic
+     - Impact of ``commit`` 
+   * - :ref:`Unique Indexes <c2c-dr-unique>`
+     - ``commit`` resets formerly unique indexes that
+       ``mongosync`` set as non-unique indexes on the destination
+       cluster.
+
+   * - :ref:`TTL Indexes <c2c-dr-ttl>`
+     - ``commit`` resets the ``expireAfterSeconds`` field that
+     ``mongosync`` set to the value of ``MAX_INT`` on the destination cluster.
+
+   * - :ref:`Hidden Indexes <c2c-dr-hidden>`
+     - ``commit`` hides formerly hidden indexes that ``mongosync``
+       replicated as non-hidden.
+
+   * - :ref:`Write Blocking <c2c-dr-write-blocking>`
+     - if ``mongosync`` disabled writes on the destination cluster,
+     ``commit`` disables the Write Block Mode. 
+
+   * - :ref:`Capped Collections <c2c-dr-capped-collections>`
+     - ``commit`` resets the required maximum size of capped collections
+        that ``mongosync`` set to the maximum allowable size.
 
 Requirements
 ------------
@@ -117,3 +148,5 @@ If the ``commit`` request is successful, ``mongosync`` enters the
 ``COMMITTING`` state, then automatically transitions to the
 ``COMMITTED`` state. Once ``mongosync`` enters the ``COMMITTED`` state,
 continuous sync between the clusters stops. 
+
+

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -29,11 +29,11 @@ characteristics that ``mongosync`` alters during the synchronization process.
    * - Collection Characteristic
      - Impact of ``commit`` 
    * - :ref:`Unique Indexes <c2c-dr-unique>`
-     - ``commit`` resets unique indexes that``mongosync`` replicated as
+     - ``commit`` resets unique indexes that ``mongosync`` replicated as
        non-unique on the destination cluster.
 
    * - :ref:`TTL Indexes <c2c-dr-ttl>`
-     - ``commit`` resets ``expireAfterSeconds`` that ``mongosync`` set
+     - ``commit`` resets ``expireAfterSeconds`` which ``mongosync`` set
        to the value of ``MAX_INT`` on the destination cluster.
 
    * - :ref:`Hidden Indexes <c2c-dr-hidden>`
@@ -46,7 +46,7 @@ characteristics that ``mongosync`` alters during the synchronization process.
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections
-       that ``mongosync`` set to the maximum allowable size on the
+       which ``mongosync`` set to the maximum allowable size on the
        destination cluster.
 
 Requirements

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -21,7 +21,7 @@ restores collection characteristics that ``mongosync`` temporarily
 alters during synchronization. 
 
 The following table illustrates the impact of ``commit`` on collection
-characteristics that were altered during the synchronization process.
+characteristics that ``mongosync`` alters during the synchronization process.
 
 .. list-table::
    :header-rows: 1
@@ -29,17 +29,17 @@ characteristics that were altered during the synchronization process.
    * - Collection Characteristic
      - Impact of ``commit`` 
    * - :ref:`Unique Indexes <c2c-dr-unique>`
-     - ``commit`` resets formerly unique indexes that
-       ``mongosync`` set as non-unique indexes on the destination
+     - ``commit`` resets unique indexes that
+       ``mongosync`` replicated as non-unique on the destination
        cluster.
 
    * - :ref:`TTL Indexes <c2c-dr-ttl>`
-     - ``commit`` resets the ``expireAfterSeconds`` field that
-     ``mongosync`` set to the value of ``MAX_INT`` on the destination cluster.
+     - ``commit`` resets ``expireAfterSeconds`` that ``mongosync`` set
+       to the value of ``MAX_INT`` on the destination cluster.
 
    * - :ref:`Hidden Indexes <c2c-dr-hidden>`
-     - ``commit`` hides formerly hidden indexes that ``mongosync``
-       replicated as non-hidden.
+     - ``commit`` resets hidden indexes that ``mongosync``
+       replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
      - if ``mongosync`` disabled writes on the destination cluster,
@@ -47,7 +47,8 @@ characteristics that were altered during the synchronization process.
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections
-        that ``mongosync`` set to the maximum allowable size.
+        that ``mongosync`` set to the maximum allowable size on the
+        destination cluster.
 
 Requirements
 ------------

--- a/source/reference/disaster-recovery.txt
+++ b/source/reference/disaster-recovery.txt
@@ -25,8 +25,9 @@ during synchronization. The original values are restored during the
 you must manually reset these collection characteristics on the destination
 cluster before you can use it as the primary cluster.
 
-To prepare the destination cluster to replace the source cluster, make the 
-following changes that mimic the behavior of calling the ``commit`` endpoint:
+To prepare the destination cluster to replace the source cluster, make
+the following changes that mimic the sync finalization process of the
+``commit`` endpoint. 
 
 .. list-table::
    :header-rows: 1

--- a/source/reference/disaster-recovery.txt
+++ b/source/reference/disaster-recovery.txt
@@ -26,7 +26,7 @@ you must manually reset these collection characteristics on the destination
 cluster before you can use it as the primary cluster.
 
 To prepare the destination cluster to replace the source cluster, make the 
-following changes:
+following changes that mimic the behavior of calling the ``commit`` endpoint:
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
## DESCRIPTION

adding information to the commit page to clarify behavior

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-28174/reference/api/commit/

## JIRA

https://jira.mongodb.org/browse/DOCSP-28174

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6579e76f7a5cb5fef5c7c6c4

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
