### PR TITLE
DOCSP-38286 Enable ORR

### DIFF
--- a/source/includes/document-filtering-intro.rst
+++ b/source/includes/document-filtering-intro.rst
@@ -1,4 +1,4 @@
-Starting in ``mongosync-beta`` 1.8, you can selectively migrate documents based 
-on specific conditions. To further limit which documents migrate to the 
-destination cluster, you can combine document filtering and :ref:`namespace 
-filtering <c2c-filtered-sync>`.
+Starting in {+c2c-beta-program-short+} 1.8, you can selectively migrate 
+documents based on specific conditions. To further limit which documents migrate 
+to the destination cluster, you can combine document filtering and 
+:ref:`namespace filtering <c2c-filtered-sync>`.

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,6 +1,5 @@
 Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
 Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
-cluster to the destination cluster during the initial sync. This adds resilience 
-to long-running operations, mitigates the risk of oplog rollover, and 
-significantly lowers the risk of restarting the sync.
-
+cluster to the destination cluster concurrently with initial sync. For source 
+clusters with a high write rate, ORR significantly lowers the risk of oplog 
+rollover and reduces the need to restart the sync.

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,0 +1,3 @@
+Starting in {+c2c-beta-program-short+}, you can enable Oplog Rollover 
+Resilience (ORR). With ORR,  ``mongosync`` applies changes on the source 
+cluster to the destination cluster during the initial sync. 

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,3 +1,6 @@
 Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
 Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
-cluster to the destination cluster during the initial sync. 
+cluster to the destination cluster during the initial sync. This adds resilience 
+to long-running operations, mitigates the risk of oplog rollover, and 
+significantly lowers the risk of restarting the sync.
+

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,3 +1,3 @@
-Starting in {+c2c-beta-program-short+}, you can enable Oplog Rollover 
+Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
 Resilience (ORR). With ORR,  ``mongosync`` applies changes on the source 
 cluster to the destination cluster during the initial sync. 

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -2,4 +2,4 @@ Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover
 Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
 cluster to the destination cluster concurrently with initial sync. For source 
 clusters with a high write rate, ORR significantly lowers the risk of oplog 
-rollover and reduces the need to restart the sync.
+rollover during initial sync and reduces the need to restart the sync.

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,3 +1,3 @@
 Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
-Resilience (ORR). With ORR,  ``mongosync`` applies changes on the source 
+Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
 cluster to the destination cluster during the initial sync. 

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -75,9 +75,6 @@ Beta Features
    * - :ref:`c2c-beta-document-filtering`
      - .. include:: /includes/document-filtering-intro.rst
 
-   * - :ref:`c2c-beta-orr`
-     - # DESCRIPTION TBD 
-
    * - :ref:`c2c-beta-destination-data-handling`
      - .. include:: /includes/destinationDataHandling-introduction.rst
 
@@ -89,6 +86,9 @@ Beta Features
 
    * - :ref:`c2c-beta-many-to-one`
      - .. include:: /includes/many-to-one-cluster.rst
+
+   * - :ref:`c2c-beta-orr`
+     - .. include:: /includes/orr-intro.rst
 
 .. toctree::
    :titlesonly:

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -18,7 +18,7 @@ Oplog Rollover Resilience
 
 By applying changes earlier in the sync process, ``mongosync`` maintains a more 
 recent position in the :term:`oplog`. This adds resilience to long-running 
-operations, mitigates the risk of ``oplog`` rollover, and significantly lowers 
+operations, mitigates the risk of oplog rollover, and significantly lowers 
 the risk of restarting the sync.
 
 Syntax 

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -14,7 +14,9 @@ Oplog Rollover Resilience
 
 .. include:: /includes/beta-feature.rst
 
-.. include:: /includes/orr-intro.rst
+Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
+Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
+cluster to the destination cluster during the initial sync.
 
 By applying changes earlier in the sync process, ``mongosync`` maintains a more 
 recent position in the :term:`oplog`. This adds resilience to long-running 
@@ -24,10 +26,9 @@ the risk of restarting the sync.
 Syntax 
 ------
 
-To enable ORR, use the ``--oplogRolloverResilienceIntervalSeconds`` command line 
-option and specify the interval, in seconds, in which ``mongosync`` checks for 
-eligible change events in the oplog. The default value is ``-1``, which disables 
-the option.
+To enable ORR, use ``--oplogRolloverResilienceIntervalSeconds``and specify the 
+interval, in seconds, in which ``mongosync`` checks for eligible change events 
+in the oplog. The default value is ``-1``, which disables the option.
 
 For example, to start ``mongosync`` with the 
 ``oplogRolloverResilienceIntervalSeconds`` set to ``60`` seconds, run the 

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -15,20 +15,20 @@ Oplog Rollover Resilience
 .. include:: /includes/beta-feature.rst
 
 Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
-Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
-cluster to the destination cluster during the initial sync.
+Resilience (ORR). With ORR,  ``mongosync`` applies changes made on 
+the source cluster to the destination cluster concurrently with initial sync.
 
 By applying changes earlier in the sync process, ``mongosync`` maintains a more 
-recent position in the :term:`oplog`. This adds resilience to long-running 
-operations, mitigates the risk of oplog rollover, and significantly lowers 
-the risk of restarting the sync.
+recent position in the :term:`oplog`. For source clusters with a high write 
+rate, ORR significantly lowers the risk of oplog rollover and reduces 
+the need to restart the sync.
 
 Syntax 
 ------
 
 To enable ORR, use ``--oplogRolloverResilienceIntervalSeconds``and specify the 
 interval, in seconds, in which ``mongosync`` checks for eligible change events 
-in the oplog. The default value is ``-1``, which disables the option.
+in the oplog. The default value is ``-1``, which disables ORR.
 
 For example, to start ``mongosync`` with the 
 ``oplogRolloverResilienceIntervalSeconds`` set to ``60`` seconds, run the 

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -26,13 +26,14 @@ Syntax
 
 To enable ORR, use the ``--oplogRolloverResilienceIntervalSeconds`` command line 
 option and specify the interval, in seconds, in which ``mongosync`` checks for 
-eligible change events. The default value is ``-1``, which disables the option.
+eligible change events in the oplog. The default value is ``-1``, which disables 
+the option.
 
 For example, to start ``mongosync`` with the 
-``oplogRolloverResilienceIntervalSeconds`` set to ``60``, run the following 
-command: 
+``oplogRolloverResilienceIntervalSeconds`` set to ``60`` seconds, run the 
+following command: 
 
-.. code-block:: json 
+.. code-block:: shell 
    :copyable: false
 
    ./bin/mongosync \
@@ -46,19 +47,19 @@ Behavior
 ORR increases the resilience of ``mongosync`` to oplog rollover but does not 
 prevent rollover entirely.
 
-You might exceed the oplog window if you: 
+You might exceed the :term:`oplog window` if you: 
 
 - Sync from a high write rate source cluster for an extended
   period.
 - Pause sync for an extended period.
 
-To increase the size of the ``oplog`` on the source cluster, use
-:setting:`~replication.oplogSizeMB`. For more information, see
-:ref:`Change Oplog Size <tutorial-change-oplog-size>` and
-:ref:`Workloads that Might Requre a Large Oplog Size
-<replica-set-large-oplog-required>`.
+To increase the size of the oplog on the source cluster, use
+:setting:`~replication.oplogSizeMB`. 
 
 Learn More 
 ----------
 
 - :ref:`c2c-beta-program`
+- :ref:`Change Oplog Size <tutorial-change-oplog-size>`
+- :ref:`Workloads that Might Requre a Large Oplog Size 
+  <replica-set-large-oplog-required>`

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -20,8 +20,8 @@ the source cluster to the destination cluster concurrently with initial sync.
 
 By applying changes earlier in the sync process, ``mongosync`` maintains a more 
 recent position in the :term:`oplog`. For source clusters with a high write 
-rate, ORR significantly lowers the risk of oplog rollover and reduces 
-the need to restart the sync.
+rate, ORR significantly lowers the risk of oplog rollover during initial sync 
+and reduces the need to restart the sync.
 
 Syntax 
 ------
@@ -45,8 +45,8 @@ following command:
 Behavior 
 --------
 
-ORR increases the resilience of ``mongosync`` to oplog rollover but does not 
-prevent rollover entirely.
+ORR increases the resilience of ``mongosync`` to oplog rollover during initial 
+sync but does not prevent rollover entirely.
 
 You might exceed the :term:`oplog window` if you: 
 

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -1,8 +1,8 @@
 .. _c2c-beta-orr:
 
-================================
-Enable Oplog Rollover Resilience
-================================
+=========================
+Oplog Rollover Resilience
+=========================
 
 .. default-domain:: mongodb
 
@@ -13,3 +13,52 @@ Enable Oplog Rollover Resilience
    :class: singlecol
 
 .. include:: /includes/beta-feature.rst
+
+.. include:: /includes/orr-intro.rst
+
+By applying changes earlier in the sync process, ``mongosync`` maintains a more 
+recent position in the :term:`oplog`. This adds resilience to long-running 
+operations, mitigates the risk of ``oplog`` rollover, and significantly lowers 
+the risk of restarting the sync.
+
+Syntax 
+------
+
+To enable ORR, use the ``--oplogRolloverResilienceIntervalSeconds`` command line 
+option and specify the interval, in seconds, in which ``mongosync`` checks for 
+eligible change events. The default value is ``-1``, which disables the option.
+
+For example, to start ``mongosync`` with the 
+``oplogRolloverResilienceIntervalSeconds`` set to ``60``, run the following 
+command: 
+
+.. code-block:: json 
+   :copyable: false
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27000" \
+         --cluster1 "mongodb://localhost:27001" \
+         --oplogRolloverResilienceIntervalSeconds 60
+
+Behavior 
+--------
+
+ORR increases the resilience of ``mongosync`` to oplog rollover but does not 
+prevent rollover entirely.
+
+You might exceed the oplog window if you: 
+
+- Sync from a high write rate source cluster for an extended
+  period.
+- Pause sync for an extended period.
+
+To increase the size of the ``oplog`` on the source cluster, use
+:setting:`~replication.oplogSizeMB`. For more information, see
+:ref:`Change Oplog Size <tutorial-change-oplog-size>` and
+:ref:`Workloads that Might Requre a Large Oplog Size
+<replica-set-large-oplog-required>`.
+
+Learn More 
+----------
+
+- :ref:`c2c-beta-program`

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -49,19 +49,19 @@ Handle Destination Data with destinationDataHandling Option
 
 For details, see :ref:`c2c-beta-destination-data-handling`.
 
-Set a Migration Name
-````````````````````
-
-.. include:: /includes/migrationName.rst
-
-To learn more, see :ref:`c2c-beta-migration-name`.
-
 Many-to-One Migrations
 ``````````````````````
 
 .. include:: /includes/many-to-one-cluster.rst
 
 To learn more, see :ref:`c2c-beta-many-to-one`.
+
+Set a Migration Name
+````````````````````
+
+.. include:: /includes/migrationName.rst
+
+To learn more, see :ref:`c2c-beta-migration-name`.
 
 Other Notes
 ~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION 
- Creates reference page for ORR 
- Adds note on ORR to 1.8 beta release notes 
- Adds ORR to beta program feature table

## STAGING 
- [Beta Feature table](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-38286-enable-ORR/reference/beta-program/#beta-features)
- [ORR reference page](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-38286-enable-ORR/reference/beta-program/orr/#std-label-c2c-beta-orr)
- [1.8 RN](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-38286-enable-ORR/release-notes/1.8/#oplog-rollover-resilience)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-38286

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66846c07fe162e5006346204