### PR TITLE
DOCSP-33161 Disable Require Indexes Option on Atlas

### DIFF
--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -45,6 +45,11 @@ Behavior
 
 .. include:: /includes/fact-behavior-initial-state
 
+Limitations
+~~~~~~~~~~~
+
+.. include:: /includes/fact-atlas-require-indexes-limitation.rst
+
 Example
 -------
 

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -53,6 +53,11 @@ Behavior
 
 .. include:: /includes/fact-behavior-initial-state
 
+Limitations
+~~~~~~~~~~~
+
+.. include:: /includes/fact-atlas-require-indexes-limitation.rst
+
 Example
 -------
 

--- a/source/includes/fact-atlas-require-indexes-limitation.rst
+++ b/source/includes/fact-atlas-require-indexes-limitation.rst
@@ -1,0 +1,2 @@
+Before you attempt to run ``mongosync`` with an ``M10+`` Atlas cluster, disable 
+the :guilabel:`Require Indexes for All Queries` option.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -51,6 +51,7 @@ General Limitations
   isn't supported.
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
+- .. include:: /includes/fact-atlas-require-indexes-limitation.rst
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
## DESCRIPTION
Adds a note to C2C docs about disabling the **Require Indexes for All Queries** option on Atlas before running `mongosync`

## STAGING 
- [Limitations](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33161-disable-require-indexes-option/reference/limitations/#:~:text=Before%20you%20attempt%20to%20run%20mongosync%20with%20an%20M10%2B%20Atlas%20cluster%2C%20disable%20the%20Require%20Indexes%20for%20All%20Queries%20option.)
- [Connect Two Atlas Clusters](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33161-disable-require-indexes-option/connecting/atlas-to-atlas/#limitations)
- [Connect a Self-Managed Cluster to Atlas](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-33161-disable-require-indexes-option/connecting/onprem-to-atlas/#limitations)

## JIRA
https://jira.mongodb.org/browse/DOCSP-33161

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65959f0bdcc0144a51c053e7
