### PR TITLE
DOCSP-41580 creates release notes for 1.8.0

### DIFF
--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -21,9 +21,91 @@ Release Notes for mongosync 1.8
 
 **Upcoming**
 
-New Features:
+Embedded Verifier
+~~~~~~~~~~~~~~~~~
+
+Starting in 1.8, ``mongosync`` includes an optional embedded
+verifier that performs a series of checks against the source and 
+destination clusters to verify a successful sync.
+
+For more information, see :ref:`c2c-embedded-verifier`.
+
+Other Notes
+~~~~~~~~~~~
+
+Updates to ``mongosync`` ``/progress`` API endpoint:
+
+- The ``/progress`` endpoint now returns a top-level boolean 
+  ``success`` field.
+
+- The ``/progress`` endpoint now returns the integer 
+  ``totalEventsApplied`` field, which approximates the number of 
+  change events applied to a destination cluster by an instance of 
+  ``mongosync``.
+
+- The ``/progress`` endpoint now reports per-partition progress 
+  tracking with the following changes:
+
+  - Calling ``/progress`` before ``mongosync`` reaches the collection 
+    copy phase will return 0 for ``estimatedCopiedBytes`` and 1 for 
+    ``estimatedTotalBytes``.
+
+  - ``estimatedTotalBytes`` may change throughout the collection copy 
+    phase if documents are inserted or deleted on the source cluster.
+
+  - ``estimatedCopiedBytes`` will never be greater than 
+    ``estimatedTotalBytes``. Progress will reach 100% at the end of 
+    the collection copy phase 
+    (``estimatedCopiedBytes`` = ``estimatedTotalBytes``).
+
+  - When performing a live upgrade from an earlier version to 1.8.0 or 
+    higher, the collection copy data will start over from 
+    ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
+    ``/progress`` only reports the progress of data copied after the 
+    upgrade completed.
+
+Optimizations:
+
+- Significantly reduced the time needed to create partitions and added logging 
+  that tracks the partition creation process.
+
+Other Changes:
+
+- ``mongosync`` now performs a round robin assignment of the primary 
+  shard for each database if the destination is a sharded cluster.
+
+- ``mongosync`` now errors if it cannot create an index after 10 
+  attempts. Previously, the system would attempt to create an index 
+  indefinitely.
+
+- ``mongosync`` now sends hostnames as telemetry.
+
+- Improved performance of the initialization process by eliminating 
+  the creation of unnecessary dummy indexes. ``mongosync`` now creates 
+  dummy indexes for sharded collections only if the destination 
+  cluster does not have an index to support the shard key.
+
+Issues Fixed:
+
+- Fixed a bug that caused ``mongosync`` to fall off the source 
+  cluster's oplog if no real writes occurred on the source 
+  cluster for an extended period of time.
+
+- Fixed a bug that caused ``mongosync`` to write certain logs to a 
+  location outside of the specified log directory.
+
+- Fixed a bug that caused the ``mongosync`` ``/progress`` endpoint to 
+  potentially return incorrect ``totalBytes`` for sharded clusters.
+
+- Fixed a bug that could decrease the ``size`` of capped collections 
+  by up to 256 bytes. This bug affected capped collection resizing 
+  when migrating from a source with a version <7.0 to a destination 
+  with 7.0+.
 
 
 Minimum Supported Version
 -------------------------
 
+In 1.8.0, the minimum supported versions of MongoDB are 6.0.16 and 7.0.9.
+
+.. include:: /includes/migration-upgrade-recommendation.rst

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -26,29 +26,9 @@ Updates to ``mongosync`` ``/progress`` API endpoint
 
 - Returns a top-level boolean ``success`` field.
 
-- Returns the integer ``totalEventsApplied`` field, which approximates 
-  the number of change events applied to a destination cluster by an 
-  instance of ``mongosync``.
+- Returns a new ``totalEventsApplied`` field.
 
-- Reports per-partition progress tracking with the following changes:
-
-  - Calls to ``/progress`` before ``mongosync`` reaches the collection 
-    copy phase return 0 for ``estimatedCopiedBytes`` and 1 for 
-    ``estimatedTotalBytes``.
-
-  - ``estimatedTotalBytes`` may change throughout the collection copy 
-    phase if documents are inserted or deleted on the source cluster.
-
-  - ``estimatedCopiedBytes`` is never be greater than 
-    ``estimatedTotalBytes``. Progress reaches 100% at the end of 
-    the collection copy phase 
-    (``estimatedCopiedBytes`` = ``estimatedTotalBytes``).
-
-  - When performing a live upgrade from an earlier version to 1.8.0 or 
-    higher, the collection copy data starts over from 
-    ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
-    ``/progress`` only reports the progress of data copied after the 
-    upgrade completed.
+- Reports per-partition progress tracking
 
 See the :ref:`c2c-api-progress` documentation for more details.
 
@@ -88,11 +68,6 @@ Issues Fixed:
 - Fixed a bug introduced in v1.0.0 that caused the ``mongosync`` 
   ``/progress`` endpoint to potentially return incorrect 
   ``totalBytes`` for sharded clusters.
-
-- Fixed a bug introduced in v1.7.0 that could decrease the ``size`` of 
-  capped collections by up to 256 bytes. This bug affected capped 
-  collection resizing when migrating from a source with a version less 
-  than 7.0 to a destination with 7.0 or greater.
 
 
 Minimum Supported Version

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -28,46 +28,46 @@ Starting in 1.8, ``mongosync`` includes an optional embedded
 verifier that performs a series of checks against the source and 
 destination clusters to verify a successful sync.
 
-For more information, see :ref:`c2c-embedded-verifier`.
+For more information, see the Embedded Verifier documentation.
 
-Other Notes
-~~~~~~~~~~~
+Updates to ``mongosync`` ``/progress`` API endpoint
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Updates to ``mongosync`` ``/progress`` API endpoint:
+- Returns a top-level boolean ``success`` field.
 
-- The ``/progress`` endpoint now returns a top-level boolean 
-  ``success`` field.
+- Returns the integer ``totalEventsApplied`` field, which approximates 
+  the number of change events applied to a destination cluster by an 
+  instance of ``mongosync``.
 
-- The ``/progress`` endpoint now returns the integer 
-  ``totalEventsApplied`` field, which approximates the number of 
-  change events applied to a destination cluster by an instance of 
-  ``mongosync``.
+- Reports per-partition progress tracking with the following changes:
 
-- The ``/progress`` endpoint now reports per-partition progress 
-  tracking with the following changes:
-
-  - Calling ``/progress`` before ``mongosync`` reaches the collection 
-    copy phase will return 0 for ``estimatedCopiedBytes`` and 1 for 
+  - Calls to ``/progress`` before ``mongosync`` reaches the collection 
+    copy phase return 0 for ``estimatedCopiedBytes`` and 1 for 
     ``estimatedTotalBytes``.
 
   - ``estimatedTotalBytes`` may change throughout the collection copy 
     phase if documents are inserted or deleted on the source cluster.
 
-  - ``estimatedCopiedBytes`` will never be greater than 
-    ``estimatedTotalBytes``. Progress will reach 100% at the end of 
+  - ``estimatedCopiedBytes`` is never be greater than 
+    ``estimatedTotalBytes``. Progress reaches 100% at the end of 
     the collection copy phase 
     (``estimatedCopiedBytes`` = ``estimatedTotalBytes``).
 
-  - When performing a live upgrade from an earlier version to 1.8.0 or 
-    higher, the collection copy data will start over from 
+  - Performing a live upgrade from an earlier version to 1.8.0 or 
+    higher, the collection copy data starts over from 
     ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
     ``/progress`` only reports the progress of data copied after the 
     upgrade completed.
 
+See the :ref:`c2c-api-progress` documentation for more details.
+
+Other Notes
+~~~~~~~~~~~
+
 Optimizations:
 
-- Significantly reduced the time needed to create partitions and added logging 
-  that tracks the partition creation process.
+- Fixes and enhancements to significantly reduce the time needed to create 
+  partitions and adds logging that tracks the partition creation process.
 
 Other Changes:
 
@@ -99,8 +99,8 @@ Issues Fixed:
 
 - Fixed a bug that could decrease the ``size`` of capped collections 
   by up to 256 bytes. This bug affected capped collection resizing 
-  when migrating from a source with a version <7.0 to a destination 
-  with 7.0+.
+  when migrating from a source with a version less than 7.0 to a 
+  destination with 7.0 or greater.
 
 
 Minimum Supported Version

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -21,10 +21,6 @@ Release Notes for mongosync 1.8
 
 **Upcoming**
 
-Embedded Verifier
-~~~~~~~~~~~~~~~~~
-
-
 Updates to ``mongosync`` ``/progress`` API endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -24,11 +24,14 @@ Release Notes for mongosync 1.8
 Embedded Verifier
 ~~~~~~~~~~~~~~~~~
 
-Starting in 1.8, ``mongosync`` includes an optional embedded
-verifier that performs a series of checks against the source and 
-destination clusters to verify a successful sync.
+Starting in 1.8, ``mongosync`` includes an embedded verifier to confirm the
+successful sync of collections from the source cluster to the destination.
 
-For more information, see the Embedded Verifier documentation.
+- To enable the embedded verifier, use the ``verificationMode`` field in the
+  :ref:`/start <c2c-api-start>` request.
+
+- To check verification status, see the ``verification`` field in the
+  :ref:`/progress <c2c-api-progress>` response.
 
 Updates to ``mongosync`` ``/progress`` API endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,7 +56,7 @@ Updates to ``mongosync`` ``/progress`` API endpoint
     the collection copy phase 
     (``estimatedCopiedBytes`` = ``estimatedTotalBytes``).
 
-  - Performing a live upgrade from an earlier version to 1.8.0 or 
+  - When performing a live upgrade from an earlier version to 1.8.0 or 
     higher, the collection copy data starts over from 
     ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
     ``/progress`` only reports the progress of data copied after the 
@@ -87,20 +90,21 @@ Other Changes:
 
 Issues Fixed:
 
-- Fixed a bug that caused ``mongosync`` to fall off the source 
-  cluster's oplog if no real writes occurred on the source 
+- Fixed a bug introduced in v1.0.0 that caused ``mongosync`` to fall 
+  off the source cluster's oplog if no writes occurred on the source 
   cluster for an extended period of time.
 
-- Fixed a bug that caused ``mongosync`` to write certain logs to a 
-  location outside of the specified log directory.
+- Fixed a bug introduced in v1.0.0 that caused ``mongosync`` to write 
+  certain logs to a location outside of the specified log directory.
 
-- Fixed a bug that caused the ``mongosync`` ``/progress`` endpoint to 
-  potentially return incorrect ``totalBytes`` for sharded clusters.
+- Fixed a bug introduced in v1.0.0 that caused the ``mongosync`` 
+  ``/progress`` endpoint to potentially return incorrect 
+  ``totalBytes`` for sharded clusters.
 
-- Fixed a bug that could decrease the ``size`` of capped collections 
-  by up to 256 bytes. This bug affected capped collection resizing 
-  when migrating from a source with a version less than 7.0 to a 
-  destination with 7.0 or greater.
+- Fixed a bug introduced in v1.7.0 that could decrease the ``size`` of 
+  capped collections by up to 256 bytes. This bug affected capped 
+  collection resizing when migrating from a source with a version less 
+  than 7.0 to a destination with 7.0 or greater.
 
 
 Minimum Supported Version

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -24,14 +24,6 @@ Release Notes for mongosync 1.8
 Embedded Verifier
 ~~~~~~~~~~~~~~~~~
 
-Starting in 1.8, ``mongosync`` includes an embedded verifier to confirm the
-successful sync of collections from the source cluster to the destination.
-
-- To enable the embedded verifier, use the ``verificationMode`` field in the
-  :ref:`/start <c2c-api-start>` request.
-
-- To check verification status, see the ``verification`` field in the
-  :ref:`/progress <c2c-api-progress>` response.
 
 Updates to ``mongosync`` ``/progress`` API endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description
Adds release notes for mongosync 1.8.0

# Staging
https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-41580/release-notes/1.8/

# JIRA
https://jira.mongodb.org/browse/DOCSP-41580

# Build Log
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66a3effb26eba7955279cb9d