### PR TITLE
DOCSP-34589 clarify multiple mongosync limitations

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -137,6 +137,8 @@ Multiple Clusters
 - One cluster cannot simultaneously be a source cluster in one
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 
+- To sync a source cluster to multiple destination clusters, use
+   one ``mongosync`` instance for each destination cluster. 
 
 .. _c2c-filtering-limitations:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -129,6 +129,8 @@ Reversing
   Ensure that unique indexes exist on all shards before reversing.
 - .. include:: /includes/fact-reverse-limitation.rst
 
+.. _multiple-clusters-limitations:
+
 Multiple Clusters
 -----------------
 
@@ -137,8 +139,6 @@ Multiple Clusters
 - One cluster cannot simultaneously be a source cluster in one
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 
--  To sync a source cluster to multiple destination clusters, use one
-   ``mongosync`` instance for each destination cluster. 
 
 .. _c2c-filtering-limitations:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -134,8 +134,11 @@ Multiple Clusters
 
 - Syncing multiple source clusters to one destination cluster isn't
   supported.
-- Syncing one source cluster to many destination clusters isn't
-  supported.
+- One ``mongosync`` instance cannot sync one source cluster to many
+  destination clusters.
+- A source cluster in one ``mongosync`` instance
+  cannot simultaneously be a destination cluster in another
+  ``mongosync`` instance. 
 
 .. _c2c-filtering-limitations:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -132,12 +132,12 @@ Reversing
 Multiple Clusters
 -----------------
 
-- Syncing multiple source clusters to one destination cluster isn't
-  supported.
-- One ``mongosync`` instance cannot sync one source cluster to many
+- ``mongosync`` does not support syncing multiple source clusters to one
+  destination cluster. 
+- One ``mongosync`` instance cannot sync a source cluster to many
   destination clusters.
-- A source cluster in one ``mongosync`` instance
-  cannot simultaneously be a destination cluster in another
+- One cluster cannot simultaneously be a source cluster in one
+  ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 
 
 .. _c2c-filtering-limitations:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -134,14 +134,6 @@ Multiple Clusters
 
 - ``mongosync`` does not support syncing multiple source clusters to one
   destination cluster. 
-- One ``mongosync`` instance cannot sync a source cluster to many
-  destination clusters.
-
-.. note::
-
-   To sync a source cluster to multiple destination clusters, use
-   one ``mongosync`` instance for each destination cluster. 
-
 - One cluster cannot simultaneously be a source cluster in one
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -136,6 +136,12 @@ Multiple Clusters
   destination cluster. 
 - One ``mongosync`` instance cannot sync a source cluster to many
   destination clusters.
+
+.. note::
+
+   To sync a source cluster to multiple destination clusters, use
+   one ``mongosync`` instance for each destination cluster. 
+
 - One cluster cannot simultaneously be a source cluster in one
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -138,7 +138,7 @@ Multiple Clusters
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 
 -  To sync a source cluster to multiple destination clusters, use one
-  ``mongosync`` instance for each destination cluster. 
+   ``mongosync`` instance for each destination cluster. 
 
 .. _c2c-filtering-limitations:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -137,8 +137,8 @@ Multiple Clusters
 - One cluster cannot simultaneously be a source cluster in one
   ``mongosync`` instance and a destination cluster in another
   ``mongosync`` instance. 
-- To sync a source cluster to multiple destination clusters, use
-   one ``mongosync`` instance for each destination cluster. 
+-  To sync a source cluster to multiple destination clusters, use one
+  ``mongosync`` instance for each destination cluster. 
 
 .. _c2c-filtering-limitations:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -316,6 +316,14 @@ a defined sort method, you may need to update those applications to
 specify the expected sort order before the applications work properly
 with the migrated cluster. 
 
+Multiple Clusters
+~~~~~~~~~~~~~~~~~
+
+To sync a source cluster to multiple destination clusters, use one
+``mongosync`` instance for each destination cluster. For more
+information, see :ref:`Multiple Clusters Limitations
+<multiple-clusters-limitations>`. 
+
 .. _c2c-mongosync-examples:
 
 Examples


### PR DESCRIPTION
## DESCRIPTION

correcting/adding to the mongosync multiple clusters limitations

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-34589/reference/limitations/#multiple-clusters
https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-34589/reference/mongosync/#multiple-clusters

## JIRA

https://jira.mongodb.org/browse/DOCSP-34589

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65de1fb17111165982c9ea2a

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
