### PR TITLE
DOCSP-40138-Mongosync-Delay-After-Resume-Restart

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -102,6 +102,8 @@ available again, restart the ``mongosync`` process with the same
 parameters. ``mongosync`` resumes the operation from where it stopped
 when ``mongosync`` became unavailable.
 
+.. include:: /includes/fact-restart-resume-delay.rst
+
 Can the source or destination be a replica set with arbiters? 
 -------------------------------------------------------------
 

--- a/source/includes/fact-restart-resume-delay.rst
+++ b/source/includes/fact-restart-resume-delay.rst
@@ -2,4 +2,5 @@
    
    Starting in ``mongosync`` 1.7.3, ``mongosync`` can take at least two minutes 
    to respond when you resume or restart a sync operation. During this time, 
-   any calls to the :ref:`c2c-api-progress` endpoint might fail.
+   any calls to the :ref:`c2c-api-progress` endpoint might fail. If a 
+   ``progress`` call fails, it is safe to retry.

--- a/source/includes/fact-restart-resume-delay.rst
+++ b/source/includes/fact-restart-resume-delay.rst
@@ -1,5 +1,5 @@
 .. note:: 
-
+   
    Starting in ``mongosync`` 1.7.3, ``mongosync`` can take at least two minutes 
    to respond when you resume or restart a sync operation. This means that 
    until ``mongosync`` responds, any calls to the :ref:`c2c-api-progress` 

--- a/source/includes/fact-restart-resume-delay.rst
+++ b/source/includes/fact-restart-resume-delay.rst
@@ -1,6 +1,5 @@
 .. note:: 
    
    Starting in ``mongosync`` 1.7.3, ``mongosync`` can take at least two minutes 
-   to respond when you resume or restart a sync operation. This means that 
-   until ``mongosync`` responds, any calls to the :ref:`c2c-api-progress` 
-   endpoint might fail.
+   to respond when you resume or restart a sync operation. During this time, 
+   any calls to the :ref:`c2c-api-progress` endpoint might fail.

--- a/source/includes/fact-restart-resume-delay.rst
+++ b/source/includes/fact-restart-resume-delay.rst
@@ -1,0 +1,6 @@
+.. note:: 
+
+   Starting in ``mongosync`` 1.7.3, ``mongosync`` can take at least two minutes 
+   to respond when you resume or restart a sync operation. This means that 
+   until ``mongosync`` responds, any calls to the :ref:`c2c-api-progress` 
+   endpoint might fail.

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -64,6 +64,8 @@ Behavior
 
 - The endpoint does not auto-refresh. To get updated status, call the
   ``progress`` endpoint again.
+  
+  .. include:: /includes/fact-restart-resume-delay.rst
 
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/resume.txt
+++ b/source/reference/api/resume.txt
@@ -71,11 +71,11 @@ Response
 Behavior
 --------
 
+- When you send a ``resume`` request, ``mongosync`` might take at least two 
+  minutes before resuming the migration.
+
 - If the ``resume`` request is successful, ``mongosync`` enters the
   ``RUNNING`` state.
-
-- When you send a ``resume`` request, there may be a delay of up to a
-  few minutes before ``mongosync`` resumes the migration.
 
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/resume.txt
+++ b/source/reference/api/resume.txt
@@ -72,7 +72,8 @@ Behavior
 --------
 
 - When you send a ``resume`` request, ``mongosync`` might take at least two 
-  minutes before resuming the migration.
+  minutes before resuming the migration. To see if the migration resumed, you 
+  can call the :ref:`c2c-api-progress` endpoint.
 
 - If the ``resume`` request is successful, ``mongosync`` enters the
   ``RUNNING`` state.

--- a/source/reference/mongosync-states.txt
+++ b/source/reference/mongosync-states.txt
@@ -26,6 +26,8 @@ To view the current state of ``mongosync``, use the :ref:`/progress
 <c2c-api-progress>`. endpoint. The :ref:`/progress <c2c-api-progress>`
 endpoint returns the state in the ``state`` field.
 
+.. include:: /includes/fact-restart-resume-delay.rst
+
 .. _c2c-states-descriptions:
 
 State Descriptions

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -38,6 +38,7 @@ Previous Rapid Releases
 .. toctree::
    :titlesonly: 
 
+   /release-notes/1.8
    /release-notes/1.7
    /release-notes/1.6
    /release-notes/1.5

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -141,6 +141,8 @@ Issues Fixed:
 
 Other Changes:
 
+- Adds a two minute delay when restarting and resuming sync operations.
+
 - Disables the Oplog Rollover Resilience mechanism.
 
 - Live upgrade to mongosync 1.7.2 is not allowed.

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -70,6 +70,10 @@ Issues Fixed:
   events when mongosync is interrupted and resumed. This is an unlikely
   edge case.
 
+Other Changes:
+
+- Adds a two minute delay when restarting and resuming sync operations.
+
 Limitations:
 
 - You must stop the balancer on both the source and destination sharded
@@ -140,8 +144,6 @@ Issues Fixed:
   collections and source clusters older than MongoDB 6.0.
 
 Other Changes:
-
-- Adds a two minute delay when restarting and resuming sync operations.
 
 - Disables the Oplog Rollover Resilience mechanism.
 


### PR DESCRIPTION
## Description 
- Documents 2-minute delay behavior when resuming/restarting sync operations. 
- added 1.8 release notes to toc to fix build error

## STAGING 
- [/progress](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40138-Mongosync-Delay-After-Resume-Restart/reference/api/progress/#behavior)
- [/resume](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40138-Mongosync-Delay-After-Resume-Restart/reference/api/resume/#behavior)
- [mongosync states](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40138-Mongosync-Delay-After-Resume-Restart/reference/mongosync-states/#view-the-current-state)
- [FAQ](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40138-Mongosync-Delay-After-Resume-Restart/faq/#can-i-configure-mongosync-for-high-availability-) - this section talked a bit more extensively about resuming & restarting
- [1.7.3 release notes](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40138-Mongosync-Delay-After-Resume-Restart/release-notes/1.7/#:~:text=Adds%20a%20two%20minute%20delay%20when%20restarting%20and%20resuming%20sync%20operations.)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-40138

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=668edd3dfb8bd13b84d284d4