### PR TITLE
DOCSP-25143 Adds /reverse to COMMITTED state

### DIFF
--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -77,3 +77,4 @@ operations in that state.
    * - ``COMMITTED``
      - The cutover for the sync process is complete.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
+       - ``GET`` :ref:`/reverse <c2c-api-reverse>`


### PR DESCRIPTION
## Description

Adds `/reverse` endpoint to the `COMMITTED` state.

## Staging

[States](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-25143-reversible-state/reference/mongosync-states/#state-descriptions)

## JIRA

* [DOCSP-25143](https://jira.mongodb.org/browse/DOCSP-25143)

## Build

* [2024-02-08](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c552986b2f17c95a510bd2)
* [2024-02-13](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65cbe086cbcd269fa5e4481b)