### PR TITLE
DOCSP-41853 Updates mongosync documentation to support 1.8 release

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -55,6 +55,15 @@
        writes on the source cluster. The time difference becomes zero
        when ``mongosync`` commits the migration.
 
+   * - ``totalEventsApplied``
+     - integer
+     - The approximate number of change events this instance of 
+       ``mongosync`` has applied to the destination cluster.
+
+       This value may not be an accurate representation of the total 
+       number of events because it is not persisted and it omits 
+       certain events from the count.
+
    * - ``collectionCopy``
      - object
      - Estimates the total amount of data being copied from collections and the

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -64,7 +64,25 @@ Behavior
 
 - The endpoint does not auto-refresh. To get updated status, call the
   ``progress`` endpoint again.
-  
+
+- Calls to ``/progress`` before ``mongosync`` reaches the collection
+  copy phase return 0 for ``estimatedCopiedBytes`` and 1 for 
+  ``estimatedTotalBytes``.
+
+- ``estimatedTotalBytes`` may change throughout the collection copy 
+  phase if documents are inserted or deleted on the source cluster.
+
+- ``estimatedCopiedBytes`` is never be greater than 
+  ``estimatedTotalBytes``. Progress reaches 100% at the end of the 
+  collection copy phase (``estimatedCopiedBytes`` = 
+  ``estimatedTotalBytes``).
+
+- When performing a live upgrade from an earlier version to 1.8.0 or 
+  higher, the collection copy data starts over from 
+  ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
+  ``/progress`` only reports the progress of data copied after the 
+  upgrade completed.
+
   .. include:: /includes/fact-restart-resume-delay.rst
 
 Endpoint Protection

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -72,7 +72,7 @@ Behavior
 - ``estimatedTotalBytes`` may change throughout the collection copy 
   phase if documents are inserted or deleted on the source cluster.
 
-- ``estimatedCopiedBytes`` is never be greater than 
+- ``estimatedCopiedBytes`` is never greater than 
   ``estimatedTotalBytes``. Progress reaches 100% at the end of the 
   collection copy phase (``estimatedCopiedBytes`` = 
   ``estimatedTotalBytes``).

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -452,9 +452,10 @@ Indexes that are always built include:
 * ``mongosync`` builds an index on the ``_id`` field of every
   collection it copies.
 
-* ``mongosync`` builds dummy indexes that support the shard key for each
-  sharded collection, which are removed after commit. When ``buildIndexes`` is
-  set to ``never``, ``mongosync`` retains this index after commit.
+* ``mongosync`` builds dummy indexes for each sharded collection that 
+  does not have an index to support the shard key on the destination 
+  cluster. When ``buildIndexes`` is set to ``never``, ``mongosync`` 
+  retains this index after commit.
 
 
 Endpoint Protection

--- a/source/reference/telemetry.txt
+++ b/source/reference/telemetry.txt
@@ -29,11 +29,11 @@ The data ``mongosync`` reports includes:
 - The estimated number of bytes ``mongosync`` copies
 - The estimated number of events ``mongosync`` applies
 - The request body sent to :ref:`c2c-api-start` calls
+- Hostnames
 
 ``mongosync`` does not track:
 
 - IP addresses
-- Hostnames
 - Usernames
 - Login credentials
 - Connection strings


### PR DESCRIPTION
# Description
Makes requested documentation changes to support the release of `mongosync` 1.8.0

Note to reviewers: The writing was internally reviewed in #352. This PR moves the writing out of release notes and into the documentation. 

# JIRA
https://jira.mongodb.org/browse/DOCSP-41853

# Staging
[/start](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-41853/reference/api/start/#required-indexes)
[/progress - totalEventsApplied added to response](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-41853/reference/api/progress/#successful-response)
[/progress - adds new behaviors to Behavior section](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-41853/reference/api/progress/#behavior)
[telemetry - moves "Hostnames" from untracked to tracked](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-41853/reference/telemetry/#data-collection)

# Build log
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66a3ed8b26eba7955278f5b6