### PR TITLE
DOCSP-27579 lagTimeSecond fix

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -43,10 +43,10 @@
      - Time in seconds between the last applied event and time of the
        current latest event for this instance of ``mongosync``.
 
-       ..note::
+       .. note::
 
-         ``mongosync`` performs periodic no-op writes on the source cluster,
-         which may prevent the value from reaching zero.
+          ``mongosync`` performs periodic no-op writes on the source cluster,
+          which may prevent the value from reaching zero.
 
    * - ``collectionCopy``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -46,7 +46,8 @@
        .. note::
 
           ``mongosync`` performs periodic no-op writes on the source cluster,
-          which may prevent the value from reaching zero.
+          which may prevent the value of the ``lagTimeSeconds`` field from
+          reaching zero.
 
    * - ``collectionCopy``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -24,9 +24,9 @@
      - If ``true``, indicates that writes are permitted on the
        destination cluster. Do not write to the destination cluster
        while ``canWrite`` is ``false``.
-       
+  
        Index validation continues until the :ref:`commit
-       <c2c-api-commit>` is complete. 
+       <c2c-api-commit>` is complete.
 
    * - ``info``
      - string
@@ -43,6 +43,9 @@
      - Time in seconds between the last applied event and time of the
        current latest event for this instance of ``mongosync``.
 
+       ``mongosync`` performs periodic no-op writes on the source cluster,
+       which may prevent the value from reaching zero.
+
    * - ``collectionCopy``
      - object
      - Describes the total amount of data being copied and the
@@ -58,8 +61,8 @@
        ``.estimatedCopiedBytes``
      - integer
      - Estimated number of bytes which have been copied to the
-       destination cluster by this ``mongosync`` instance. 
-       
+       destination cluster by this ``mongosync`` instance.
+
        To calculate the total estimated progress as a percentage, add the value
        of the ``estimatedCopiedBytes`` field for each ``mongosync`` instance
        and divide the result by the value of the ``estimatedTotalBytes`` field
@@ -88,7 +91,7 @@
 
    * - ``coordinatorID``
      - string
-     - The identifier string for the coordinator instance.  
+     - The identifier string for the coordinator instance.
 
        - When ``mongosync`` is coordinated by another instance, this field shows
          the identifier string for the coordinator instance.

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -43,8 +43,10 @@
      - Time in seconds between the last applied event and time of the
        current latest event for this instance of ``mongosync``.
 
-       ``mongosync`` performs periodic no-op writes on the source cluster,
-       which may prevent the value from reaching zero.
+       ..note::
+
+         ``mongosync`` performs periodic no-op writes on the source cluster,
+         which may prevent the value from reaching zero.
 
    * - ``collectionCopy``
      - object


### PR DESCRIPTION
## Description

Adds note to `lagTimeSeconds` indicating that it doesn't hit 0.

## Staging

[progress Response](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-27579-lagTimeSeconds/reference/api/progress/#successful-response)

## JIRA

[DOCSP-27579](https://jira.mongodb.org/browse/DOCSP-27579)

## Build

* [2024-01-26 1](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b3e89a94771f7657ec592f)
* [2024-01-26 2](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b425b194771f76570628e0)
* [2024-01-29](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b81cd46b2f17c95a94c0c2)