### PR TITLE
DOCSP-41445 added reversing state in docs

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -135,7 +135,10 @@ Response
 Behavior
 --------
 
-If the ``reverse`` request is successful, ``mongosync`` enters the
+The reverse endpoint starts the ``REVERSING`` state. ``mongosync`` swaps the 
+source and destination clusters and resumes applying change events.
+
+If the ``reverse`` sync is successful, ``mongosync`` enters the
 ``RUNNING`` state. The synchronization continues in the reverse
 direction from the original sync job. You do not need to restart the
 entire sync process to copy the original data.


### PR DESCRIPTION
## DESCRIPTION
Added a description of the REVERSING state on the /reverse API endpoint page.

Note for reviewers: This ticket also entailed adding the REVERSING state to the mongosync States page. This was actually already done and just not backported. The change has been backported now. You can see that change here: #282 

## STAGING
https://preview-mongodbsonderdonkmdb.gatsbyjs.io/cluster-sync/DOCSP-41445/reference/api/reverse/#behavior

## JIRA
https://jira.mongodb.org/browse/DOCSP-41445

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=669fe7cb26eba795527bae0e

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)