### PR TITLE
DOCSP-24392 Add index constraint command examples to mongosync

### DIFF
--- a/source/reference/disaster-recovery.txt
+++ b/source/reference/disaster-recovery.txt
@@ -61,62 +61,6 @@ the following changes that mimic the sync finalization process of the
        size. To set your required maximum size, use the
        :dbcommand:`collMod` command.
 
-.. _c2c-dr-unique:
-
-Unique Indexes
---------------
-
-:program:`mongosync` replicates writes in parallel, which can cause
-transient uniqueness violations on the destination cluster. To avoid
-these errors, unique indexes are replicated as non-unique. If
-synchronization ends early, manually resolve any uniqueness violations
-and convert any non-unique indexes that should be unique into unique indexes.
-
-Prepare the Index for Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For each non-unique index on the destination cluster that should be
-unique, run :dbcommand:`collMod` with ``prepareUnique`` set to
-``true``.
-
-After running ``collMod``, the index rejects any new writes that
-would introduce duplicate keys.
-
-Resolve Uniqueness Violations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There may still be uniqueness conflicts in the index after you run
-``prepareUnique``. To find conflicts and convert the index to a unique
-index, run ``collMod`` with ``unique`` set to ``true`` on each of the
-non-unique indexes that you want to set as unique.
-
-If the call to ``collMod`` succeeds, there are no uniqueness violations
-on that index and the index is converted to an unique index.
-
-If the call to ``collMod`` fails with a ``CannotConvertIndexToUnique``
-error, correct the uniqueness violations and rerun ``collMod``.
-
-See: `Convert an Existing Index
-<https://www.mongodb.com/docs/v6.0/reference/command/collMod/#convert-an-existing-index-to-a-unique-index>`__
-
-.. _c2c-dr-ttl:
-
-TTL Indexes
------------
-
-During synchronization, ``expireAfterSeconds`` is set
-to ``MAX_INT`` for :ref:`TTL indexes
-<index-feature-ttl>`. To reset ``expireAfterSeconds``, use the
-:dbcommand:`collMod` command to change the expiration value. 
-
-.. _c2c-dr-hidden:
-
-Hidden Indexes
---------------
-During synchronization, :ref:`hidden indexes <index-type-hidden>` are
-not hidden on the destination cluster. Use the ``collMod`` command to
-hide indexes that should be hidden.
-
 .. _c2c-dr-write-blocking:
 
 Write blocking
@@ -141,6 +85,114 @@ To enable writes, update :dbcommand:`setUserWriteBlockMode`:
        }
    )
 
+.. _c2c-dr-unique:
+
+Unique Indexes
+--------------
+
+:program:`mongosync` replicates writes in parallel, which can cause
+transient uniqueness violations on the destination cluster. To avoid
+these errors, unique indexes are replicated as non-unique. If
+synchronization ends early, manually resolve any uniqueness violations
+and convert any non-unique indexes that should be unique into unique indexes.
+
+Prepare the Index for Conversion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For each non-unique index on the destination cluster that should be
+unique, run :dbcommand:`collMod` with ``prepareUnique`` set to
+``true``.
+
+.. example:: 
+
+   .. code-block:: javascript
+      :emphasize-lines: 5
+
+      db.runCommand( {
+        collMod: "<collection_name>",
+        index: {
+          keyPattern: <index_spec> || name: <index_name>,
+          prepareUnique: true
+        }
+      } )
+
+After running ``collMod``, the index rejects any new writes that
+would introduce duplicate keys.
+
+Resolve Uniqueness Violations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There may still be uniqueness conflicts in the index after you run
+``prepareUnique``. To find conflicts and convert the index to a unique
+index, run ``collMod`` with ``unique`` set to ``true`` on each of the
+non-unique indexes that you want to set as unique.
+
+.. example:: 
+
+   .. code-block:: javascript
+      :emphasize-lines: 5
+
+      db.runCommand( {
+        collMod: "<collection_name>",
+        index: {
+          keyPattern: <index_spec> || name: <index_name>,
+          unique: true
+        }
+      } )
+
+If the call to ``collMod`` succeeds, there are no uniqueness violations
+on that index and the index is converted to an unique index.
+
+If the call to ``collMod`` fails with a ``CannotConvertIndexToUnique``
+error, correct the uniqueness violations and rerun ``collMod``.
+
+See: `Convert an Existing Index
+<https://www.mongodb.com/docs/v6.0/reference/command/collMod/#convert-an-existing-index-to-a-unique-index>`__
+
+.. _c2c-dr-ttl:
+
+TTL Indexes
+-----------
+
+During synchronization, ``expireAfterSeconds`` is set
+to ``MAX_INT`` for :ref:`TTL indexes
+<index-feature-ttl>`. To reset ``expireAfterSeconds``, use the
+:dbcommand:`collMod` command to change the expiration value. 
+
+.. example:: 
+
+   .. code-block:: javascript
+      :emphasize-lines: 5
+
+      db.runCommand( {
+        collMod: "<collection_name>",
+        index: {
+          keyPattern: <index_spec> || name: <index_name>,
+          expireAfterSeconds: <number_of_seconds>
+        }
+      } )
+
+.. _c2c-dr-hidden:
+
+Hidden Indexes
+--------------
+During synchronization, :ref:`hidden indexes <index-type-hidden>` are
+not hidden on the destination cluster. Use the ``collMod`` command to
+hide indexes that should be hidden.
+
+.. example:: 
+
+   .. code-block:: javascript
+      :emphasize-lines: 5
+
+      db.runCommand( {
+        collMod: "<collection_name>",
+        index: {
+          keyPattern: <index_spec> || name: <index_name>,
+          hidden: true
+        }
+      } )
+
 .. _c2c-dr-capped-collections:
 
 Capped Collections
@@ -149,3 +201,14 @@ Capped Collections
 During synchronization, capped collections are set to the maximum
 allowable size. To set your required maximum size, use the ``collMod``
 command. For details, see :ref:`resize-capped-collection`.
+
+.. example:: 
+
+   .. code-block:: javascript
+      :emphasize-lines: 3
+
+      db.runCommand( {
+        collMod: "<collection_name>",
+        cappedSize: <max_size_in_bytes>,
+        cappedMax: <max_number_of_documents_in_collection>
+      } )


### PR DESCRIPTION
- [JIRA](https://jira.mongodb.org/browse/DOCSP-24392)
- [Stage](https://preview-mongodbkanchanamongodb.gatsbyjs.io/cluster-sync/DOCSP-24392/reference/disaster-recovery/)
- [Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65fc743d6fc5f04850b67ac1) (contains errors not introduced by changes in this PR)