### PR TITLE
DOCSP-29172 Fixes buildIndexes Data Type

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -92,7 +92,7 @@ Request Body Parameters
      - Name of the destination cluster.
 
    * - ``buildIndexes``
-     - boolean
+     - string
      - Optional
      - Configures index builds during sync.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -91,6 +91,7 @@ Request Body Parameters
      - Required
      - Name of the destination cluster.
 
+
    * - ``buildIndexes``
      - string
      - Optional

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -91,7 +91,6 @@ Request Body Parameters
      - Required
      - Name of the destination cluster.
 
-
    * - ``buildIndexes``
      - string
      - Optional


### PR DESCRIPTION
## Description

Fixes `buildIndexes` data type listing on `start` endpoint.

## Staging

[buildIndexes](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-29172-buildindexes/reference/api/start/#request-body-parameters) data type column

## Jira

[DOCSP-29172](https://jira.mongodb.org/browse/DOCSP-29172)

## Build

* [2024-01-22](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65aec58c6a2f0dd1df0cf963)