### PR TITLE
DOCSP 24715 mongosyncs must be the same version

### DIFF
--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -42,7 +42,7 @@ Configure Multiple ``mongosync`` Instances
 The number of ``mongosync`` instances must match the number of shards on
 the source cluster. For a replica set source, you can only use one
 ``mongosync`` instance. You must use the same version of ``mongosync``
-between instances. 
+between all instances. 
 
 To configure multiple ``mongosync`` instances:
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -40,9 +40,9 @@ Configure Multiple ``mongosync`` Instances
 ------------------------------------------
 
 The number of ``mongosync`` instances must match the number of shards on
-the source cluster. For a replica set source, you can only use one
-``mongosync`` instance. You must use the same version of ``mongosync``
-between all instances. 
+the source cluster. You must use the same version of ``mongosync``
+between all instances. For a replica set source, you can only use one
+``mongosync`` instance. 
 
 To configure multiple ``mongosync`` instances:
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -25,7 +25,7 @@ Configure a Single ``mongosync`` Instance
 
 To configure a single ``mongosync``, follow the :ref:`connection
 instructions <c2c-conn-top-level>` for your cluster architecture to
-connect to the :binary:`mongos` instance in your cluster.
+connect to the :binary:`mongos` instance in your cluster. 
 
 When you connect a single ``mongosync`` to a sharded cluster do not use
 the :urioption:`replicaSet` option or the :option:`id <mongosync --id>`
@@ -41,7 +41,8 @@ Configure Multiple ``mongosync`` Instances
 
 The number of ``mongosync`` instances must match the number of shards on
 the source cluster. For a replica set source, you can only use one
-``mongosync`` instance. 
+``mongosync`` instance. You must use the same version of ``mongosync``
+between instances. 
 
 To configure multiple ``mongosync`` instances:
 

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -25,7 +25,7 @@ Configure a Single ``mongosync`` Instance
 
 To configure a single ``mongosync``, follow the :ref:`connection
 instructions <c2c-conn-top-level>` for your cluster architecture to
-connect to the :binary:`mongos` instance in your cluster. 
+connect to the :binary:`mongos` instance in your cluster.
 
 When you connect a single ``mongosync`` to a sharded cluster do not use
 the :urioption:`replicaSet` option or the :option:`id <mongosync --id>`


### PR DESCRIPTION
## DESCRIPTION

clarifying that the same version of mongosync must be used between all instances

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/cluster-sync/docsworker-xlarge/DOCSP-24715/multiple-mongosyncs/#configure-multiple-mongosync-instances

## JIRA

https://jira.mongodb.org/browse/DOCSP-24715

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65831e407a5cb5fef5098dc8

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)