### PR TITLE
DOCSP-23551 Adds reversible note

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -132,6 +132,9 @@ Request Body Parameters
        original source cluster blocks writes and the destination cluster
        accepts writes.
 
+       To reverse sync, the ``enableUserWriteBlocking`` field must be set
+       to ``true``.
+
        Default value is ``false``.
 
    * - ``includeNamespaces``
@@ -158,6 +161,9 @@ Request Body Parameters
      - If set to ``true``, enables the sync operation to be
        reversed. 
 
+       To reverse sync, the ``enableUserWriteBlocking`` field must be set 
+       to ``true``.      
+
        This option is not supported for the following configurations:
 
        * Sync from a replica set to a sharded cluster
@@ -165,7 +171,7 @@ Request Body Parameters
        * Sync sharded clusters that have different numbers of shards
 
        * Reversible sync when ``buildIndexes`` is set to ``never``.
-       
+
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        
        Default value is ``false``.


### PR DESCRIPTION
## Description

Add note to the `/start` endpoint indicating that `enableUserWriteBlocking` must be set to `true` when reversing sync.

## Staging

[start](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-23551-reversible-req/reference/api/start/#request-body-parameters)

## JIRA

[DOCSP-23551](https://jira.mongodb.org/browse/DOCSP-23551)

## Build

* [2024-01-26 1](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b428a594771f7657071a89)
* [2024-02-05](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c14bb96b2f17c95a177957)