### PR TITLE
DOCS-41102 added code snippets cutover page

### DIFF
--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -248,7 +248,7 @@ documentation provides details on using the following endpoints:
      - Reverses the direction of a committed sync operation.
 
 Finalize Cutover Process
--------------
+------------------------
 
 You can finalize a migration and transfer your application
 workload from the source to the destination cluster using the

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -247,6 +247,15 @@ documentation provides details on using the following endpoints:
    * - :ref:`c2c-api-reverse`
      - Reverses the direction of a committed sync operation.
 
+Finalize Cutover Process
+-------------
+
+You can finalize a migration and transfer your application
+workload from the source to the destination cluster using the
+``mongosync`` cutover process. 
+
+For more information, see :ref:`c2c-cutover-process`.
+
 One-Time Sync
 -------------
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -43,6 +43,23 @@ Steps
   
       - ``canCommit`` is ``true``. 
 
+      The following example returns the status of the synchronization process.
+
+      Request
+      ~~~~~~~
+
+      .. literalinclude:: /includes/api/requests/progress.sh
+         :language: shell
+
+      Response
+      ~~~~~~~~
+
+      .. literalinclude:: /includes/api/responses/progress.json
+         :language: json
+         :copyable: false
+         :emphasize-lines: 5, 8
+
+
    .. step:: Stop any write operations to the synced collections on the source. 
 
       - If you started ``mongosync`` with ``enableUserWriteBlocking``
@@ -50,8 +67,16 @@ Steps
         the entire source cluster during the commit (step 4) for you. 
       - If you didn't start ``mongosync`` with
         ``enableUserWriteBlocking``, ensure that writes are disabled.
-        For example, run the ``setUserWriteBlockMode`` command on the
-        source cluster.
+        For example, run the :dbcommand:`setUserWriteBlockMode` command on the
+        source cluster:
+
+        .. code-block:: javascript
+
+           db.adminCommand( {
+              setUserWriteBlockMode: 1,
+              global: true 
+           } )
+
       - If ``mongosync`` uses filtered sync, it's not necessary to
         disable writes to the entire source cluster. But you must ensure
         that write operations are stopped for the collections included
@@ -62,6 +87,19 @@ Steps
       If you started multiple ``mongosync`` instances for your
       migration, you must issue a commit request for each ``mongosync``
       instance.
+
+      Request
+      ~~~~~~~~
+
+      .. literalinclude:: /includes/api/requests/commit.sh
+         :language: shell
+
+      Response
+      ~~~~~~~~
+
+      .. literalinclude:: /includes/api/responses/success.json
+         :language: json
+         :copyable: false
 
       .. note:: 
 
@@ -75,6 +113,21 @@ Steps
       Call the ``progress`` endpoint to determine if ``canWrite`` is
       ``true``. If ``canWrite`` is ``false``, wait until ``progress``
       shows ``canWrite`` is ``true``.
+
+      Request
+      ~~~~~~~
+
+      .. literalinclude:: /includes/api/requests/progress.sh
+         :language: shell
+
+      Response
+      ~~~~~~~~
+
+      .. literalinclude:: /includes/api/responses/progress.json
+         :language: json
+         :emphasize-lines: 5
+         :copyable: false
+
 
    .. step:: Verify data transfer.
 
@@ -101,6 +154,43 @@ Steps
       When the ``mongosync`` progress response indicates that the 
       ``mongosync`` state is ``COMMITTED``, the cutover process is
       complete. 
+
+      Request
+      ~~~~~~~
+
+      .. literalinclude:: /includes/api/requests/progress.sh
+         :language: shell
+
+      Response
+      ~~~~~~~~
+
+      .. code-block:: json
+         :emphasize-lines: 4
+         :copyable: false
+
+         {
+            "progress":
+               {
+                  "state":"COMMITTED",
+                  "canCommit":true,
+                  "canWrite":false,
+                  "info":"change event application",
+                  "lagTimeSeconds":0,
+                  "collectionCopy":
+                     {
+                        "estimatedTotalBytes":694,
+                        "estimatedCopiedBytes":694
+                     },
+                  "directionMapping":
+                     {
+                        "Source":"cluster0: localhost:27017",
+                        "Destination":"cluster1: localhost:27018"
+                     }
+               },
+            "success": true
+         }
+
+
 
 Learn More
 ----------

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -36,13 +36,13 @@ Steps
       Ensure that the ``mongosync`` process  status indicates the 
       following values:  
 
+      - ``canCommit`` is ``true``. 
+
       - ``lagTimeSeconds`` is small (near ``0``). 
    
         If ``lagTimeSeconds`` isn't close to ``0`` when the cutover
         starts, cutover might take a long time. 
   
-      - ``canCommit`` is ``true``. 
-
       The following example returns the status of the synchronization process.
 
       Request
@@ -103,10 +103,9 @@ Steps
 
       .. note:: 
 
-         Ensure that the ``mongosync`` process response for the
-         ``commit`` request indicates that the ``mongosync`` state is
-         ``COMMITTING`` or ``COMMITTED``, which is the correct
-         ``mongosync`` state when you send a ``commit`` request.
+         After you submit a ``commit`` request, call the ``progress`` endpoint
+         to ensure that the ``mongosync`` state is ``COMMITTING`` or 
+         ``COMMITTED``.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 
@@ -123,10 +122,31 @@ Steps
       Response
       ~~~~~~~~
 
-      .. literalinclude:: /includes/api/responses/progress.json
-         :language: json
-         :emphasize-lines: 5
+      .. code-block:: json
+         :emphasize-lines: 6
          :copyable: false
+
+         {
+            "progress":
+               {
+                  "state":"COMMITTED",
+                  "canCommit":true,
+                  "canWrite":true,
+                  "info":"change event application",
+                  "lagTimeSeconds":0,
+                  "collectionCopy":
+                     {
+                        "estimatedTotalBytes":694,
+                        "estimatedCopiedBytes":694
+                     },
+                  "directionMapping":
+                     {
+                        "Source":"cluster0: localhost:27017",
+                        "Destination":"cluster1: localhost:27018"
+                     }
+               },
+            "success": true
+         }
 
 
    .. step:: Verify data transfer.


### PR DESCRIPTION
## DESCRIPTION
added code snippets for steps 1, 2, 3, 4, and 7 to the "Finalize Cutover Process" page. Also added reference to page on quickstart page

## STAGING
https://preview-mongodbsonderdonkmdb.gatsbyjs.io/cluster-sync/DOCSP-41102/quickstart/#finalize-cutover-process

https://preview-mongodbsonderdonkmdb.gatsbyjs.io/cluster-sync/DOCSP-41102/reference/cutover-process/ 

## JIRA
https://jira.mongodb.org/browse/DOCSP-41102

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=668c4f36fb8bd13b8437bd8b

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
