### PR TITLE
DOCS-15748 Fix Mongosync Atlas doc examples

### DIFF
--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -19,6 +19,16 @@ This page provides instructions to connect Atlas clusters using
 Atlas cluster, see :ref:`Connect to a Database Deployment
 <atlas-connect-to-deployment>` 
 
+Considerations 
+--------------
+
+- Both the source and destination Atlas clusters must use MongoDB 6.0 or 
+  later. 
+- ``mongosync`` supports replica sets and sharded clusters.
+- ``mongosync`` does not support Atlas shared clusters or serverless
+  instances. You can use ``mongosync`` only with M10 or higher Atlas
+  clusters.  
+
 Connection Strings
 ------------------
 
@@ -53,4 +63,5 @@ Limitations
 Example
 -------
 
-.. include:: /includes/example-connect-atlas.rst
+.. include:: /includes/example-connect-atlas-to-atlas.rst
+

--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -25,7 +25,7 @@ Considerations
 - Both the source and destination Atlas clusters must use MongoDB 6.0 or 
   later. 
 - ``mongosync`` supports replica sets and sharded clusters.
-- ``mongosync`` does not support Atlas shared clusters or serverless
+- ``mongosync`` **doesn't** support Atlas shared clusters or serverless 
   instances. You can use ``mongosync`` only with M10 or higher Atlas
   clusters.  
 

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -24,6 +24,7 @@ For additional details on connecting to an Atlas cluster, see
 Connection Strings
 ------------------
 
+.. include:: /includes/fact-connection-strings-onprem
 .. include:: /includes/fact-connection-strings-atlas
 
 Authentication
@@ -61,4 +62,5 @@ Limitations
 Example
 -------
 
-.. include:: /includes/example-connect-onprem-atlas.rst
+.. include:: /includes/example-connect-onprem-to-atlas.rst
+

--- a/source/includes/example-connect-atlas-to-atlas.rst
+++ b/source/includes/example-connect-atlas-to-atlas.rst
@@ -1,0 +1,61 @@
+Gather Connection Information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The generic connection string format is: 
+
+.. code-block:: shell
+
+   mongodb://<user>:<password>@<clusterName>.<hostname>.mongodb.net/
+
+You can get the connection string for the Atlas clusters from the Atlas
+UI. To learn more, see :atlas:`Connect to a Database Deployment
+</connect-to-database-deployment/>`. 
+
+The connection strings you gathered for ``cluster0`` and ``cluster1``
+should resemble the following:
+
+.. code-block:: shell
+
+   cluster0:
+   mongodb+srv://clusterAdmin:superSecret@cluster1Name.abc123.mongodb.net
+   cluster1:
+   mongodb+srv://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net
+
+There is an database administrative user ``clusterAdmin`` with the
+password ``superSecret`` in the project that contains the clusters. 
+
+Connect the Source and Destination Clusters with ``mongosync``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``mongosync`` command layout below is modified for display. To
+connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
+following command on one line:
+
+.. code-block:: shell
+
+   mongosync \
+         --cluster0 "mongodb+srv://clusterAdmin:superSecret@cluster1Name.abc123.mongodb.net" \
+         --cluster1 "mongodb+srv://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net"
+
+Atlas clusters require TLS connections. To use ``mongosync`` with Atlas
+clusters, you add the :urioption:`tls=true <tls>` option. For example,
+to connect to the ``admin`` database on ``cluster0`` and ``cluster1``:
+
+.. code-block:: shell
+
+   mongosync \
+      --cluster0 "mongodb+srv://clusterAdmin:superSecret@cluster1Name.abc123.mongodb.net/admin?tls=true" \
+      --cluster1 "mongodb+srv://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net/admin?tls=true"
+
+You can also use ``mongodb+srv`` connection strings with ``mongosync``.
+You do not need to add the :urioption:`tls=true <tls>` option to a
+``mongodb+srv`` connection string. For example:
+
+.. code-block:: shell
+
+   mongosync \
+      --cluster0 "mongodb+srv://clusterAdmin:superSecret@cluster1Name.abc123.mongodb.net/" \
+      --cluster1 "mongodb+srv://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net/"
+
+For more details about ``mongodb+srv`` connection strings, see
+:ref:`connections-dns-seedlist`.

--- a/source/includes/example-connect-onprem-to-atlas.rst
+++ b/source/includes/example-connect-onprem-to-atlas.rst
@@ -8,12 +8,12 @@ and ports:
 - clusterOne02.fancyCorp.com:20020
 - clusterOne03.fancyCorp.com:20020
 
-The destination cluster, ``cluster1``, is hosted on the following
+The destination Atlas cluster, ``cluster1``, is hosted on the following
 servers and ports:
 
-- clusterTwo01.fancyCorp.com:20020
-- clusterTwo02.fancyCorp.com:20020
-- clusterTwo03.fancyCorp.com:20020
+- cluster2Name-01.abc123.com:27017
+- cluster2Name-02.abc123.com:27017
+- cluster2Name-03.abc123.com:27017
 
 There is an administrative user, ``clusterAdmin`` configured on each
 cluster with password, ``superSecret``.
@@ -21,21 +21,29 @@ cluster with password, ``superSecret``.
 Connect the Source and Destination Clusters with ``mongosync``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The generic connection string format is: 
+The generic connection string format for the self-managed cluster is: 
 
 .. code-block:: shell
 
    mongodb://<user>:<password>@<ip-address>:<port>,<ip-address>:<port>,<ip-address>:<port>
 
-Use the connection information you gathered to create the connection
-strings for ``cluster0`` and ``cluster1``:
+The generic connection string format for the Atlas cluster is: 
+
+.. code-block:: shell
+
+   mongodb://<user>:<password>@<clusterName>.<hostname>.mongodb.net/
+
+Use the connection information you gathered for the self-managed cluster
+to create the connection strings for ``cluster0``:
 
 .. code-block:: shell
 
    cluster0:
    mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
-   cluster1:
-   mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020
+
+You can get the connection string for the Atlas cluster from the Atlas
+UI. To learn more, see :atlas:`Connect to a Database Deployment
+</connect-to-database-deployment/>`. 
 
 The ``mongosync`` command layout below is modified for display. To
 connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
@@ -45,7 +53,17 @@ following command on one line:
 
    mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \
-         --cluster1 "mongodb://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com:20020,clusterTwo02.fancyCorp.com:20020,clusterTwo03.fancyCorp.com:20020"
+         --cluster1 "mongodb://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net"
+
+Atlas clusters require TLS connections. To use ``mongosync`` with Atlas
+clusters, you add the :urioption:`tls=true <tls>` option. For example,
+to connect to the ``admin`` database on ``cluster0`` and ``cluster1``:
+
+.. code-block:: shell
+
+   mongosync \
+      --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020/admin?tls=true" \
+      --cluster1 "mongodb://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net/admin?tls=true"
 
 You can also use ``mongodb+srv`` connection strings with ``mongosync``.
 You do not need to add the :urioption:`tls=true <tls>` option to a
@@ -55,7 +73,7 @@ You do not need to add the :urioption:`tls=true <tls>` option to a
 
    mongosync \
       --cluster0 "mongodb+srv://clusterAdmin:superSecret@clusterOne01.fancyCorp.com/" \
-      --cluster1 "mongodb+srv://clusterAdmin:superSecret@clusterTwo01.fancyCorp.com/"
+      --cluster1 "mongodb+srv://clusterAdmin:superSecret@cluster2Name.abc123.mongodb.net/"
 
 For more details about ``mongodb+srv`` connection strings, see
 :ref:`connections-dns-seedlist`.

--- a/source/includes/example-connect-onprem-to-atlas.rst
+++ b/source/includes/example-connect-onprem-to-atlas.rst
@@ -1,19 +1,19 @@
 Gather Connection Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The source cluster, ``cluster0``, is hosted on the following servers
-and ports:
-
-- clusterOne01.fancyCorp.com:20020
-- clusterOne02.fancyCorp.com:20020
-- clusterOne03.fancyCorp.com:20020
-
-The destination Atlas cluster, ``cluster1``, is hosted on the following
+The source cluster, :setting:`cluster0`, is hosted on the following
 servers and ports:
 
-- cluster2Name-01.abc123.com:27017
-- cluster2Name-02.abc123.com:27017
-- cluster2Name-03.abc123.com:27017
+- ``clusterOne01.fancyCorp.com:20020``
+- ``clusterOne02.fancyCorp.com:20020``
+- ``clusterOne03.fancyCorp.com:20020``
+
+The destination Atlas cluster, :setting:`cluster1`, is hosted on the
+following servers and ports:
+
+- ``cluster2Name-01.abc123.com:27017``
+- ``cluster2Name-02.abc123.com:27017``
+- ``cluster2Name-03.abc123.com:27017``
 
 There is an administrative user, ``clusterAdmin`` configured on each
 cluster with password, ``superSecret``.
@@ -36,7 +36,7 @@ The generic connection string format for the Atlas cluster is:
 Use the connection information you gathered for the self-managed cluster
 to create the connection strings for ``cluster0``:
 
-.. code-block:: shell
+.. code-block:: text
 
    cluster0:
    mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020
@@ -49,7 +49,7 @@ The ``mongosync`` command layout below is modified for display. To
 connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
 following command on one line:
 
-.. code-block:: shell
+.. code-block:: yaml
 
    mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \

--- a/source/includes/example-connect-onprem-to-atlas.rst
+++ b/source/includes/example-connect-onprem-to-atlas.rst
@@ -49,7 +49,7 @@ The ``mongosync`` command layout below is modified for display. To
 connect ``cluster0`` to ``cluster1`` with ``mongosync``, enter the
 following command on one line:
 
-.. code-block:: yaml
+.. code-block:: shell
 
    mongosync \
          --cluster0 "mongodb://clusterAdmin:superSecret@clusterOne01.fancyCorp.com:20020,clusterOne02.fancyCorp.com:20020,clusterOne03.fancyCorp.com:20020" \

--- a/source/includes/fact-connection-strings-atlas.rst
+++ b/source/includes/fact-connection-strings-atlas.rst
@@ -5,7 +5,7 @@ connection string <mongodb-uri>` to connect clusters:
 
   .. code-block:: none
 
-     mongodb+srv://[username:password@][host.domain.TLD][/defaultauthdb][?options]
+     mongodb+srv://[username:password]@[clusterName].[host].mongodb.net/
 
   For information on how to find your SRV connection
   string in Atlas, see :atlas:`Connect to Your Cluster 
@@ -15,17 +15,7 @@ connection string <mongodb-uri>` to connect clusters:
 
   .. code-block:: none
   
-     mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
-
-Specify the hostnames of the :binary:`mongod` instances the same way
-that they are listed in your replica set configuration.
-
-For :ref:`sharded clusters <sharding-sharded-cluster>`, specify the
-hostnames of the :binary:`mongos` instances instead of the
-:binary:`mongod` instances.
-
-.. note::
-
-   ``mongosync`` does not require the :urioption:`replicaSet` option.
+     mongodb://[username:password]@[clusterName].[host].mongodb.net/
 
 .. include:: /includes/read-preference-connection-string.rst
+   

--- a/source/includes/fact-connection-strings-atlas.rst
+++ b/source/includes/fact-connection-strings-atlas.rst
@@ -1,5 +1,5 @@
 :ref:`mongosync <c2c-mongosync>` uses a :ref:`MongoDB URI
-connection string <mongodb-uri>` to connect clusters:
+connection string <mongodb-uri>` to connect Atlas clusters:
 
 - The SRV connection scheme has the form:
 

--- a/source/includes/fact-connection-strings-onprem.rst
+++ b/source/includes/fact-connection-strings-onprem.rst
@@ -1,5 +1,5 @@
 :ref:`mongosync <c2c-mongosync>` uses a :ref:`MongoDB URI
-connection string <mongodb-uri>` to connect clusters:
+connection string <mongodb-uri>` to connect self-managed clusters:
 
 - The SRV connection scheme has the form:
 

--- a/source/includes/fact-connection-strings-onprem.rst
+++ b/source/includes/fact-connection-strings-onprem.rst
@@ -1,0 +1,27 @@
+:ref:`mongosync <c2c-mongosync>` uses a :ref:`MongoDB URI
+connection string <mongodb-uri>` to connect clusters:
+
+- The SRV connection scheme has the form:
+
+  .. code-block:: none
+
+     mongodb+srv://[username:password@][host.domain.TLD][/defaultauthdb][?options]
+
+- The standard URI connection scheme has the form:
+
+  .. code-block:: none
+  
+     mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
+
+Specify the hostnames of the :binary:`mongod` instances the same way
+that they are listed in your replica set configuration.
+
+For :ref:`sharded clusters <sharding-sharded-cluster>`, specify the
+hostnames of the :binary:`mongos` instances instead of the
+:binary:`mongod` instances.
+
+.. note::
+
+   ``mongosync`` does not require the :urioption:`replicaSet` option.
+
+.. include:: /includes/read-preference-connection-string.rst

--- a/source/includes/fact-connection-strings-onprem.rst
+++ b/source/includes/fact-connection-strings-onprem.rst
@@ -13,12 +13,12 @@ connection string <mongodb-uri>` to connect clusters:
   
      mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
 
-Specify the hostnames of the :binary:`mongod` instances the same way
+Specify the hostnames of the :program:`mongod` instances the same way
 that they are listed in your replica set configuration.
 
 For :ref:`sharded clusters <sharding-sharded-cluster>`, specify the
-hostnames of the :binary:`mongos` instances instead of the
-:binary:`mongod` instances.
+hostnames of the :program:`mongos` instances instead of the
+:program:`mongod` instances.
 
 .. note::
 


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCS-15748)
- Stage: 
  - [Atlas to Atlas](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCS-15748/connecting/atlas-to-atlas/) 
  - [Self-Managed to Atlas](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCS-15748/connecting/onprem-to-atlas/)
  - [Self-Managed to Self-Managed](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCS-15748/connecting/onprem-to-onprem/)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e8a2f311db7b04271bcd1f) (clean)

Tested and updated doc for Atlas connection string fix. This required fixes in multiple pages.
       
```
{8:12}~/server-bug-bash ➭ mongosync \
      --logPath data/log/mongosync \
      --cluster0 "mongodb+srv://testUser:testPwd@c2ctestcluster1.w2z3k.mongodb-dev.net/" \
      --cluster1 "mongodb+srv://testUser:testPwd@c2ctestcluster2.w2z3k.mongodb-dev.net/" 

{9:19}~/server-bug-bash ➭ curl localhost:27182/api/v1/start -XPOST \
--data '
   {
      "source": "cluster0",
      "destination": "cluster1"
   } '

{"success":true}%  
``` 