### PR TITLE
DOCSP-23343 Improve Atlas Connection String Example

### DIFF
--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -54,4 +54,3 @@ Example
 -------
 
 .. include:: /includes/example-connect-atlas.rst
-

--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -53,5 +53,5 @@ Limitations
 Example
 -------
 
-.. include:: /includes/example-connect
+.. include:: /includes/example-connect-atlas.rst
 

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -62,4 +62,3 @@ Example
 -------
 
 .. include:: /includes/example-connect-onprem-atlas.rst
-

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -61,5 +61,5 @@ Limitations
 Example
 -------
 
-.. include:: /includes/example-connect
+.. include:: /includes/example-connect-onprem-atlas.rst
 

--- a/source/includes/example-connect-atlas.rst
+++ b/source/includes/example-connect-atlas.rst
@@ -4,9 +4,10 @@ Gather Connection Information
 The source cluster, ``cluster0``, is hosted on the following servers
 and ports:
 
-- clusterOne01.fancyCorp.com:20020
-- clusterOne02.fancyCorp.com:20020
-- clusterOne03.fancyCorp.com:20020
+- clusterOne-shard-00-00.abc12.mongodb.net:27017
+- clusterOne-shard-00-01.abc12.mongodb.net:27017
+- clusterOne-shard-00-02.abc12.mongodb.net:27017
+
 
 The destination cluster, ``cluster1``, is hosted on the following
 servers and ports:
@@ -27,7 +28,7 @@ strings for ``cluster0`` and ``cluster1``:
 .. code-block:: shell
 
    cluster0:
-   mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
+   mongodb+srv://clusterAdmin:superSecret@clusterOne01.abc12.mongodb.net
    cluster1:
    mongodb+srv://clusterAdmin:superSecret@clusterTwo.abc12.mongodb.net
 
@@ -46,5 +47,5 @@ following command on one line:
 .. code-block:: shell
 
    mongosync \
-         --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
+         --cluster0 "mongodb+srv://clusterAdmin:superSecret@clusterOne01.abc12.mongodb.net" \
          --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo.abc12.mongodb.net"

--- a/source/includes/example-connect-atlas.rst
+++ b/source/includes/example-connect-atlas.rst
@@ -27,7 +27,7 @@ strings for ``cluster0`` and ``cluster1``:
 .. code-block:: shell
 
    cluster0:
-   mongodb+srv://clusterAdmin:superSecret@clusterOne01.abc12.mongodb.net
+   mongodb+srv://clusterAdmin:superSecret@clusterOne.abc12.mongodb.net
    cluster1:
    mongodb+srv://clusterAdmin:superSecret@clusterTwo.abc12.mongodb.net
 
@@ -46,5 +46,5 @@ following command on one line:
 .. code-block:: shell
 
    mongosync \
-         --cluster0 "mongodb+srv://clusterAdmin:superSecret@clusterOne01.abc12.mongodb.net" \
+         --cluster0 "mongodb+srv://clusterAdmin:superSecret@clusterOne.abc12.mongodb.net" \
          --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo.abc12.mongodb.net"

--- a/source/includes/example-connect-atlas.rst
+++ b/source/includes/example-connect-atlas.rst
@@ -8,7 +8,6 @@ and ports:
 - clusterOne-shard-00-01.abc12.mongodb.net:27017
 - clusterOne-shard-00-02.abc12.mongodb.net:27017
 
-
 The destination cluster, ``cluster1``, is hosted on the following
 servers and ports:
 

--- a/source/includes/example-connect-onprem-atlas.rst
+++ b/source/includes/example-connect-onprem-atlas.rst
@@ -31,6 +31,14 @@ strings for ``cluster0`` and ``cluster1``:
    cluster1:
    mongodb+srv://clusterAdmin:superSecret@clusterTwo01.mongodb.net:27017,clusterTwo02.mongodb.net:27017,clusterTwo03.mongodb.net:27017
 
+.. note:: 
+    
+   Atlas clusters require TLS connections. To use ``mongosync`` with Atlas 
+   clusters, add the :urioption:`tls=true <tls>` option or use the 
+   ``mongodb+srv`` connection string format. For more details about 
+   ``mongodb+srv`` connection strings, see :ref:`connections-dns-seedlist`.
+
+
 The ``mongosync`` command layout below is modified for display. To
 connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
 following command on one line:
@@ -40,10 +48,3 @@ following command on one line:
    mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
          --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo01.mongodb.net:27017,clusterTwo02.mongodb.net:27017,clusterTwo03.mongodb.net:27017"
-
-.. note:: 
-    
-   Atlas clusters require TLS connections. To use ``mongosync`` with Atlas 
-   clusters, add the :urioption:`tls=true <tls>` option or use the 
-   ``mongodb+srv`` connection string format. For more details about 
-   ``mongodb+srv`` connection strings, see :ref:`connections-dns-seedlist`.

--- a/source/includes/example-connect-onprem-atlas.rst
+++ b/source/includes/example-connect-onprem-atlas.rst
@@ -38,7 +38,6 @@ strings for ``cluster0`` and ``cluster1``:
    ``mongodb+srv`` connection string format. For more details about 
    ``mongodb+srv`` connection strings, see :ref:`connections-dns-seedlist`.
 
-
 The ``mongosync`` command layout below is modified for display. To
 connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
 following command on one line:

--- a/source/includes/example-connect-onprem-atlas.rst
+++ b/source/includes/example-connect-onprem-atlas.rst
@@ -48,3 +48,4 @@ following command on one line:
    mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
          --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo.abc12.mongodb.net"
+

--- a/source/includes/example-connect-onprem-atlas.rst
+++ b/source/includes/example-connect-onprem-atlas.rst
@@ -21,12 +21,6 @@ cluster with password, ``superSecret``.
 Connect the Source and Destination Clusters with ``mongosync``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The generic connection string format is: 
-
-.. code-block:: shell
-
-   mongodb://<user>:<password>@<ip-address>:<port>,<ip-address>:<port>,<ip-address>:<port>
-
 Use the connection information you gathered to create the connection
 strings for ``cluster0`` and ``cluster1``:
 

--- a/source/includes/example-connect-onprem-atlas.rst
+++ b/source/includes/example-connect-onprem-atlas.rst
@@ -1,0 +1,55 @@
+Gather Connection Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The source cluster, ``cluster0``, is hosted on the following servers
+and ports:
+
+- clusterOne01.fancyCorp.com:20020
+- clusterOne02.fancyCorp.com:20020
+- clusterOne03.fancyCorp.com:20020
+
+The destination cluster, ``cluster1``, is hosted on the following
+servers and ports:
+
+- clusterTwo01.mongodb.net:27017
+- clusterTwo02.mongodb.net:27017
+- clusterTwo03.mongodb.net:27017
+
+There is an administrative user, ``clusterAdmin`` configured on each
+cluster with password, ``superSecret``.
+
+Connect the Source and Destination Clusters with ``mongosync``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The generic connection string format is: 
+
+.. code-block:: shell
+
+   mongodb://<user>:<password>@<ip-address>:<port>,<ip-address>:<port>,<ip-address>:<port>
+
+Use the connection information you gathered to create the connection
+strings for ``cluster0`` and ``cluster1``:
+
+.. code-block:: shell
+
+   cluster0:
+   mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
+   cluster1:
+   mongodb+srv://clusterAdmin:superSecret@clusterTwo01.mongodb.net:27017,clusterTwo02.mongodb.net:27017,clusterTwo03.mongodb.net:27017
+
+The ``mongosync`` command layout below is modified for display. To
+connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
+following command on one line:
+
+.. code-block:: shell
+
+   mongosync \
+         --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
+         --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo01.mongodb.net:27017,clusterTwo02.mongodb.net:27017,clusterTwo03.mongodb.net:27017"
+
+.. note:: 
+    
+   Atlas clusters require TLS connections. To use ``mongosync`` with Atlas 
+   clusters, add the :urioption:`tls=true <tls>` option or use the 
+   ``mongodb+srv`` connection string format. For more details about 
+   ``mongodb+srv`` connection strings, see :ref:`connections-dns-seedlist`.


### PR DESCRIPTION
## DESCRIPTION 
- Moved on-prem to Atlas cluster example to separate include since there are differences when connecting to Atlas
- Updated `cluster1` hosts and ports to better resemble an Atlas cluster 
- Changed connection strings to use SRV format 
- Moved note on Atlas string requirements (SRV or tls option) higher up for better visibility

## STAGING 
- [On Prem to Atlas](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-23343-connect-self-managed-cluster-atlas/connecting/onprem-to-atlas/#example)
- [Atlas to Atlas](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-23343-connect-self-managed-cluster-atlas/connecting/atlas-to-atlas/#example)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-23343

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65de2a577111165982ce24e8