### PR TITLE
DOCSP-39095 adding atlas search indexes limitation

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -55,7 +55,7 @@ General Limitations
 - ``mongosync`` must read from the source cluster using the 
   :readmode:`primary` read preference.
 - ``mongosync`` does not support syncing 
-  :ref:`Atlas Search Indexes <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>` .
+  `Atlas Search Indexes <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>` .
 
 
 MongoDB Community Edition

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -54,7 +54,8 @@ General Limitations
 - .. include:: /includes/fact-applyOps.rst
 - ``mongosync`` must read from the source cluster using the 
   :readmode:`primary` read preference.
-- ``mongosync`` does not support syncing Atlas Search Indexes.
+- ``mongosync`` does not support syncing 
+  :ref:`Atlas Search Indexes <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>` .
 
 
 MongoDB Community Edition

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -55,7 +55,7 @@ General Limitations
 - ``mongosync`` must read from the source cluster using the 
   :readmode:`primary` read preference.
 - ``mongosync`` does not support syncing 
-  `Atlas Search Indexes <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>` .
+  `Atlas Search Indexes <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>`__.
 
 
 MongoDB Community Edition

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -54,6 +54,7 @@ General Limitations
 - .. include:: /includes/fact-applyOps.rst
 - ``mongosync`` must read from the source cluster using the 
   :readmode:`primary` read preference.
+- ``mongosync`` does not support syncing Atlas Search Indexes.
 
 
 MongoDB Community Edition


### PR DESCRIPTION
## DESCRIPTION

Add limitation that mongosync does not support syncing atlas search indexes

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/cluster-sync/DOCSP-39095/reference/limitations/#general-limitations

## JIRA

https://jira.mongodb.org/browse/DOCSP-39095

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66325c40b67dbf804af25dfc

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
