### PR TITLE
DOCSP-23937 Fix Role Issue on Mongosync Start Page

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -41,7 +41,7 @@ To set a custom role for the ``mongosync`` user:
       db.adminCommand( {
          createRole: "reverseSync",
          privileges: [ {
-             resource: { db: "", collection: "" },
+             resource: { cluster: "true" },
              actions: [ "setUserWriteBlockMode", "bypassWriteBlockingMode" ]
          } ],
          roles: []

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -27,36 +27,18 @@ State
 To use the ``start`` endpoint, ``mongosync`` must be in the ``IDLE``
 state.
 
-User Write Blocking
-~~~~~~~~~~~~~~~~~~~
+Permissions
+~~~~~~~~~~~
 
-.. include:: /includes/fact-write-blocking-requirement.rst
+The user specified in the ``mongosync`` connection string must have the
+required permissions on the source and destination clusters. Refer to
+:ref:`c2c-permissions-and-roles` to ensure that the user has the correct
+permissions to start the synchronization.
 
-To set a custom role for the ``mongosync`` user:
- 
-#. To create a custom role, use the :dbcommand:`createRole` command:
+Multiple ``mongosync`` Instances
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   .. code-block:: javascript
-   
-      db.adminCommand( {
-         createRole: "reverseSync",
-         privileges: [ {
-             resource: { cluster: "true" },
-             actions: [ "setUserWriteBlockMode", "bypassWriteBlockingMode" ]
-         } ],
-         roles: []
-      } )
- 
-#. To grant the custom role to the ``mongosync`` user, use the :dbcommand:`grantRolesToUser` command:
-
-   .. code-block:: javascript
-
-      db.adminCommand( {
-         grantRolesToUser: "mongosync-user",
-         roles: [ { role: "reverseSync", db: "admin" } ]
-      } )
-
-Ensure that you use this configured ``mongosync`` user in the connection 
+Ensure that you use the configured ``mongosync`` user in the connection 
 strings for the :setting:`cluster0` or :setting:`cluster1` settings when
 you start ``mongosync``. 
 


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCSP-23937): Document for [setUserWriteBlockMode](https://www.mongodb.com/docs/master/reference/privilege-actions/#mongodb-authaction-setUserWriteBlockMode) and [bypassWriteBlockingMode](https://www.mongodb.com/docs/master/reference/privilege-actions/#mongodb-authaction-bypassWriteBlockingMode) specify that these roles should be applied to the cluster resource, but current example in [doc](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/start/#user-write-blocking) shows these applied on the db/collection. Fixes incorrect documentation.
- [Stage](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCSP-23937/reference/api/start/#user-write-blocking/) 
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65f8afba6fc5f04850b6162a)