### PR TITLE
DOCSP-31136 Adds --logPath to Quickstart

### DIFF
--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -163,6 +163,7 @@ command is reformated here for clarity):
 .. code-block:: shell
 
    ./bin/mongosync \
+         --logPath /var/log/mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
          --cluster1 "mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020"
 


### PR DESCRIPTION
## Description

Adds the `--logPath` option to the Quickstart page to better emphasize use of logs for customers.

## Staging

[Quickstart](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-31136-logPath-quickstart/quickstart/#initialize-mongosync)

## Jira

* [DOCSP-31136](https://jira.mongodb.org/browse/DOCSP-31136)

## Build

* [2023-12-14](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=657b712b7a5cb5fef53e4608)
* [2024-01-10](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=659edd59dcc0144a51f3ade2)
* [2024-01-11](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65a07800dcc0144a5171ebe8)