### PR TITLE
DOCSP-23910 dropping and recreating capped collection limitation

### DIFF
--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -5,7 +5,7 @@ collections <manual-capped-collection>` with some limitations.
   ``convertToCapped``, ``mongosync`` exits with an error.
 - ``mongosync`` does not support :dbcommand:`cloneCollectionAsCapped`.
 - ``mongosync`` does not support dropping a collection and then
-  recreating the collection with the same name as a capped collection. 
+  recreating the collection as a capped collection under the same name. 
 
 Capped collections on the source cluster work normally during sync.
 

--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -4,8 +4,9 @@ collections <manual-capped-collection>` with some limitations.
 - ``mongosync`` does not support :dbcommand:`convertToCapped`. If you run
   ``convertToCapped``, ``mongosync`` exits with an error.
 - ``mongosync`` does not support :dbcommand:`cloneCollectionAsCapped`.
-- ``mongosync`` does not support dropping a collection and then
-  recreating the collection as a capped collection under the same name. 
+- ``mongosync`` does not support dropping and then recreating a
+  collection as a capped collection with the same name as the original
+  collection. 
 
 Capped collections on the source cluster work normally during sync.
 

--- a/source/includes/collections/behavior-capped-collections.rst
+++ b/source/includes/collections/behavior-capped-collections.rst
@@ -1,9 +1,11 @@
 Starting in 1.3.0, {+c2c-product-name+} supports :ref:`capped
 collections <manual-capped-collection>` with some limitations.
 
-- :dbcommand:`convertToCapped` is not supported. If you run
+- ``mongosync`` does not support :dbcommand:`convertToCapped`. If you run
   ``convertToCapped``, ``mongosync`` exits with an error.
-- :dbcommand:`cloneCollectionAsCapped` is not supported.
+- ``mongosync`` does not support :dbcommand:`cloneCollectionAsCapped`.
+- ``mongosync`` does not support dropping a collection and then
+  recreating the collection with the same name as a capped collection. 
 
 Capped collections on the source cluster work normally during sync.
 


### PR DESCRIPTION
## DESCRIPTION

add limitation about dropping and recreating a collection as a capped collection to mongosync limitations
**question for tech review**: has this behavior changed since MongoDB v6.1?

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-23910/reference/limitations/#capped-collections

## JIRA

https://jira.mongodb.org/browse/DOCSP-23910

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65f3175d6fc5f048507b88c1

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
