### PR TITLE
DOCSP-36175 Clarify mongosync's lagTimeSeconds field

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -40,14 +40,20 @@
 
    * - ``lagTimeSeconds``
      - integer
-     - Time in seconds between the last applied event and time of the
-       current latest event for this instance of ``mongosync``.
+     - Time difference in seconds between the latest event timestamp that
+       ``mongosync`` applied to the destination cluster and the latest
+       timestamp on the source cluster for this instance of ``mongosync``.
 
        .. note::
 
           ``mongosync`` performs periodic no-op writes on the source cluster,
           which may prevent the value of the ``lagTimeSeconds`` field from
-          reaching zero.
+          reaching zero until ``mongosync`` commits the migration.
+
+       Due to constant no-ops on the source cluster, the time difference
+       is often a few seconds above zero even if there are no real
+       writes on the source cluster. The time difference becomes zero
+       when ``mongosync`` commits the migration.
 
    * - ``collectionCopy``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -51,7 +51,7 @@
           reaching zero until ``mongosync`` commits the migration.
 
        Due to constant no-ops on the source cluster, the time difference
-       is often a few seconds above zero even if there are no real
+       is often a few seconds above zero, even if there are no real
        writes on the source cluster. The time difference becomes zero
        when ``mongosync`` commits the migration.
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -28,7 +28,7 @@ Request
 Response
 --------
 
-The ``progress`` endpoint returns etiher an updated status or an error.
+The ``progress`` endpoint returns either an updated status or an error.
 
 Successful Response
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCSP-36175)
- [Stage](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCSP-36175/reference/api/progress/#successful-response)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c664c76b2f17c95a97c02e)