### PR TITLE
DOCSP-33399 role limitation

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -24,14 +24,14 @@ Limitations
 General Limitations
 -------------------
 
-.. note:: 
+.. note::
 
-  For information on MongoDB server compatility, see 
+  For information on MongoDB server compatility, see
   :ref:`c2c-server-version-compatibility`.
 
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
-  are properly configured. 
+  are properly configured.
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
 - If write blocking is disabled, the client must :ref:`prevent writes
@@ -52,6 +52,7 @@ General Limitations
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
+- ``mongosync`` doesn't sync users and roles.
 
 MongoDB Community Edition
 -------------------------
@@ -60,7 +61,7 @@ MongoDB does not test {+c2c-product-name+} with Community builds and in
 most cases, MongoDB does not offer support for {+c2c-product-name+} with
 Community deployments. If you would like to use {+c2c-product-name+}
 with MongoDB Community Edition, contact a MongoDB sales representative
-to discuss requirements and individualized options. 
+to discuss requirements and individualized options.
 
 Unsupported Collection Types
 ----------------------------
@@ -81,12 +82,12 @@ Sharded Clusters
     ``sharding.shardingEntries`` option for the :ref:`c2c-api-start`
     command includes during sync. To see limitations on renaming
     collections while ``mongosync`` is running, see :ref:`Renaming
-    During Sync <rename-during-sync>`. 
+    During Sync <rename-during-sync>`.
   - When using the ``sharding.createSupportingIndexes`` option to create
     indexes supporting shard keys on the destination cluster during
     sync, you cannot create these indexes afterwards on the source
-    cluster.  
-    
+    cluster.
+
     The index must either exist before ``mongosync`` starts or be
     created after the migration is complete and ``mongosync`` has
     stopped.
@@ -99,9 +100,9 @@ Sharded Clusters
 - There is no replication for zone configuration. ``mongosync``
   replicates data, it doesn't inherit zones.
 - Shards cannot be added or removed while syncing.
-- ``mongosync`` only syncs indexes that exist on all shards. 
+- ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
-  specifications on all shards. 
+  specifications on all shards.
 
 .. note::
 
@@ -114,9 +115,9 @@ Sharded Clusters
   during syncing.
 - The maximum number of indexes per sharded collection is 63, which is
   one less than the :ref:`default limit
-  <limit-number-of-indexes-per-collection>` of 64. 
-- ``mongosync`` only supports syncing sharded collections that have 
-  default :ref:`collation <collation>` settings. 
+  <limit-number-of-indexes-per-collection>` of 64.
+- ``mongosync`` only supports syncing sharded collections that have
+  default :ref:`collation <collation>` settings.
 
 Reversing
 ---------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -52,6 +52,7 @@ General Limitations
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
+
 - ``mongosync`` doesn't sync users and roles.
 
 MongoDB Community Edition

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -52,7 +52,7 @@ General Limitations
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
-- ``mongosync`` doesn't sync users and roles.
+- ``mongosync`` doesn't sync users or roles.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -52,7 +52,6 @@ General Limitations
 - You cannot sync a collection that has a unique index and a non-unique
   index defined on the same field(s).
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
-
 - ``mongosync`` doesn't sync users and roles.
 
 MongoDB Community Edition


### PR DESCRIPTION
## Description

Adds sync limitation: mongosync does not sync users and roles.

## Staging

* [General Limitations](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-33399-role-limitation/reference/limitations/#general-limitations) (last entry)

## JIRA

[DOCSP-33399](https://jira.mongodb.org/browse/DOCSP-33399)

## Build

* [2024-01-26](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b4300994771f76570acc82)
