### PR TITLE
DOCSP-36932 RN for 1.7.2

### DIFF
--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -9,7 +9,7 @@ on the source cluster, the sync fails and ``mongosync`` exits.
    .. include:: /includes/fact-applyOps.rst
 
 During the initial sync, ``mongosync`` may apply operations at a slower
-rate due to the load imposed by copying documents concurrently.
+rate due to copying documents concurrently.
 After the initial sync, ``mongosync`` applies changes 
 faster and is more likely to maintain a position in the ``oplog``
 that is close to the real-time writes occurring on the source cluster.

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -8,22 +8,14 @@ on the source cluster, the sync fails and ``mongosync`` exits.
 
    .. include:: /includes/fact-applyOps.rst
 
-Starting in version 1.5.0, ``mongosync`` enables Oplog Rollover
-Resilience (ORR).  With ORR,  ``mongosync`` applies changes on the
-source cluster to the destination cluster during the initial sync. ORR
-increases the resilience of ``mongosync`` to oplog rollover but does not
-prevent rollover entirely.
+During the initial sync, ``mongosync`` may apply operations at a slower
+rate due to the load imposed by copying documents concurrently.
+After ``mongosync`` completes the initial sync, it applies changes 
+faster and is more likely to maintain a position in the ``oplog``
+that is close to the real-time writes occurring on the source cluster.
 
-You might exceed the oplog window if you: 
-
-- Sync from a high write rate source cluster for an extended
-  period.
-- Pause sync for an extended period.
-
-To increase the size of the ``oplog`` on the source cluster, use
-:setting:`~replication.oplogSizeMB`. For more information, see
-:ref:`Change Oplog Size <tutorial-change-oplog-size>` and
-:ref:`Workloads that Might Requre a Large Oplog Size
-<replica-set-large-oplog-required>`.
-
+If you anticipate syncing a large data set, or if you plan to pause
+synchronization for an extended period of time, you might exceed the
+:term:`oplog window`. Use the :setting:`~replication.oplogSizeMB` setting
+to increase the size of the ``oplog`` on the source cluster.
 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -10,7 +10,7 @@ on the source cluster, the sync fails and ``mongosync`` exits.
 
 During the initial sync, ``mongosync`` may apply operations at a slower
 rate due to the load imposed by copying documents concurrently.
-After ``mongosync`` completes the initial sync, it applies changes 
+After the initial sync, ``mongosync`` applies changes 
 faster and is more likely to maintain a position in the ``oplog``
 that is close to the real-time writes occurring on the source cluster.
 

--- a/source/includes/read-preference-connection-string.rst
+++ b/source/includes/read-preference-connection-string.rst
@@ -1,5 +1,5 @@
 
 ``mongosync`` requires the :readmode:`primary` read preference
-to connect to the source cluster.  For more information on read
-preference, see :ref:`connections-read-preference`.
+to connect to the source cluster. For more information on read
+preferences, see :ref:`connections-read-preference`.
 

--- a/source/includes/read-preference-connection-string.rst
+++ b/source/includes/read-preference-connection-string.rst
@@ -1,5 +1,4 @@
 
 ``mongosync`` requires the :readmode:`primary` read preference
-to connect to the source cluster. For more information on read
-preferences, see :ref:`connections-read-preference`.
+to connect to the source cluster. For more information, see :ref:`connections-read-preference`.
 

--- a/source/includes/read-preference-connection-string.rst
+++ b/source/includes/read-preference-connection-string.rst
@@ -1,5 +1,5 @@
-You can also specify read preference on a per-connection basis in the
-connection string. By default, ``mongosync`` sets the source cluster
-read preference to :readmode:`nearest` to distribute reads evenly across
-nodes. For more information on setting read preference in connection
-strings, see :ref:`connections-read-preference`.
+
+``mongosync`` requires the :readmode:`primary` read preference
+to connect to the source cluster.  For more information on read
+preference, see :ref:`connections-read-preference`.
+

--- a/source/multiple-mongosyncs.txt
+++ b/source/multiple-mongosyncs.txt
@@ -18,6 +18,13 @@ There are two ways to synchronize :ref:`sharded clusters
 loaded clusters, use one ``mongosync`` instance for each shard on the
 source cluster.
 
+.. important::
+
+   When the source cluster is a sharded cluster, stop the
+   balancer and don't run the :dbcommand:`moveChunk` or
+   :dbcommand:`moveRange` commands until ``mongosync`` reaches
+   the collection copy phase.
+
 .. _c2c-sharded-config-single:
 
 Configure a Single ``mongosync`` Instance

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -122,7 +122,7 @@ Sharded Clusters
      starting ``mongosync``. This gives the cluster time to
      finish any in progress chunk migrations.
 
-- You must not run the  :dbcommand:`moveChunk` and
+- You must not run the :dbcommand:`moveChunk` and
   :dbcommand:`moveRange` commands on the source cluster.
 - The shard key cannot be :ref:`refined <shard-key-refine>` while
   syncing.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -107,9 +107,17 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
-- You must stop the balancer on a sharded source cluster until mongosync finishes the collection copy phase.
-- You can not run the  :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
-   on the source cluster.
+- You must stop the balancer on a sharded source cluster until
+  mongosync finishes the collection copy phase.
+
+  .. note::
+
+     After stopping the balancer, wait fifteen minutes before
+     starting ``mongosync``. This gives the cluster time to
+     finish any in process chunk migrations.
+
+- You can not run the  :dbcommand:`moveChunk` and
+  :dbcommand:`moveRange` commands on the source cluster.
 
 
 .. note::

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -52,6 +52,9 @@ General Limitations
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
 - ``mongosync`` doesn't sync users or roles.
 - .. include:: /includes/fact-applyOps.rst
+- mongosync must read from the source cluster using the 
+  :readmode:`primary` read preference.
+
 
 MongoDB Community Edition
 -------------------------
@@ -104,6 +107,11 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
+- The balancer must be stopped on a sharded source cluster until
+  until mongosync finishes the collection copy phase.
+- The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
+  must not be run on the source cluster.
+
 
 .. note::
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -122,7 +122,7 @@ Sharded Clusters
      starting ``mongosync``. This gives the cluster time to
      finish any in progress chunk migrations.
 
-- You can not run the  :dbcommand:`moveChunk` and
+- You must not run the  :dbcommand:`moveChunk` and
   :dbcommand:`moveRange` commands on the source cluster.
 - The shard key cannot be :ref:`refined <shard-key-refine>` while
   syncing.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -52,7 +52,7 @@ General Limitations
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
 - ``mongosync`` doesn't sync users or roles.
 - .. include:: /includes/fact-applyOps.rst
-- mongosync must read from the source cluster using the 
+- ``mongosync`` must read from the source cluster using the 
   :readmode:`primary` read preference.
 
 
@@ -107,10 +107,9 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
-- The balancer must be stopped on a sharded source cluster until
-  until mongosync finishes the collection copy phase.
-- The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
-  must not be run on the source cluster.
+- You must stop the balancer on a sharded source cluster until mongosync finishes the collection copy phase.
+- You can not run the  :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
+   on the source cluster.
 
 
 .. note::

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -107,6 +107,12 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
+
+  .. note::
+
+     To check for index inconsistencies, see :ref:`Find Inconsistent
+     Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.
+
 - You must stop the balancer on a sharded source cluster until
   mongosync finishes the collection copy phase.
 
@@ -118,13 +124,6 @@ Sharded Clusters
 
 - You can not run the  :dbcommand:`moveChunk` and
   :dbcommand:`moveRange` commands on the source cluster.
-
-
-.. note::
-
-  To check for index inconsistencies, see :ref:`Find Inconsistent
-  Indexes Across Shards <manage-indexes-find-inconsistent-indexes>`.
-
 - The shard key cannot be :ref:`refined <shard-key-refine>` while
   syncing.
 - The :dbcommand:`reshardCollection` operations from the source cluster

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -114,7 +114,7 @@ Sharded Clusters
 
      After stopping the balancer, wait fifteen minutes before
      starting ``mongosync``. This gives the cluster time to
-     finish any in process chunk migrations.
+     finish any in progress chunk migrations.
 
 - You can not run the  :dbcommand:`moveChunk` and
   :dbcommand:`moveRange` commands on the source cluster.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -274,11 +274,9 @@ behavior, see :ref:`read-concern` and :ref:`write-concern`.
 Read Preference
 ~~~~~~~~~~~~~~~
 
-By default, ``mongosync`` sets the source cluster read preference to
-:readmode:`nearest` to distribute reads evenly across nodes. To change
-the read preference of the source cluster, specify the read preference
-mode in the URI of the connection string. For details, see
-:ref:`connections-read-preference`. 
+``mongosync`` requires the :readmode:`primary` read preference
+when connecting to the source cluster. For more information on
+read preferences, see :ref:`connections-read-preference`. 
 
 .. _c2c-capped-collections:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -275,8 +275,8 @@ Read Preference
 ~~~~~~~~~~~~~~~
 
 ``mongosync`` requires the :readmode:`primary` read preference
-when connecting to the source cluster. For more information on
-read preferences, see :ref:`connections-read-preference`. 
+when connecting to the source cluster. For more information, see
+:ref:`connections-read-preference`. 
 
 .. _c2c-capped-collections:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -62,7 +62,7 @@ Issues Fixed:
 
 Other Changes:
 
-- Disables the Oplog Rollover Resilience machanism. 
+- Disables the Oplog Rollover Resilience mechanism. 
 
 - Live upgrade to mongosync 1.7.2 is not allowed.
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -46,6 +46,8 @@ Other Changes:
 
 - Disables the Oplog Rollover Resilience machanism. 
 
+- Live upgrade to mongosync 1.7.2 is not allowed.
+
 - Reduces latency of the mongosync API.
 
 Limitations:

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -24,23 +24,42 @@ Patch Releases
 
 Issues Fixed:
 
-- Fixed a bug causing mongosync to error out due to index
-  inconsistencies in background keys between shards, which the
-  server ignores.
-- Fixed a bug where mongosync could miss change events if stopped
-  or paused then resumed during the collection copy phase.  
+- Fixed bug introduced in v1.5.0 that could result in data
+  inconsistencies when mongosync is killed or paused during
+  the initial collection copy phase and then resumed.
 
-  This can happen when the destination cluster runs MongoDB 4.x
-  and the migration includes collections with mixed ``_id``
-  types or when the destination is MongoDB 6.0+ and the
-  migration includes capped collections.
+  This can only affect migrations where the destination server
+  runs:
 
-- Fixed a bug where indexes could be created on the destination
-  cluster during migration even when dropped on the source
-  cluster.
+  - MongoDB 4.4 and earlier and the migration includes mixed _id
+    types.
 
-- Fixed a bug where change events could be applied to the wrong
-  collection during concurrent collection renames.
+  - MongoDB 6.0 and later and the migration includes capped
+    collections.
+
+- Fixed bug introduced in v1.0.0 where indexes could be created
+  on the destination cluster that were dropped on the source
+  cluster during migration.
+
+  This can only affect migrations where the given index is both
+  created and dropped while mongosync is running.
+
+- Fixed bug introduced in v1.0.0 that could result in
+  collections being created on the destination cluster with
+  incorrect types, options, or indexes.
+
+  This can only affect migrations where collections are dropped
+  or renamed while mongosync is running and the source or
+  destintion cluster runs MongoDB 6.0.0 to 6.0.12 or MongoDB
+  7.0.0 or 7.0.3.
+
+- Fixed bug introduced in v1.1.0 that could result in a
+  mongosync crash if shard key indexes on the source cluster
+  have inconsistent values across shards for the "background"
+  index build option.
+
+  This can only affect migrations that involve sharded
+  collections and source clusters older than MongoDB 6.0.
 
 Other Changes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -28,13 +28,13 @@ Issues Fixed:
   inconsistencies when mongosync is killed or paused during
   the initial collection copy phase and then resumed.
 
-  This can only affect migrations where the destination cluster
+  This can only affect migrations if the destination cluster
   runs:
 
-  - MongoDB 4.4 and earlier and the migration includes mixed _id
+  - MongoDB 4.4 and earlier where the migration includes mixed _id
     types.
 
-  - MongoDB 6.0 and later and the migration includes capped
+  - MongoDB 6.0 and later where the migration includes capped
     collections.
 
 - Fixed bug introduced in v1.0.0 where indexes could be created

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -25,7 +25,7 @@ Patch Releases
 Issues Fixed:
 
 * Fixed a bug causing mongosync to error out due to index
-  inconsistencies between shards in background keys, which the
+  inconsistencies in background keys between shards, which the
   server ignores.
 
 .. _1.7.1-c2c-release-notes:

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -28,7 +28,7 @@ Issues Fixed:
   inconsistencies when mongosync is killed or paused during
   the initial collection copy phase and then resumed.
 
-  This can only affect migrations if: 
+  This can only affect migrations if:
 
   - The migration includes mixed _id types and the destination
     cluster runs MongoDB 4.4 or earlier.
@@ -62,7 +62,7 @@ Issues Fixed:
 
 Other Changes:
 
-- Disables the Oplog Rollover Resilience mechanism. 
+- Disables the Oplog Rollover Resilience mechanism.
 
 - Live upgrade to mongosync 1.7.2 is not allowed.
 
@@ -70,7 +70,7 @@ Other Changes:
 
 Limitations:
 
-- mongosync must read from the source cluster using the 
+- mongosync must read from the source cluster using the
   :readmode:`primary` read preference. If you try to start mongosync
   with a different read preference, it throws an error.
 
@@ -79,7 +79,7 @@ Limitations:
   start mongosync while the balancer is still running, it throws
   an error.
 
-- You must not run the :dbcommand:`moveChunk` or :dbcommand:`moveRange` 
+- You must not run the :dbcommand:`moveChunk` or :dbcommand:`moveRange`
   commands on the source cluster. If these are run on the
   source cluster, mongosync throws an error.
 
@@ -132,7 +132,7 @@ Issues Fixed:
   capped collection during migration, before or while the Collection Copy phase
   is working on the same capped collection.
 
-- Fixed bug introduced in 1.6 that caused ``mongosync`` to fail during 
+- Fixed bug introduced in 1.6 that caused ``mongosync`` to fail during
   initialization if the user specified only an exclusion filter and there were
   no fully excluded databases.
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -72,16 +72,16 @@ Other Changes:
 Limitations:
 
 - mongosync must read from the source cluster using the 
-  :readmode:`primary` read preference.  If you try to start mongosync
+  :readmode:`primary` read preference. If you try to start mongosync
   with a different read preference, it throws an error.
 
 - You must stop the balancer on a sharded source cluster until
-  mongosync finishes the collection copy phase.  If you try to
+  mongosync finishes the collection copy phase. If you try to
   start mongosync while the balancer is still running, it throws
   an error.
 
 - You must not run the :dbcommand:`moveChunk` or :dbcommand:`moveRange` 
-  commands on the source cluster.  If these are run on the
+  commands on the source cluster. If these are run on the
   source cluster, mongosync throws an error.
 
 .. _1.7.1-c2c-release-notes:

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -31,11 +31,11 @@ Issues Fixed:
   This can only affect migrations if the destination cluster
   runs:
 
-  - MongoDB 4.4 and earlier where the migration includes mixed _id
-    types.
+  - The migration includes mixed _id types and the destination
+    cluster runs MongoDB 4.4 or earlier.
 
-  - MongoDB 6.0 and later where the migration includes capped
-    collections.
+  - The migration includes capped collections and the
+    destination cluster runs MongoDB 6.0 or later.
 
 - Fixed bug introduced in v1.0.0 where indexes could be created
   on the destination cluster that were dropped on the source

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -77,8 +77,8 @@ Limitations:
 - You must stop the balancer on a sharded source cluster until
   mongosync finishes the collection copy phase.
 
-- The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
-  must not run on the source cluster.
+- You must not run the :dbcommand:`moveChunk` or :dbcommand:`moveRange` 
+  commands on the source cluster.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -50,12 +50,14 @@ Other Changes:
 
 Limitations:
 
-* ``mongosync`` must read from the source cluster using the 
+* mongosync must read from the source cluster using the 
   :readmode:`primary` read preference.
 
-Mongosync must read from the source cluster using read preference "primary". 
-The source cluster's balancer must be off from the time that mongosync starts until it finishes the Collection Copy phase.
-The source cluster must not undergo any moveChunk or moveRange commands.
+* The balancer must be stopped on a sharded source cluster until
+  until mongosync finishes the collection copy phase.
+
+* The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
+  must not be run on the source cluster.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -27,6 +27,29 @@ Issues Fixed:
 * Fixed a bug causing mongosync to error out due to index
   inconsistencies in background keys between shards, which the
   server ignores.
+* Fixed a bug where mongosync could miss change events if stopped
+  or paused then resumed during the collection copy phase.  
+
+  This can happen when the destination cluster runs MongoDB 4.x
+  and the migration includes collections with mixed ``_id``
+  types or when the destination is MongoDB 6.0+ and the
+  migration includes capped collections.
+
+* Fixed a bug where indexes could be created on the destination
+  cluster during migration even when dropped on the source
+  cluster.
+
+* Fixed a bug where change events could be applied to the wrong
+  collection during concurrent collection renames.
+
+Other Changes:
+
+* Disables the Oplog Rollover Resilience machanism. 
+
+* Reduces latency of the mongosync API.
+
+.. REP-4188: (Evgeni Dobranov to add details on the 3 changes needed)
+
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -25,7 +25,8 @@ Patch Releases
 Issues Fixed:
 
 * Fixed a bug causing mongosync to error out due to index
-  inconsistencies in background keys, which the server ignores.
+  inconsistencies between shards in background keys, which the
+  server ignores.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -48,8 +48,14 @@ Other Changes:
 
 * Reduces latency of the mongosync API.
 
-.. REP-4188: (Evgeni Dobranov to add details on the 3 changes needed)
+Limitations:
 
+* ``mongosync`` must read from the source cluster using the 
+  :readmode:`primary` read preference.
+
+Mongosync must read from the source cluster using read preference "primary". 
+The source cluster's balancer must be off from the time that mongosync starts until it finishes the Collection Copy phase.
+The source cluster must not undergo any moveChunk or moveRange commands.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -24,10 +24,10 @@ Patch Releases
 
 Issues Fixed:
 
-* Fixed a bug causing mongosync to error out due to index
+- Fixed a bug causing mongosync to error out due to index
   inconsistencies in background keys between shards, which the
   server ignores.
-* Fixed a bug where mongosync could miss change events if stopped
+- Fixed a bug where mongosync could miss change events if stopped
   or paused then resumed during the collection copy phase.  
 
   This can happen when the destination cluster runs MongoDB 4.x
@@ -35,28 +35,28 @@ Issues Fixed:
   types or when the destination is MongoDB 6.0+ and the
   migration includes capped collections.
 
-* Fixed a bug where indexes could be created on the destination
+- Fixed a bug where indexes could be created on the destination
   cluster during migration even when dropped on the source
   cluster.
 
-* Fixed a bug where change events could be applied to the wrong
+- Fixed a bug where change events could be applied to the wrong
   collection during concurrent collection renames.
 
 Other Changes:
 
-* Disables the Oplog Rollover Resilience machanism. 
+- Disables the Oplog Rollover Resilience machanism. 
 
-* Reduces latency of the mongosync API.
+- Reduces latency of the mongosync API.
 
 Limitations:
 
-* mongosync must read from the source cluster using the 
+- mongosync must read from the source cluster using the 
   :readmode:`primary` read preference.
 
-* The balancer must be stopped on a sharded source cluster until
+- The balancer must be stopped on a sharded source cluster until
   until mongosync finishes the collection copy phase.
 
-* The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
+- The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
   must not be run on the source cluster.
 
 .. _1.7.1-c2c-release-notes:

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -72,13 +72,17 @@ Other Changes:
 Limitations:
 
 - mongosync must read from the source cluster using the 
-  :readmode:`primary` read preference.
+  :readmode:`primary` read preference.  If you try to start mongosync
+  with a different read preference, it throws an error.
 
 - You must stop the balancer on a sharded source cluster until
-  mongosync finishes the collection copy phase.
+  mongosync finishes the collection copy phase.  If you try to
+  start mongosync while the balancer is still running, it throws
+  an error.
 
 - You must not run the :dbcommand:`moveChunk` or :dbcommand:`moveRange` 
-  commands on the source cluster.
+  commands on the source cluster.  If these are run on the
+  source cluster, mongosync throws an error.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -15,6 +15,18 @@ Release Notes for mongosync 1.7
 Patch Releases
 --------------
 
+.. _1.7.2-c2c-release-notes:
+
+1.7.2 Release
+~~~~~~~~~~~~~
+
+**February 21, 2024**
+
+Issues Fixed:
+
+* Fixed a bug causing mongosync to error out due to index
+  inconsistencies in background keys, which the server ignores.
+
 .. _1.7.1-c2c-release-notes:
 
 1.7.1 Release

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -28,8 +28,7 @@ Issues Fixed:
   inconsistencies when mongosync is killed or paused during
   the initial collection copy phase and then resumed.
 
-  This can only affect migrations if the destination cluster
-  runs:
+  This can only affect migrations if: 
 
   - The migration includes mixed _id types and the destination
     cluster runs MongoDB 4.4 or earlier.

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -28,7 +28,7 @@ Issues Fixed:
   inconsistencies when mongosync is killed or paused during
   the initial collection copy phase and then resumed.
 
-  This can only affect migrations where the destination server
+  This can only affect migrations where the destination cluster
   runs:
 
   - MongoDB 4.4 and earlier and the migration includes mixed _id

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -55,11 +55,11 @@ Limitations:
 - mongosync must read from the source cluster using the 
   :readmode:`primary` read preference.
 
-- The balancer must be stopped on a sharded source cluster until
-  until mongosync finishes the collection copy phase.
+- You must stop the balancer on a sharded source cluster until
+  mongosync finishes the collection copy phase.
 
 - The :dbcommand:`moveChunk` and :dbcommand:`moveRange` commands
-  must not be run on the source cluster.
+  must not run on the source cluster.
 
 .. _1.7.1-c2c-release-notes:
 

--- a/source/using-mongosync.txt
+++ b/source/using-mongosync.txt
@@ -1,4 +1,5 @@
 :orphan:
+
 .. place holder for the using mongosync section TOC
 .. _c2c-running-mongosync:
 .. _c2c-using-mongosync:

--- a/source/using-mongosync.txt
+++ b/source/using-mongosync.txt
@@ -1,3 +1,4 @@
+:orphan:
 .. place holder for the using mongosync section TOC
 .. _c2c-running-mongosync:
 .. _c2c-using-mongosync:


### PR DESCRIPTION
## Description

Adds release notes for v1.7.2.

## Staging

* [RN](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/release-notes/1.7/#1.7.2-release)
* [General Limitations](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/reference/limitations/#general-limitations) (last bullet)
* [Sharded Limitations](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/reference/limitations/#sharded-clusters) (last two bullets)
* [Sharded Sync](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/multiple-mongosyncs/) (important admonition at top of page).
* [Read Preference](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/reference/mongosync/#read-preference)
* [oplog Sizing](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-35932-1.7.2-RN/reference/oplog-sizing/) (reverts intro text)

## Jira

[DOCSP-36932](https://jira.mongodb.org/browse/DOCSP-36932)

## Build

* [2024-02-16.1](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65cf7a84711116598247bdf0)