### PR TITLE
DOCSP-38839 Source Cluster Read Only Behavior

### DIFF
--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -2,7 +2,7 @@
 write-blocking, ``mongosync`` blocks writes:
 
 - On the destination cluster during sync.
-- On the source cluster while ``commit`` is running.
+- On the source cluster when ``commit`` is received.
 
 To enable write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``. You cannot enable

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -44,7 +44,12 @@ characteristics that ``mongosync`` alters during the synchronization process.
      - If ``mongosync`` disables writes on the destination cluster,
        ``commit`` disables the Write Block Mode. 
 
-       .. include:: /includes/fact-write-blocking-enable.rst
+       If you enable write-blocking, ``mongosync`` blocks writes:
+       
+       - On the destination cluster during sync.
+       - On the source cluster when ``commit`` is received.
+
+       To learn more, see :ref:`c2c-write-blocking`.
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -41,7 +41,9 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - If ``mongosync`` disabled writes on the destination cluster,
+     - .. include:: /includes/fact-write-blocking-enable.rst
+
+       If ``mongosync`` disables writes on the destination cluster,
        ``commit`` disables the Write Block Mode. 
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -46,7 +46,10 @@ characteristics that ``mongosync`` alters during the synchronization process.
        - On the destination cluster during sync.
        - On the source cluster when ``commit`` is received.
 
-       To learn more, see :ref:`c2c-write-blocking`.
+       .. seealso:: 
+
+          - :ref:`c2c-failure-recovery`
+          - :ref:`c2c-write-blocking`
   
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -41,10 +41,10 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - .. include:: /includes/fact-write-blocking-enable.rst
-
-       If ``mongosync`` disables writes on the destination cluster,
+     - If ``mongosync`` disables writes on the destination cluster,
        ``commit`` disables the Write Block Mode. 
+
+       .. include:: /includes/fact-write-blocking-enable.rst
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -41,13 +41,13 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - If ``mongosync`` disables writes on the destination cluster,
-       ``commit`` disables the Write Block Mode. 
-
-       If you enable write-blocking, ``mongosync`` blocks writes:
+     - If you enable write-blocking, ``mongosync`` blocks writes:
        
        - On the destination cluster during sync.
        - On the source cluster when ``commit`` is received.
+
+       If ``mongosync`` blocks writes on the destination cluster,
+       ``commit`` disables the Write Block Mode. 
 
        To learn more, see :ref:`c2c-write-blocking`.
 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -41,15 +41,7 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - If you enable write-blocking, ``mongosync`` blocks writes:
-       
-       - On the destination cluster during sync.
-       - On the source cluster when ``commit`` is received.
-
-       If ``mongosync`` blocks writes on the destination cluster,
-       ``commit`` disables the Write Block Mode. 
-
-       To learn more, see :ref:`c2c-write-blocking`.
+     - .. include:: /includes/fact-write-blocking-enable.rst
 
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -41,8 +41,13 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - .. include:: /includes/fact-write-blocking-enable.rst
+     - If you enable write-blocking, ``mongosync`` blocks writes: 
+       
+       - On the destination cluster during sync.
+       - On the source cluster when ``commit`` is received.
 
+       To learn more, see :ref:`c2c-write-blocking`.
+  
    * - :ref:`Capped Collections <c2c-dr-capped-collections>`
      - ``commit`` resets the required maximum size of capped collections
        which ``mongosync`` set to the maximum allowable size on the

--- a/source/reference/disaster-recovery.txt
+++ b/source/reference/disaster-recovery.txt
@@ -51,7 +51,10 @@ the following changes that mimic the sync finalization process of the
        Use the :dbcommand:`collMod` command to hide any indexes that should
        be hidden.
    * - :ref:`Write Blocking <c2c-dr-write-blocking>`
-     - ``mongosync`` can disable writes on the destination cluster. 
+     - If you enable write-blocking, ``mongosync`` blocks writes: 
+       
+       - On the destination cluster during sync.
+       - On the source cluster when ``commit`` is received.
 
        If synchronization was started with write blocking, disable the Write
        Block Mode.


### PR DESCRIPTION
## DESCRIPTION 
Adds note on read-only behavior of source cluster when write blocking is enabled and `commit` is received. 
Note that I swapped out the description with an abbreviated version of the include text since not all the information from the original include is relevant to the table information. 

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-38839-source-read-only-support/reference/api/commit/#description

## JIRA 
https://jira.mongodb.org/browse/DOCSP-38839

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6622d787b67dbf804a81115c
^ warning unrelated to this PR