### PR TITLE
DOCSP-35053 removing duplicate sections

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -252,44 +252,6 @@ To monitor the ``commit`` process, use the :ref:`progress
 - Index conversion is complete when ``mongosync`` enters the
   ``COMMITTED`` state.
 
-User Permissions
-````````````````
-
-.. include:: /includes/fact-write-blocking-requirement.rst
-
-Permissible Reads
-`````````````````
-
-.. include:: /includes/fact-read-operations-source.rst
-
-.. include:: /includes/fact-read-operations-check.rst
-
-Permissible Writes
-``````````````````
-
-.. include:: /includes/fact-write-blocking-check.rst
-
-.. include:: /includes/fact-write-blocking-when.rst
-
-Commit
-~~~~~~
-
-To stop syncing, use the :ref:`commit <c2c-api-commit>` command on the
-destination cluster to convert indexes and finalize the changes. By default, 
-``commit`` operations have no effect on writes unless you enable 
-:ref:`write-blocking <c2c-write-blocking>`. If you enable write blocking:
-
-- ``commit`` blocks writes on the source cluster. 
-- ``commit`` blocks writes on the destination cluster until
-  ``mongosync`` begins index validation.
-
-The ``commit`` operation should take less than a few minutes. To monitor the 
-``commit`` process, use the :ref:`progress <c2c-api-progress>` command:
-
-- The destination cluster is writable when ``canWrite`` is true.
-- Index conversion is complete when ``mongosync`` enters the
-  ``COMMITTED`` state.
-
 Read and Write Concern
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## DESCRIPTION

removing duplicate commit, user permissions, permissible reads, and permissible writes sections

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-35053/reference/mongosync/

## JIRA

https://jira.mongodb.org/browse/DOCSP-35053

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=657b61747a5cb5fef5397ed4

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
