### PR TITLE
DOCSP-37693-destination-sharded-cluster-with-arbiter-not-supported-mo…

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -76,6 +76,8 @@ Sharded Clusters
 
 - ``mongosync`` doesn't support sync from a sharded cluster
   to a replica set.
+- ``mongosync`` doesn't support syncing into a sharded cluster 
+  topology with one or more arbiters.
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 
@@ -104,8 +106,6 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
-- ``mongosync`` doesn't support syncing into a sharded cluster 
-  topology with one or more arbiters.
 
 .. note::
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -104,6 +104,8 @@ Sharded Clusters
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
   specifications on all shards.
+- ``mongosync`` doesn't support syncing into a sharded cluster 
+  topology with one or more arbiters.
 
 .. note::
 


### PR DESCRIPTION
## DESCRIPTION
Adding limitation that mongosync doesn't support syncing into a sharded cluster topology with one or more arbiters.

## STAGING


## JIRA
https://jira.mongodb.org/browse/DOCSP-37693

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660daa243a5920a291bcf57a
