### PR TITLE
DOCSP 30174 clarifying estimatedCopiedByes and estimatedTotalBytes

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -72,8 +72,8 @@
          ``mongosync`` approximates the estimated total number of bytes
          prior to migration and does not update this value during
          migration. This value does not reflect changes to the source
-         cluster during migration and should not be used as an indicator
-         of migration progress. 
+         cluster during migration and is not an accurate indicator of
+         migration progress. 
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
@@ -92,8 +92,8 @@
          ``mongosync`` approximates the estimated number of copied bytes
          prior to migration and does not update this value during
          migration. This value does not reflect changes to the source
-         cluster during migration and should not be used as an indicator
-         of migration progress. 
+         cluster during migration and is not an accurate indicator of
+         migration progress. 
 
 
    * - ``directionMapping``

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -70,10 +70,10 @@
        .. note::
 
          ``mongosync`` approximates the estimated total number of bytes
-         prior to migration and does not update this value during
-         migration. This value does not reflect changes to the source
-         cluster during migration and is not an accurate indicator of
-         migration progress. 
+         prior to migration and does not update this value during the
+         synchronization process. This value does not reflect changes
+         made to the source cluster during sync and is not an accurate
+         indicator of migration progress. 
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
@@ -91,8 +91,8 @@
 
          ``mongosync`` approximates the estimated number of copied bytes
          prior to migration and does not update this value during
-         migration. This value does not reflect changes to the source
-         cluster during migration and is not an accurate indicator of
+         migration. This value does not reflect changes made to the
+         source cluster during sync and is not an accurate indicator of
          migration progress. 
 
 

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -64,7 +64,16 @@
        ``.estimatedTotalBytes``
      - integer
      - Estimated total number of bytes to be copied globally by all
-       ``mongosync`` instances during the initial copying of collections.
+       ``mongosync`` instances during the initial copying of
+       collections.
+       
+       .. note::
+
+         ``mongosync`` approximates the estimated total number of bytes
+         prior to migration and does not update this value during
+         migration. This value does not reflect changes to the source
+         cluster during migration and should not be used as an indicator
+         of migration progress. 
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
@@ -77,6 +86,15 @@
        of the ``estimatedCopiedBytes`` field for each ``mongosync`` instance
        and divide the result by the value of the ``estimatedTotalBytes`` field
        . Then, multiply the result by 100.
+
+       .. note::
+
+         ``mongosync`` approximates the estimated number of copied bytes
+         prior to migration and does not update this value during
+         migration. This value does not reflect changes to the source
+         cluster during migration and should not be used as an indicator
+         of migration progress. 
+
 
    * - ``directionMapping``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -88,16 +88,7 @@
        . Then, multiply the result by 100.
 
        The value of ``estimatedCopiedBytes`` may be larger than the
-       value of the ``estimatedTotalBytes`` due to retried operations. 
-
-       .. note::
-
-         ``mongosync`` approximates the estimated number of copied bytes
-         prior to migration and does not update this value during the
-         synchronization process. This value does not reflect changes
-         made to the source cluster during sync and is not an accurate
-         indicator of migration progress. 
-
+       value of the ``estimatedTotalBytes`` due to retried operations.
 
    * - ``directionMapping``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -87,8 +87,8 @@
        and divide the result by the value of the ``estimatedTotalBytes`` field
        . Then, multiply the result by 100.
 
-       The estimated copied bytes may be larger than the estimated total
-       bytes due to retried operations. 
+       The value of ``estimatedCopiedBytes`` may be larger than the
+       value of the ``estimatedTotalBytes`` due to retried operations. 
 
        .. note::
 

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -87,8 +87,13 @@
        and divide the result by the value of the ``estimatedTotalBytes`` field
        . Then, multiply the result by 100.
 
-       The value of ``estimatedCopiedBytes`` may be larger than the
-       value of the ``estimatedTotalBytes`` due to retried operations.
+       .. note::
+
+         The value of ``estimatedCopiedBytes`` may be larger than the
+         value of the ``estimatedTotalBytes`` due to retried operations.
+         A comparison of ``estimatedTotalBytes`` and
+         ``estimatedCopiedBytes`` is not an accurate indicator of
+         migration progress.  
 
    * - ``directionMapping``
      - object

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -90,10 +90,10 @@
        .. note::
 
          ``mongosync`` approximates the estimated number of copied bytes
-         prior to migration and does not update this value during
-         migration. This value does not reflect changes made to the
-         source cluster during sync and is not an accurate indicator of
-         migration progress. 
+         prior to migration and does not update this value during the
+         synchronization process. This value does not reflect changes
+         made to the source cluster during sync and is not an accurate
+         indicator of migration progress. 
 
 
    * - ``directionMapping``

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -87,6 +87,9 @@
        and divide the result by the value of the ``estimatedTotalBytes`` field
        . Then, multiply the result by 100.
 
+       The estimated copied bytes may be larger than the estimated total
+       bytes due to retried operations. 
+
        .. note::
 
          ``mongosync`` approximates the estimated number of copied bytes


### PR DESCRIPTION
## DESCRIPTION

clarifying that estimatedCopiedByes and estimatedTotalBytes are approximated before migration and should not be used as an indicator of progress. 

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-30174/reference/api/progress/#successful-response

## JIRA

https://jira.mongodb.org/browse/DOCSP-30174

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65d7783e7111165982411eb5

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
