### PR TITLE
DOCSP-40105-storageEngine-limitation

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -59,6 +59,8 @@ General Limitations
 - ``mongosync`` does not support syncing 
   `Atlas Search Indexes
   <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>`__.
+- ``mongosync`` only supports clusters that use the :ref:`WiredTiger 
+  <storage-wiredtiger>` storage engine.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
## DESCRIPTION 
Adds note on ``mongosync`` only supporting clusters that use WiredTiger

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-40105-storageEngine-limitation/reference/limitations/#:~:text=mongosync%20only%20supports%20clusters%20that%20use%20the%20WiredTiger%20storage%20engine

## JIRA 
https://jira.mongodb.org/browse/DOCSP-40105

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6697d5a026eba79552b75cb2