### PR TITLE
DOCSP-29172 Fixes buildIndexes Data Type (#242)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -92,7 +92,7 @@ Request Body Parameters
      - Name of the destination cluster.
 
    * - ``buildIndexes``
-     - boolean
+     - string
      - Optional
      - Configures index builds during sync.
 


### PR DESCRIPTION
Backport to v1.7

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b2931384f878f2a7261097)