### PR TITLE
DOCSP-34408 Updates Role Requirements

### DIFF
--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -18,56 +18,43 @@
 
    * - default
      - destination
-     -
-
-         - :authrole:`readWriteAnyDatabase`
-         - :authrole:`restore`
-         - :authrole:`clusterMonitor`
-         - :authrole:`clusterManager`
+     - - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+       - :authrole:`clusterMonitor`
+       - :authrole:`clusterManager`
 
    * - write-blocking
      - source
-     -  
-
-         - :authrole:`readWriteAnyDatabase`
-         - :authrole:`backup`
-         - :authrole:`restore`
-         - :authrole:`clusterMonitor`
-         - :authrole:`clusterManager`
+     -  - :authrole:`readWriteAnyDatabase`
+        - :authrole:`backup`
+        - :authrole:`restore`
+        - :authrole:`clusterMonitor`
+        - :authrole:`clusterManager`
 
    * - write-blocking
      - destination
-     -
-
-         - :authrole:`readWriteAnyDatabase`
-         - :authrole:`backup`
-         - :authrole:`restore`
-         - :authrole:`clusterMonitor`
-         - :authrole:`clusterManager`
-
+     - - :authrole:`readWriteAnyDatabase`
+       - :authrole:`backup`
+       - :authrole:`restore`
+       - :authrole:`clusterMonitor`
+       - :authrole:`clusterManager`
 
    * - reversing
      - source
-     -  
-
-         - :authrole:`readWriteAnyDatabase`
-         - :authrole:`backup`
-         - :authrole:`restore`
-         - :authrole:`clusterMonitor`
-         - :authrole:`clusterManager`
-         - :authrole:`dbAdmin`
-
+     - - :authrole:`readWriteAnyDatabase`
+       - :authrole:`backup`
+       - :authrole:`restore`
+       - :authrole:`clusterMonitor`
+       - :authrole:`clusterManager`
+       - :authrole:`dbAdmin`
 
    * -  reversing
      - destination
-     -
-
-         - :authrole:`readWriteAnyDatabase`
-         - :authrole:`backup`
-         - :authrole:`restore`
-         - :authrole:`clusterMonitor`
-         - :authrole:`clusterManager`
-
+     - - :authrole:`readWriteAnyDatabase`
+       - :authrole:`backup`
+       - :authrole:`restore`
+       - :authrole:`clusterMonitor`
+       - :authrole:`clusterManager`
 
 For details on server roles, see: :ref:`authorization`.
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -11,7 +11,7 @@
      - Required Source Permissions
      - Required Destination Permissions
 
-   * - default
+   * - Default
      - - :authrole:`backup`
        - :authrole:`clusterMonitor`
        - :authrole:`readAnyDatabase`
@@ -21,7 +21,7 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
-   * - write-blocking
+   * - Write-blocking
      - - :authrole:`backup`
         - :authrole:`clusterManager`
         - :authrole:`clusterMonitor`
@@ -34,7 +34,7 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
-   * - reversing
+   * - Reversing
      - - :authrole:`backup`
         - :authrole:`clusterManager`
         - :authrole:`clusterMonitor`

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -4,6 +4,7 @@
 
 .. list-table::
    :header-rows: 1
+   :widths: 25 25 50
 
    * - Sync Type
      - Target
@@ -14,7 +15,7 @@
      -
 
          - :authrole:`readAnyDatabase`
-         - backup
+         - :authrole:`backup`
          - clusterMonitor
 
    * - default
@@ -26,7 +27,7 @@
          - clusterMonitor
          - clusterManager
 
-   * - write-blocking or reversing
+   * - write-blocking
      - source cluster
      -  
 
@@ -36,7 +37,7 @@
          - clusterMonitor
          - clusterManager
 
-   * - write-blocking or reversing
+   * - write-blocking
      - destination cluster
      -
 
@@ -45,6 +46,29 @@
          - restore
          - clusterMonitor
          - clusterManager
+
+
+   * - reversing
+     - source cluster
+     -  
+
+         - readWriteAnyDatabase
+         - backup
+         - restore
+         - clusterMonitor
+         - clusterManager
+
+
+   * -  reversing
+     - destination cluster
+     -
+
+         - readWriteAnyDatabase
+         - backup
+         - restore
+         - clusterMonitor
+         - clusterManager
+
 
 For details on server roles, see: :ref:`authorization`.
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -40,11 +40,11 @@
         - :authrole:`clusterMonitor`
         - :authrole:`readWriteAnyDatabase`
         - :authrole:`restore`
-        - :authrole:`dbRole`
 
      - - :authrole:`backup`
        - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`
+       - :authrole:`dbAdmin`
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -21,17 +21,26 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
-   * - write-blocking and reversing
+   * - write-blocking
      - - :authrole:`backup`
         - :authrole:`clusterManager`
         - :authrole:`clusterMonitor`
         - :authrole:`readWriteAnyDatabase`
         - :authrole:`restore`
 
-        .. note::
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
 
-           Additionally, to reverse sync, the original destination cluster
-           requires the :authrole:`dbRole` role.
+   * - reversing
+     - - :authrole:`backup`
+        - :authrole:`clusterManager`
+        - :authrole:`clusterMonitor`
+        - :authrole:`readWriteAnyDatabase`
+        - :authrole:`restore`
+        - :authrole:`dbRole`
 
      - - :authrole:`backup`
        - :authrole:`clusterManager`

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -12,11 +12,12 @@
 
    * - default
      - source
-     -
+     - .. hlist::
+          :columns: 2
 
-         - :authrole:`readAnyDatabase`
-         - :authrole:`backup`
-         - :authrole:`clusterMonitor`
+          - :authrole:`readAnyDatabase`
+          - :authrole:`backup`
+          - :authrole:`clusterMonitor`
 
    * - default
      - destination

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -1,6 +1,6 @@
 ..
-   Comment: The nested lists need blank lines before and after each list
-            plus extra indents 
+   Comment: The nested lists need extra indents.  Keep roles in alphabetic
+            order.
 
 .. list-table::
    :header-rows: 1
@@ -13,24 +13,24 @@
 
    * - default
      - source cluster
-     - - :authrole:`readAnyDatabase`
-       - :authrole:`backup`
+     - - :authrole:`backup`
        - :authrole:`clusterMonitor`
+       - :authrole:`readAnyDatabase`
 
    * - default
      - destination cluster
-     - - :authrole:`readWriteAnyDatabase`
-       - :authrole:`restore`
+     - - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`
-       - :authrole:`clusterManager`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
 
    * - write-blocking and reversing
      - source cluster
-     -  - :authrole:`readWriteAnyDatabase`
-        - :authrole:`backup`
-        - :authrole:`restore`
-        - :authrole:`clusterMonitor`
+     - - :authrole:`backup`
         - :authrole:`clusterManager`
+        - :authrole:`clusterMonitor`
+        - :authrole:`readWriteAnyDatabase`
+        - :authrole:`restore`
 
         .. note::
 
@@ -39,12 +39,11 @@
 
    * - write-blocking and reversing
      - destination cluster
-     - - :authrole:`readWriteAnyDatabase`
-       - :authrole:`backup`
-       - :authrole:`restore`
-       - :authrole:`clusterMonitor`
+     - - :authrole:`backup`
        - :authrole:`clusterManager`
-
+       - :authrole:`clusterMonitor`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
 
 For details on server roles, see: :ref:`authorization`.
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -24,7 +24,7 @@
        - :authrole:`clusterMonitor`
        - :authrole:`clusterManager`
 
-   * - write-blocking
+   * - write-blocking and reversing
      - source cluster
      -  - :authrole:`readWriteAnyDatabase`
         - :authrole:`backup`
@@ -32,7 +32,12 @@
         - :authrole:`clusterMonitor`
         - :authrole:`clusterManager`
 
-   * - write-blocking
+        .. note::
+
+           Additionally, to reverse sync, the original destination cluster
+           requires the :authrole:`dbRole` role.
+
+   * - write-blocking and reversing
      - destination cluster
      - - :authrole:`readWriteAnyDatabase`
        - :authrole:`backup`
@@ -40,22 +45,6 @@
        - :authrole:`clusterMonitor`
        - :authrole:`clusterManager`
 
-   * - reversing
-     - source cluster
-     - - :authrole:`readWriteAnyDatabase`
-       - :authrole:`backup`
-       - :authrole:`restore`
-       - :authrole:`clusterMonitor`
-       - :authrole:`clusterManager`
-       - :authrole:`dbAdmin`
-
-   * -  reversing
-     - destination cluster
-     - - :authrole:`readWriteAnyDatabase`
-       - :authrole:`backup`
-       - :authrole:`restore`
-       - :authrole:`clusterMonitor`
-       - :authrole:`clusterManager`
 
 For details on server roles, see: :ref:`authorization`.
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -4,7 +4,8 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 15 15 70
+   :stub-columns: 2
+   :widths: 15 20 65
 
    * - Sync Type
      - Cluster

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -12,12 +12,9 @@
 
    * - default
      - source
-     - .. hlist::
-          :columns: 2
-
-          - :authrole:`readAnyDatabase`
-          - :authrole:`backup`
-          - :authrole:`clusterMonitor`
+     - - :authrole:`readAnyDatabase`
+       - :authrole:`backup`
+       - :authrole:`clusterMonitor`
 
    * - default
      - destination

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -4,7 +4,7 @@
 
 .. list-table::
    :header-rows: 1
-   :stub-columns: 2
+   :stub-columns: 1
    :widths: 15 20 65
 
    * - Sync Type

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -11,20 +11,20 @@
      - Required Permissions
 
    * - default
-     - source
+     - source cluster
      - - :authrole:`readAnyDatabase`
        - :authrole:`backup`
        - :authrole:`clusterMonitor`
 
    * - default
-     - destination
+     - destination cluster
      - - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
        - :authrole:`clusterMonitor`
        - :authrole:`clusterManager`
 
    * - write-blocking
-     - source
+     - source cluster
      -  - :authrole:`readWriteAnyDatabase`
         - :authrole:`backup`
         - :authrole:`restore`
@@ -32,7 +32,7 @@
         - :authrole:`clusterManager`
 
    * - write-blocking
-     - destination
+     - destination cluster
      - - :authrole:`readWriteAnyDatabase`
        - :authrole:`backup`
        - :authrole:`restore`
@@ -40,7 +40,7 @@
        - :authrole:`clusterManager`
 
    * - reversing
-     - source
+     - source cluster
      - - :authrole:`readWriteAnyDatabase`
        - :authrole:`backup`
        - :authrole:`restore`
@@ -49,7 +49,7 @@
        - :authrole:`dbAdmin`
 
    * -  reversing
-     - destination
+     - destination cluster
      - - :authrole:`readWriteAnyDatabase`
        - :authrole:`backup`
        - :authrole:`restore`

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -4,70 +4,71 @@
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 25 50
+   :widths: 15 15 70
 
    * - Sync Type
-     - Target
+     - Cluster
      - Required Permissions
 
    * - default
-     - source cluster
+     - source
      -
 
          - :authrole:`readAnyDatabase`
          - :authrole:`backup`
-         - clusterMonitor
+         - :authrole:`clusterMonitor`
 
    * - default
-     - destination cluster
+     - destination
      -
 
-         - readWriteAnyDatabase
-         - restore
-         - clusterMonitor
-         - clusterManager
+         - :authrole:`readWriteAnyDatabase`
+         - :authrole:`restore`
+         - :authrole:`clusterMonitor`
+         - :authrole:`clusterManager`
 
    * - write-blocking
-     - source cluster
+     - source
      -  
 
-         - readWriteAnyDatabase
-         - backup
-         - restore
-         - clusterMonitor
-         - clusterManager
+         - :authrole:`readWriteAnyDatabase`
+         - :authrole:`backup`
+         - :authrole:`restore`
+         - :authrole:`clusterMonitor`
+         - :authrole:`clusterManager`
 
    * - write-blocking
-     - destination cluster
+     - destination
      -
 
-         - readWriteAnyDatabase
-         - backup
-         - restore
-         - clusterMonitor
-         - clusterManager
+         - :authrole:`readWriteAnyDatabase`
+         - :authrole:`backup`
+         - :authrole:`restore`
+         - :authrole:`clusterMonitor`
+         - :authrole:`clusterManager`
 
 
    * - reversing
-     - source cluster
+     - source
      -  
 
-         - readWriteAnyDatabase
-         - backup
-         - restore
-         - clusterMonitor
-         - clusterManager
+         - :authrole:`readWriteAnyDatabase`
+         - :authrole:`backup`
+         - :authrole:`restore`
+         - :authrole:`clusterMonitor`
+         - :authrole:`clusterManager`
+         - :authrole:`dbAdmin`
 
 
    * -  reversing
-     - destination cluster
+     - destination
      -
 
-         - readWriteAnyDatabase
-         - backup
-         - restore
-         - clusterMonitor
-         - clusterManager
+         - :authrole:`readWriteAnyDatabase`
+         - :authrole:`backup`
+         - :authrole:`restore`
+         - :authrole:`clusterMonitor`
+         - :authrole:`clusterManager`
 
 
 For details on server roles, see: :ref:`authorization`.

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -13,7 +13,7 @@
      - source cluster
      -
 
-         - readAnyDatabase
+         - :authrole:`readAnyDatabase`
          - backup
          - clusterMonitor
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -5,27 +5,23 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 15 20 65
+   :widths: 20 40 40
 
    * - Sync Type
-     - Cluster
-     - Required Permissions
+     - Source Permissions
+     - Destination Permissions
 
    * - default
-     - source cluster
      - - :authrole:`backup`
        - :authrole:`clusterMonitor`
        - :authrole:`readAnyDatabase`
 
-   * - default
-     - destination cluster
      - - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
    * - write-blocking and reversing
-     - source cluster
      - - :authrole:`backup`
         - :authrole:`clusterManager`
         - :authrole:`clusterMonitor`
@@ -37,8 +33,6 @@
            Additionally, to reverse sync, the original destination cluster
            requires the :authrole:`dbRole` role.
 
-   * - write-blocking and reversing
-     - destination cluster
      - - :authrole:`backup`
        - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -8,8 +8,8 @@
    :widths: 20 40 40
 
    * - Sync Type
-     - Source Permissions
-     - Destination Permissions
+     - Required Source Permissions
+     - Required Destination Permissions
 
    * - default
      - - :authrole:`backup`


### PR DESCRIPTION
## Description

Reworks the table of roles required for self-managed clusters to include `dbAdmin` on destination cluster for reversing sync.  Also updates the listed roles to render as links.

## Staging

[Table](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-34408-req-roles/reference/permissions/#self-managed-clusters)

## Jira

* [DOCSP-34408](https://jira.mongodb.org/browse/DOCSP-34408)

## Build
* [2024-01-29](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65b82aa86b2f17c95a9abe96)
* [2024-01-31](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ba7beb6b2f17c95a52292b)
* [2024-02-01](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bbf0636b2f17c95acc1ec6)
* [2024-02-02](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bd34e16b2f17c95a2e7f84)