### PR TITLE
DOCSP-24946 Clarifies estimatedTotalBytes and estimatedCopiedBytes

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -57,14 +57,15 @@
    * - ``collectionCopy``
        ``.estimatedTotalBytes``
      - integer
-     - Estimated total number of bytes to be copied globally by all ``mongosync``
-       instances.
+     - Estimated total number of bytes to be copied globally by all
+       ``mongosync`` instances during the initial copying of collections.
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
      - integer
-     - Estimated number of bytes which have been copied to the
-       destination cluster by this ``mongosync`` instance.
+     - Estimated number of bytes which have been copied to the destination
+       cluster by this ``mongosync`` instance during the initial copying of 
+       collections.
 
        To calculate the total estimated progress as a percentage, add the value
        of the ``estimatedCopiedBytes`` field for each ``mongosync`` instance

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -51,8 +51,8 @@
 
    * - ``collectionCopy``
      - object
-     - Describes the total amount of data being copied and the
-       amount that has already been copied to the destination cluster.
+     - Estimates the total amount of data being copied from collections and the
+       amount that has already been copied to the destination cluster
 
    * - ``collectionCopy``
        ``.estimatedTotalBytes``


### PR DESCRIPTION
## Description

Clarifies that `estimatedTotalBytes` and `estimatedCopiedBytes` refer to the initial collection copy.

## Staging
* [/progress Response](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-24946-collectionCopy/reference/api/progress/#successful-response)

## JIRA

[DOCSP-24946](https://jira.mongodb.org/browse/DOCSP-24946)

## Build

* [2024-02-01](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65bc22406b2f17c95ae23547)
* [2024-02-12](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ca94c1cbcd269fa5879ec3)