### PR TITLE
(DOCSP-38546): Add product name to quickstart page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -35,11 +35,10 @@ common questions users have asked about ``mongosync``.
 .. toctree::
    :titlesonly:
 
-   /quickstart
+   Quickstart </quickstart>
    /installation
    /connecting
    /multiple-mongosyncs
    /reference
    /release-notes
    /faq
-

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -1,8 +1,8 @@
 .. _c2c-quickstart:
 
-==========
-Quickstart
-==========
+==================================
+{+c2c-product-name+} Quickstart
+==================================
 
 .. default-domain:: mongodb
 
@@ -305,5 +305,3 @@ Synchronization Notes
 
 - To estimate the size of ``oplog`` needed for initial synchronization,
   see :ref:`c2c-oplog-sizing`.
-
-


### PR DESCRIPTION
## DESCRIPTION

Standardize quickstart page names. Add product name for C2C quickstart page.

## STAGING

https://preview-mongodbjeffallenmongo.gatsbyjs.io/cluster-sync/DOCSP-38546/quickstart/

## JIRA

https://jira.mongodb.org/browse/DOCSP-38546

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=661fddeb3a5920a29101c065

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
