### PR TITLE
DOCSP-37408 Rollover Requirement

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -43,6 +43,8 @@ To use the ``reverse`` endpoint:
   
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
+- The destination cluster oplog must not roll over before
+  ``mongosync`` reaches the ``COMMITTED`` state.
 - :ref:`index-type-unique` require proper formatting.  Collections with indexes
   initially created on MongoDB 4.2 may not have the proper formatting. 
   

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -43,8 +43,9 @@ To use the ``reverse`` endpoint:
   
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
-- The destination cluster oplog must not roll over before
-  ``mongosync`` reaches the ``COMMITTED`` state.
+- The destination cluster oplog must not roll over between 
+  ``mongosync`` reaching the ``COMMITTED`` state and receiving
+  the ``/reverse`` request.
 - :ref:`index-type-unique` require proper formatting.  Collections with indexes
   initially created on MongoDB 4.2 may not have the proper formatting. 
   


### PR DESCRIPTION
## Description

Adds requirement to `reverse` that the destination cluster cannot rollover before `mongosync` reaches the `COMMITTED` state.

## Staging

[reverse Requirement](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-37408-oplog-rollover/reference/api/reverse/#requirements)

## JIRA

[DOCSP-37408](https://jira.mongodb.org/browse/DOCSP-37408)

## Build

* [2024-03-06](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e8da9211db7b04273beeff)
* [2024-03-08](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65eb5f936fc5f04850b01a14)
