### PR TITLE
DOCS-15446 applyOps limitation

### DIFF
--- a/source/includes/fact-applyOps.rst
+++ b/source/includes/fact-applyOps.rst
@@ -1,0 +1,3 @@
+``mongosync`` may not replicate :dbcommand:`applyOps` operations on the
+source cluster to the destination cluster while the sync is in
+the ``RUNNING`` state. 

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -6,7 +6,7 @@ on the source cluster, the sync fails and ``mongosync`` exits.
 
 .. note::
 
-   include:: /includes/fact-applyOps.rst
+   .. include:: /includes/fact-applyOps.rst
 
 
 Starting in version 1.5.0, ``mongosync`` enables Oplog Rollover

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -4,6 +4,8 @@ to the data on the destination cluster.  When operations
 that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
+
+
 Starting in version 1.5.0, ``mongosync`` enables Oplog Rollover
 Resilience (ORR).  With ORR,  ``mongosync`` applies changes on the
 source cluster to the destination cluster during the initial sync. ORR

--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -4,6 +4,9 @@ to the data on the destination cluster.  When operations
 that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
+.. note::
+
+   include:: /includes/fact-applyOps.rst
 
 
 Starting in version 1.5.0, ``mongosync`` enables Oplog Rollover

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -53,6 +53,7 @@ General Limitations
   index defined on the same field(s).
 - .. include:: /includes/fact-atlas-require-indexes-limitation.rst
 - ``mongosync`` doesn't sync users or roles.
+- .. include:: /includes/fact-applyOps.rst
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -1,8 +1,8 @@
 .. _c2c-oplog-sizing:
 
-================
+============
 oplog Sizing
-================
+============
 
 .. default-domain:: mongodb
 
@@ -18,11 +18,10 @@ clusters. ``mongosync`` does not access the :term:`oplog` directly,
 but when a change stream returns events from the past, the events must
 be within the ``oplog`` time range. 
 
-
 .. include:: /includes/fact-oplog-background
 
 Monitor oplog Size Needed for Initial Sync
------------------------------------------------
+------------------------------------------
 
 .. procedure::
    :style: normal


### PR DESCRIPTION
## DESCRIPTION

add limitation that mongosync does not support applyOps operations during sync

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCS-15446/reference/limitations/#general-limitations
https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCS-15446/reference/oplog-sizing/#oplog-sizing

## JIRA

https://jira.mongodb.org/browse/DOCS-15446

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65df81c4711116598237780c

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
