### PR TITLE
DOCSP-39211 reverse update

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -28,7 +28,8 @@ For example:
   writes.
 
 In this scenario, you can use the ``reverse`` endpoint to sync writes
-from ``cluster1`` to ``cluster0``.
+from ``cluster1`` to ``cluster0``, including any writes that
+occurred after ``mongosync`` reached ``canWrite=true``. 
 
 Requirements
 ------------
@@ -44,7 +45,7 @@ To use the ``reverse`` endpoint:
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - The destination cluster oplog must not roll over between 
-  ``mongosync`` reaching the ``COMMITTED`` state and receiving
+  ``mongosync`` reaching ``canWrite=true`` and receiving
   the ``/reverse`` request.
 - :ref:`index-type-unique` require proper formatting.  Collections with indexes
   initially created on MongoDB 4.2 may not have the proper formatting. 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -27,9 +27,11 @@ For example:
   the destination cluster. The source cluster will not accept new
   writes.
 
-In this scenario, you can use the ``reverse`` endpoint to sync writes
-from ``cluster1`` to ``cluster0``, including any writes that
-occurred after ``mongosync`` reached ``canWrite=true``. 
+In this scenario, you can use the ``reverse`` endpoint to sync
+writes from ``cluster1`` to ``cluster0``, including any writes
+that occurred on ``cluster1`` after ``mongosync`` reached
+``canWrite=true``.  To check the ``canWrite`` status during
+sync, use the :ref:`/progress <c2c-api-progress>` endpoint.
 
 Requirements
 ------------


### PR DESCRIPTION
## Description

Updates the `/reverse` endpoint to indicate that writes included in the reversal begin at `canWrite=true`.

## Staging

* [Description](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-39211-reverse/reference/api/reverse/#description) last line.
* [Requirements](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-39211-reverse/reference/api/reverse/#requirements) third bullet.

## JIRA

[DOCSP-39211](https://jira.mongodb.org/browse/DOCSP-39211)

## Build
* [2024-04-21](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664cde56cf5bec1c2970f8b6)
* [2024-04-22](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664e2fa1cf5bec1c29c1a78e)
* [2024-04-22a](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664e3628cf5bec1c29c391fc)

