### PR TITLE
DOCS-15441 mongosync read preference behavior

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -278,6 +278,15 @@ behavior, see :ref:`read-concern` and :ref:`write-concern`.
 Read Preference
 ~~~~~~~~~~~~~~~
 
+If you specify a read preference for your source cluster, ``mongosync``
+uses your specified read preference on the source cluster. If you do not
+specify a read preference, ``mongosync`` uses the read preference
+:readmode:`primaryPreferred`.
+
+``mongosync`` uses the read preference :readmode:`primary` on the
+destination cluster, even if you specify a destination cluster read
+preference.
+
 ``mongosync`` requires the :readmode:`primary` read preference
 when connecting to the source cluster. For more information, see
 :ref:`connections-read-preference`. 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -281,15 +281,13 @@ Read Preference
 If you specify a read preference for your source cluster, ``mongosync``
 uses your specified read preference on the source cluster. If you do not
 specify a read preference, ``mongosync`` uses the read preference
-:readmode:`primaryPreferred`.
+:readmode:`primaryPreferred` on the source cluster.
 
-``mongosync`` uses the read preference :readmode:`primary` on the
-destination cluster, even if you specify a destination cluster read
-preference.
+By default, ``mongosync`` uses the read preference :readmode:`primary`
+on the destination cluster, even if you specify a destination cluster
+read preference.
 
-``mongosync`` requires the :readmode:`primary` read preference
-when connecting to the source cluster. For more information, see
-:ref:`connections-read-preference`. 
+For more information, see :ref:`connections-read-preference`.
 
 .. _c2c-capped-collections:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -283,9 +283,9 @@ uses your specified read preference on the source cluster. If you do not
 specify a read preference, ``mongosync`` uses the read preference
 :readmode:`primaryPreferred` on the source cluster.
 
-By default, ``mongosync`` uses the read preference :readmode:`primary`
-on the destination cluster, even if you specify a destination cluster
-read preference.
+``mongosync`` always uses the :readmode:`primary` read preference on the
+destination cluster, even if you manually specify a read preference for
+the destination cluster.
 
 For more information, see :ref:`connections-read-preference`.
 


### PR DESCRIPTION
## DESCRIPTION

On the source, mongosync uses the user specified read preference and uses the read preference PrimaryPreferred if they did not set any preference.
On the destination, mongosync overwrites the user specified read preference with Primary.

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCS-15441/reference/mongosync/#read-preference

## JIRA

https://jira.mongodb.org/browse/DOCS-15441

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6615857d3a5920a291966d88

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
