### PR TITLE
DOCS-16652 Adds Reversing State

### DIFF
--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -90,10 +90,9 @@ operations in that state.
        ``REVERSING``
 
      - The sync process copies metadata from the destination
-       cluster to the source cluster. When complete, the phase
-       reverts to applying change events and the original source
-       cluster becomes the new destination cluster while the old
-       destination becomes the new source.
+       cluster to the source cluster. Then, MongoDB swaps the
+       source and destination clusters and resumes applying
+       change events.
      - - ``POST`` :ref:`/reverse <c2c-api-reverse>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
 

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -97,10 +97,3 @@ operations in that state.
      - - ``POST`` :ref:`/reverse <c2c-api-reverse>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
 
-   * - .. _c2c-state-waitingforreversecomplete:
-       ``WAITINGFORREVERSECOMPLETE``
-     - The sync process is waiting for the reverse operation to
-       finish on all ``mongosync`` instances.
-     - - ``POST`` :ref:`/revese <c2c-api-revese>`
-       - ``GET`` :ref:`/progress <c2c-api-progress>`
-

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -83,7 +83,7 @@ operations in that state.
        ``COMMITTED``
      - The cutover for the sync process is complete.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
-       - ``GET`` :ref:`/reverse <c2c-api-reverse>`
+       - ``POST`` :ref:`/reverse <c2c-api-reverse>`
 
    * - .. _c2c-state-reversing:
 
@@ -93,6 +93,5 @@ operations in that state.
        cluster to the source cluster. Then, MongoDB swaps the
        source and destination clusters and resumes applying
        change events.
-     - - ``POST`` :ref:`/reverse <c2c-api-reverse>`
        - ``GET`` :ref:`/progress <c2c-api-progress>`
 

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -90,7 +90,7 @@ operations in that state.
        ``REVERSING``
 
      - The sync process copies metadata from the destination
-       cluster to the source cluster.  When complete, the phase
+       cluster to the source cluster. When complete, the phase
        reverts to applying change events and the original source
        cluster becomes the new destination cluster while the old
        destination becomes the new source.

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -93,5 +93,6 @@ operations in that state.
        cluster to the source cluster. Then, MongoDB swaps the
        source and destination clusters and resumes applying
        change events.
-       - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+     - - ``GET`` :ref:`/progress <c2c-api-progress>`
 

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -85,3 +85,22 @@ operations in that state.
      - - ``GET`` :ref:`/progress <c2c-api-progress>`
        - ``GET`` :ref:`/reverse <c2c-api-reverse>`
 
+   * - .. _c2c-state-reversing:
+
+       ``REVERSING``
+
+     - The sync process copies metadata from the destination
+       cluster to the source cluster.  When complete, the phase
+       reverts to applying change events and the original source
+       cluster becomes the new destination cluster while the old
+       destination becomes the new source.
+     - - ``POST`` :ref:`/reverse <c2c-api-reverse>`
+       - ``GET`` :ref:`/progress <c2c-api-progress>`
+
+   * - .. _c2c-state-waitingforreversecomplete:
+       ``WAITINGFORREVERSECOMPLETE``
+     - The sync process is waiting for the reverse operation to
+       finish on all ``mongosync`` instances.
+     - - ``POST`` :ref:`/revese <c2c-api-revese>`
+       - ``GET`` :ref:`/progress <c2c-api-progress>`
+


### PR DESCRIPTION
## Description

Adds `REVERSING` to table of mongosync states.

## Staging

* [mongosync States](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCS-16652-mongosync-states/reference/mongosync-states/#state-descriptions)

## JIRA

[DOCS-16652](https://jira.mongodb.org/browse/DOCS-16652)

## Build

* [2024-03-05](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e75b5311db7b0427bebccd)
* [2024-03-13](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65f1ceee6fc5f048501f7b86)