### PR TITLE
DOCSP-40979: fix typo in /progress 

### DIFF
--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -28,7 +28,7 @@ Request
 Response
 --------
 
-The ``progress`` endpoint returns etiher an updated status or an error.
+The ``progress`` endpoint returns either an updated status or an error.
 
 Successful Response
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Quick typo bug fix in 1.7 only.

Build log: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66969f0626eba795526eea12

Staging: https://preview-mongodbmdbashley.gatsbyjs.io/cluster-sync/DOCSP-40979-typo-fix/reference/api/progress/#response

