### PR TITLE
DOCSP 39098  Recommend limiting DDL operations during a sync

### DIFF
--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -337,10 +337,10 @@ information, see :ref:`Multiple Clusters Limitations
 Data Definition Language (DDL) Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DDL operations (operations that act on collections or databases)
-increase the complexity of sync and may negatively impact performance.
-To optimize sync, refrain from performing DDL operations on the source
-cluster while the sync is in progress. 
+DDL operations (operations that act on collections or databases) during
+sync increase the risk of migration failure and may negatively impact
+``mongosync`` performance. For best performance, refrain from performing
+DDL operations on the source cluster while the sync is in progress.
 
 .. _c2c-mongosync-examples:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -337,11 +337,15 @@ information, see :ref:`Multiple Clusters Limitations
 Data Definition Language (DDL) Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using DDL operations (operations that act on collections or databases)
+Using DDL operations (operations that act on collections or databases
+such as :method:`db.createCollection()` and :method:`db.dropDatabase()`)
 during sync increase the risk of migration failure and may negatively
 impact ``mongosync`` performance. For best performance, refrain from
 performing DDL operations on the source cluster while the sync is in
 progress.
+
+For more information on DDL operations, see
+:ref:`txn-prod-considerations-ddl`. 
 
 .. _c2c-mongosync-examples:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -337,10 +337,11 @@ information, see :ref:`Multiple Clusters Limitations
 Data Definition Language (DDL) Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-DDL operations (operations that act on collections or databases) during
-sync increase the risk of migration failure and may negatively impact
-``mongosync`` performance. For best performance, refrain from performing
-DDL operations on the source cluster while the sync is in progress.
+Using DDL operations (operations that act on collections or databases)
+during sync increase the risk of migration failure and may negatively
+impact ``mongosync`` performance. For best performance, refrain from
+performing DDL operations on the source cluster while the sync is in
+progress.
 
 .. _c2c-mongosync-examples:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -338,7 +338,9 @@ Data Definition Language (DDL) Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 DDL operations (operations that act on collections or databases)
-increase ``mongosync`` complecity 
+increase the complexity of sync and may negatively impact performance.
+To optimize sync, refrain from performing DDL operations on the source
+cluster while the sync is in progress. 
 
 .. _c2c-mongosync-examples:
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -334,6 +334,12 @@ To sync a source cluster to multiple destination clusters, use one
 information, see :ref:`Multiple Clusters Limitations
 <multiple-clusters-limitations>`. 
 
+Data Definition Language (DDL) Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+DDL operations (operations that act on collections or databases)
+increase ``mongosync`` complecity 
+
 .. _c2c-mongosync-examples:
 
 Examples

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -207,6 +207,19 @@ Even if documents move between source shards during replication,
 {+c2c-product-name+} maintains the :term:`eventual consistency`
 guarantee on the destination cluster.
 
+Data Definition Language (DDL) Operations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using DDL operations (operations that act on collections or databases
+such as :method:`db.createCollection()` and :method:`db.dropDatabase()`)
+during sync increase the risk of migration failure and may negatively
+impact ``mongosync`` performance. For best performance, refrain from
+performing DDL operations on the source cluster while the sync is in
+progress.
+
+For more information on DDL operations, see
+:ref:`txn-prod-considerations-ddl`. 
+
 Views
 ~~~~~
 
@@ -333,19 +346,6 @@ To sync a source cluster to multiple destination clusters, use one
 ``mongosync`` instance for each destination cluster. For more
 information, see :ref:`Multiple Clusters Limitations
 <multiple-clusters-limitations>`. 
-
-Data Definition Language (DDL) Operations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Using DDL operations (operations that act on collections or databases
-such as :method:`db.createCollection()` and :method:`db.dropDatabase()`)
-during sync increase the risk of migration failure and may negatively
-impact ``mongosync`` performance. For best performance, refrain from
-performing DDL operations on the source cluster while the sync is in
-progress.
-
-For more information on DDL operations, see
-:ref:`txn-prod-considerations-ddl`. 
 
 .. _c2c-mongosync-examples:
 


### PR DESCRIPTION
## DESCRIPTION

Recommend limiting DDL operations during a sync

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-39098/reference/mongosync/#data-definition-language--ddl--operations

## JIRA

https://jira.mongodb.org/browse/DOCSP-39098

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66324f30b67dbf804aec9d92

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
