### PR TITLE
Merge C2C Beta Feature Branch

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -21,6 +21,7 @@ toc_landing_pages = ["/quickstart",
                      "/multiple-mongosyncs",
                      "/release-notes/release-notes",
                      "/faq",
+                     "/reference/beta-program",
                      "/reference/collection-level-filtering",
                      "/reference/verification",
                      "/reference/mongosync"
@@ -33,6 +34,8 @@ version-dev = "1.8"
 c2c-product-name = "Cluster-to-Cluster Sync"
 c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"
 mdb-download-center = "`MongoDB Download Center <https://www.mongodb.com/try/download/mongosync>`__"
+c2c-full-beta-program = "Cluster-to-Cluster Sync Beta Program"
+c2c-beta-program-short = "``mongosync`` beta"
 
 [substitutions]
 c2c-product-name = "Cluster-to-Cluster Sync"

--- a/source/includes/abc-migration-intro.rst
+++ b/source/includes/abc-migration-intro.rst
@@ -1,0 +1,4 @@
+Starting in {+c2c-beta-program-short+} 1.8, you can perform A->B->C migrations. 
+A->B->C migrations allow you to perform two consecutive migrations, where the 
+destination cluster of the first migration acts as the source cluster for the 
+second migration. 

--- a/source/includes/api/requests/start-namespace-remap.sh
+++ b/source/includes/api/requests/start-namespace-remap.sh
@@ -1,0 +1,15 @@
+curl -X POST "http://localhost:27182/api/v1/start" --data '
+   {
+      "source": "cluster0",
+      "destination": "cluster1",
+      "namespaceRemap": [
+        {
+           "from": {
+              "database": "accounts",
+           },
+           "to": {
+              "database": "sales",
+           }
+        }
+      ]
+   } '

--- a/source/includes/beta-feature.rst
+++ b/source/includes/beta-feature.rst
@@ -1,0 +1,4 @@
+.. important:: Cluster-to-Cluster Sync Beta Program
+
+   This feature is only available in {+c2c-beta-program-short+}. To learn more, 
+   see :ref:`c2c-beta-program`.

--- a/source/includes/beta-program-intro.rst
+++ b/source/includes/beta-program-intro.rst
@@ -1,0 +1,3 @@
+Starting in version 1.8.0, {+c2c-product-name+} introduces the 
+{+c2c-full-beta-program+}. With {+c2c-beta-program-short+}, you can use 
+experimental features with direct support and assistance from MongoDB.

--- a/source/includes/destinationDataHandling-introduction.rst
+++ b/source/includes/destinationDataHandling-introduction.rst
@@ -1,0 +1,4 @@
+Starting in {+c2c-beta-program-short+} 1.8, use the ``destinationDataHandling``
+option in the start request to define what happens if the destination
+cluster already has user data. Earlier ``mongosync`` versions return an
+error if the destination cluster has user data.

--- a/source/includes/document-filtering-intro.rst
+++ b/source/includes/document-filtering-intro.rst
@@ -1,0 +1,4 @@
+Starting in {+c2c-beta-program-short+} 1.8, you can selectively migrate 
+documents based on specific conditions. To further limit which documents migrate 
+to the destination cluster, you can combine document filtering and 
+:ref:`namespace filtering <c2c-filtered-sync>`.

--- a/source/includes/document-filtering-limitations.rst
+++ b/source/includes/document-filtering-limitations.rst
@@ -1,0 +1,25 @@
+- ``field`` names can't contain dots (``.``) or dollar signs (``$``).
+
+- ``matchValues`` array items can be the following BSON types: 
+
+  - All number types
+  - Binary
+  - Booleans
+  - Datetime
+  - ObjectID
+  - Strings 
+
+- Documents must not move in or out of the filter during migration.
+
+- If the document filter contains a string and at least one migrated collection 
+  with non-default collation, ``mongosync`` fails immediately.
+
+- If you call the :ref:`progress <c2c-api-progress>` API endpoint and use a 
+  :ref:`document filter <c2c-beta-document-filtering>`, the 
+  ``estimatedTotalBytes`` response field returns ``null``.
+
+- The destination cluster must not contain pre-existing data that matches the 
+  filter.
+
+- You can't specify a document filter and set the ``reversible`` flag to 
+  ``true``.

--- a/source/includes/fact-valid-namespace-remap.rst
+++ b/source/includes/fact-valid-namespace-remap.rst
@@ -1,0 +1,33 @@
+
+The following restrictions apply to namespace remapping:
+
+- Namespace remapping doesn't permit writing to the ``system``, ``config``, ``admin``,
+  or ``local`` databases, or writing to internal databases used by ``mongosync``.
+
+- The database name on the destination cluster must be valid under Windows
+  restrictions.
+
+  For more information, see :limit:`Restrictions on Database Names for Windows`.
+
+- Remapped database names on the destination cluster cannot differ only in case.
+
+- The remap cannot produce namespace conflicts on the destination cluster.
+
+  For example:
+
+  .. code-block:: javascript
+     :copyable: false
+
+     "namespaceRemap": [
+       {
+          "from": { "database": "us-west" },
+          "to": {"database": "us-accounts" }
+       },
+       {
+          "from": { "database": "us-south" },
+          "to": { "database": "us-accounts" }
+       }
+     ]
+
+  If each database on the source cluster contains a ``texas`` collection,
+  ``mongosync`` may fail, corrupt data, or exhibit unexpected behavior.

--- a/source/includes/many-to-one-cluster.rst
+++ b/source/includes/many-to-one-cluster.rst
@@ -1,0 +1,4 @@
+Starting in {+c2c-beta-program-short+} 1.8, you can perform Many-to-One 
+migrations. Many-to-One migrations allow you to sync multiple source 
+clusters simultaneously with a destination cluster. For example, you can
+consolidate data from many small clusters into a central cluster.

--- a/source/includes/migration-name-limitation.rst
+++ b/source/includes/migration-name-limitation.rst
@@ -1,0 +1,7 @@
+The ``migrationName`` string can contain up to 44 alphanumeric and underscore 
+characters. ``migrationName`` is appended to the string 
+``"mongosync_internal_"`` to set the migration metadata database name.
+
+For example, if you set ``migrationName`` to 
+``"cluster_27000_to_cluster_35000_sync"``, the resulting ``mongosync`` metadata 
+database name is ``"mongosync_internal_cluster_27000_to_cluster_35000_sync"``.

--- a/source/includes/namespace-remapping-intro.rst
+++ b/source/includes/namespace-remapping-intro.rst
@@ -1,0 +1,3 @@
+Starting in {+c2c-beta-program-short+} 1.8, you can remap database names during 
+sync. This allows you to take data in one database on the source cluster and 
+migrate it into a different database on the destination cluster.

--- a/source/includes/opts/migrationName.rst
+++ b/source/includes/opts/migrationName.rst
@@ -1,0 +1,13 @@
+.. reference/configuration.txt
+.. reference/mongosync.txt
+
+Starting in ``mongosync-beta`` 1.8, sets a migration name for a sync
+operation. For example, you can set a migration name to identify each
+sync operation from multiple source clusters into one destination
+cluster.
+
+.. include:: /includes/migration-name-limitation.rst
+
+For complete examples, see :ref:`Many-to-One Migrations 
+<c2c-beta-many-to-one-example>` or :ref:`A->B->C Migrations 
+<c2c-beta-abc-migration-example>`.

--- a/source/includes/orr-intro.rst
+++ b/source/includes/orr-intro.rst
@@ -1,0 +1,5 @@
+Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
+Resilience (ORR). With ORR,  ``mongosync`` applies changes made on the source 
+cluster to the destination cluster concurrently with initial sync. For source 
+clusters with a high write rate, ORR significantly lowers the risk of oplog 
+rollover during initial sync and reduces the need to restart the sync.

--- a/source/includes/table-beta-compatibility.rst
+++ b/source/includes/table-beta-compatibility.rst
@@ -1,0 +1,60 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility
+
+   * - 
+     - Many-to-One
+     - A->B->C Migration
+     - Document Filtering
+     - Namespace Remapping 
+     - Oplog Rollover Resilience
+     - Destination Data Handling 
+
+   * - Many-to-One
+     -
+     - 
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - A->B->C Migration
+     - 
+     - 
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - Document Filtering 
+     - 
+     - 
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - Namespace Remapping 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - |checkmark|
+     - |checkmark|
+
+   * - Oplog Rollover Resilience
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - |checkmark|
+
+   * - Destination Data Handling 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 

--- a/source/index.txt
+++ b/source/index.txt
@@ -9,7 +9,7 @@ Cluster-to-Cluster Sync
 .. default-domain:: mongodb
 
 {+c2c-product-name+} provides continuous data synchronization or a 
-one-time data migration between two MongoDB clusters. You can enable
+one-time data migration between MongoDB clusters. You can enable
 {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 ``mongosync`` can continuously synchronize data between two clusters.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -206,6 +206,8 @@ Initialization Notes
   <c2c-api-start>` command. "cluster0" and "cluster1" are just labels,
   either cluster can be ``cluster0`` or ``cluster1``.
 
+.. _c2c-quickstart-synchronize:
+
 Synchronize Data Between Clusters
 ---------------------------------
 

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -66,4 +66,4 @@ Reference
    /reference/verification
    /reference/versioning
    /reference/supported-server-version
-
+   /reference/beta-program

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -112,6 +112,17 @@ Request Body Parameters
 
        .. versionadded:: 1.3.0
 
+   * - ``documentFilter``
+     - document
+     - Optional
+     - .. include:: /includes/beta-feature.rst
+
+       .. include:: /includes/document-filtering-intro.rst
+       
+       To learn more, see :ref:`c2c-beta-document-filtering`.
+
+       .. versionadded:: 1.8 Beta
+
    * - ``enableUserWriteBlocking``
      - boolean
      - Optional
@@ -149,6 +160,17 @@ Request Body Parameters
        .. include:: /includes/api/facts/namespace-explanation.rst
 
        .. versionadded:: 1.6
+
+   * - ``namespaceRemap``
+     - array
+     - Optional
+     - .. include:: /includes/beta-feature.rst
+
+       Array of documents that specify namespace changes to make during sync.
+
+       For more information, see :ref:`c2c-beta-namespace-remapping`.
+
+       .. versionadded:: 1.8 Beta
 
    * - ``reversible``
      - boolean
@@ -464,5 +486,3 @@ Endpoint Protection
 
 .. |endpoint| replace:: ``start``
 .. include:: /includes/fact-api-endpoint
-
-

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -1,0 +1,112 @@
+.. _c2c-beta-program:
+
+====================================
+{+c2c-full-beta-program+}
+====================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-program-intro.rst
+
+Each ``mongosync`` release has a corresponding {+c2c-beta-program-short+} 
+build that includes its own set of experimental features.
+
+.. _c2c-beta-program-disclaimer:
+
+Get Started 
+-----------
+
+To request access to the {+c2c-beta-program-short+} binaries, please file a 
+`HELP ticket <https://jira.mongodb.org/browse/HELP>`_.
+
+When you first run the {+c2c-beta-program-short+} binary, you must accept the 
+following disclaimer:
+
+.. code-block:: shell
+   :copyable: false
+  
+   MongoDB restricts access to beta features via the beta build. Your use 
+   of the beta is governed by the language specified in the Cloud 
+   Subscription Agreement, Cloud Terms of Service, or other applicable 
+   agreement between you and MongoDB with respect to your use of 
+   mongosync.
+   
+   You understand that features are available through the beta build, and 
+   flags are not generally available. All use of beta builds is at your own 
+   risk. Beta builds provide no stability guarantees; API, UI, options, and 
+   behaviors may change or be removed any time. MongoDB will never issue a 
+   Critical Advisory or notify about defects in beta builds. 
+   
+   You should follow feature usage guidance provided by Field and R&D 
+   without deviation and should only use beta builds for one-time, human-
+   supervised migrations (e.g., not for continuous sync or automated 
+   migrations). Beta capabilities are not intended for use to migrate 
+   production workloads.
+
+   Do you want to continue? (y/n):
+
+.. seealso:: 
+
+   - `Cloud Subscription Agreement <https://www.mongodb.com/cloud-subscription-agreement/november-2023>`_
+   - `Cloud Terms of Service <https://www.mongodb.com/legal/terms-and-conditions/cloud>`_
+
+
+Beta Features
+-------------
+
+{+c2c-beta-program-short+} {+version-dev+} includes the following features:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Feature
+     - Description
+
+   * - :ref:`c2c-beta-abc-migration`
+     - .. include:: /includes/abc-migration-intro.rst
+
+   * - :ref:`c2c-beta-document-filtering`
+     - .. include:: /includes/document-filtering-intro.rst
+
+   * - :ref:`c2c-beta-destination-data-handling`
+     - .. include:: /includes/destinationDataHandling-introduction.rst
+
+   * - :ref:`c2c-beta-namespace-remapping`
+     - .. include:: /includes/namespace-remapping-intro.rst
+
+   * - :ref:`c2c-beta-many-to-one`
+     - .. include:: /includes/many-to-one-cluster.rst
+
+   * - :ref:`c2c-beta-orr`
+     - .. include:: /includes/orr-intro.rst
+
+Feature Compatibility Matrix
+----------------------------
+
+.. |checkmark| unicode:: U+2713
+
+The following table shows supported combinations of beta features:
+
+.. warning:: 
+
+   Unsupported feature combinations do not have guardrails and can result in 
+   undefined behavior.  
+
+.. include:: /includes/table-beta-compatibility.rst
+
+.. toctree::
+   :titlesonly:
+
+   /reference/beta-program/abc-migration
+   /reference/beta-program/many-to-one
+   /reference/beta-program/document-filtering
+   /reference/beta-program/destinationDataHandling 
+   /reference/beta-program/namespace-remapping
+   /reference/beta-program/orr 

--- a/source/reference/beta-program/abc-migration.txt
+++ b/source/reference/beta-program/abc-migration.txt
@@ -1,0 +1,103 @@
+.. _c2c-beta-abc-migration:
+
+==================
+A->B->C Migrations
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+.. include:: /includes/abc-migration-intro.rst
+
+Syntax 
+------
+
+To perform an A->B->C migration, run the following commands when starting 
+:ref:`mongosync <c2c-mongosync>`: 
+
+.. code-block:: shell
+
+   ./bin/mongosync \
+         --cluster0 <cluster-A-connection-string> \
+         --cluster1 <cluster-B-connection-string> \
+         --migrationName <string>
+
+   ./bin/mongosync \
+         --cluster0 <cluster-B-connection-string> \
+         --cluster1 <cluster-C-connection-string> \
+         --migrationName <string>
+
+To start the sync operation between the source and destination clusters, see 
+:ref:`c2c-quickstart-synchronize`.
+
+Behavior 
+--------
+
+The first migration (A->B) must finish :ref:`committing <c2c-api-commit>` 
+before the second migration (B->C) starts committing. 
+
+.. warning:: 
+
+   If the second migration starts committing before the first migration 
+   finishes, you may experience data loss.
+
+   Before you use any experimental {+c2c-beta-program-short+} features, 
+   review the :ref:`{+c2c-full-beta-program+} Disclaimer 
+   <c2c-beta-program-disclaimer>`.
+
+
+For better performance, ensure that the first migration (A->B) reaches 
+``change event application`` before the second migration (B->C) starts. To 
+see if a migration reached ``change event application``, check the ``info`` 
+field in the :ref:`c2c-api-progress` response document.
+
+Migration Name 
+~~~~~~~~~~~~~~
+
+.. include:: /includes/migration-name-limitation.rst
+
+.. _c2c-beta-abc-migration-example:
+
+Example 
+-------
+
+The following example performs two consecutive migrations that:
+
+#. Connect a source cluster running on port ``27000`` with a destination 
+   cluster running on port ``27001``.
+
+#. Use the destination cluster running on port ``27001`` as a source cluster 
+   for the second migration. 
+
+#. Connect the source cluster on port ``27001`` with a destination cluster 
+   running on port ``27002``.
+
+The command also sets :option:`--migrationName`
+to describe the operations and store migration metadata for each 
+sync.
+
+.. code-block:: shell
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27000" \
+         --cluster1 "mongodb://localhost:27001" \
+         --migrationName "cluster_27000_to_cluster_27001_sync"
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27001" \
+         --cluster1 "mongodb://localhost:27002" \
+         --migrationName "cluster_27001_to_cluster_27002_sync"
+
+Learn More 
+----------
+
+- :ref:`c2c-beta-program`
+- :ref:`c2c-config`
+- :ref:`c2c-mongosync`

--- a/source/reference/beta-program/destinationDataHandling.txt
+++ b/source/reference/beta-program/destinationDataHandling.txt
@@ -1,0 +1,101 @@
+.. _c2c-beta-destination-data-handling:
+
+===========================================
+Handle Pre-Existing Data on the Destination
+===========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+.. include:: /includes/destinationDataHandling-introduction.rst
+
+Syntax
+------
+
+To set a ``"destinationDataHandling"`` option string:
+
+.. code-block:: shell
+   :emphasize-lines: 5
+
+   curl <host>:<port>/api/v1/start -XPOST \
+   --data '
+      {
+         <options>,
+         "destinationDataHandling": <string>
+      } '
+
+Command Option
+--------------
+
+The following table shows the strings you can set for
+``"destinationDataHandling"``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+ 
+   * - String
+     - Description
+ 
+   * - ``"requireEmptyDestination"``
+     - ``mongosync`` requires databases on the destination
+       cluster that you want to replicate from the source
+       cluster are empty. ``"requireEmptyDestination"`` is the default.
+   * - ``"ignorePreExistingData"``
+     - ``mongosync`` ignores existing databases on the destination
+       cluster. Ensure your destination namespaces are different from
+       those ``mongosync`` replicates from the source cluster.
+
+If you omit a ``"destinationDataHandling"`` string, and the destination
+cluster has user data, ``mongosync`` returns an error. Otherwise,
+``mongosync`` continues the sync operation.
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+
+   .. step:: Connect the source and destination clusters
+
+      The following example connects a source cluster (``cluster0``)
+      with a destination cluster (``cluster1``):
+
+      .. code-block:: shell
+
+         mongosync \
+            --cluster0 "mongodb://localhost:27000" \
+            --cluster1 "mongodb://localhost:35000"
+
+   .. step:: Set the destinationDataHandling string
+
+      The following example sets ``"destinationDataHandling"`` to
+      ``"ignorePreExistingData"``:
+
+      .. code-block:: shell
+         :emphasize-lines: 6
+
+         curl localhost:27182/api/v1/start -XPOST \
+         --data '
+            {
+               "source": "cluster0",
+               "destination": "cluster1",
+               "destinationDataHandling": "ignorePreExistingData"
+            } '
+
+      The sync operation continues.
+
+Learn More
+----------
+
+- :ref:`c2c-quickstart`
+- :ref:`c2c-sharded-clusters`
+
+.. include:: /includes/beta-feature.rst

--- a/source/reference/beta-program/document-filtering.txt
+++ b/source/reference/beta-program/document-filtering.txt
@@ -1,0 +1,89 @@
+.. _c2c-beta-document-filtering:
+
+==================
+Document Filtering
+==================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+.. include:: /includes/document-filtering-intro.rst
+
+To use document filtering, both the source cluster and destination cluster must 
+use MongoDB 6.0 or later. 
+
+Syntax 
+------
+
+The :ref:`c2c-api-start` API endpoint accepts an optional ``documentFilter`` 
+parameter with the following syntax:
+
+.. code-block:: json
+   :copyable: false
+
+   "documentFilter" : {
+      "field" : <field-name>,
+      "matchValues" : [<field-values>] 
+   }
+
+Parameter Fields 
+----------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field 
+     - Type 
+     - Necessity 
+     - Description 
+
+   * - ``field`` 
+     - String
+     - Required 
+     - Field name  
+
+   * - ``matchValues`` 
+     - Array 
+     - Required 
+     - Field value(s) that a document must have in order to migrate.
+
+Limitations
+-----------
+
+.. include:: /includes/document-filtering-limitations.rst
+
+Examples 
+--------
+
+Start ``mongosync`` with a Document Filter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/intro-start-api-example-intro.rst
+
+``cluster0`` contains the ``travel`` database, which includes the 
+``restaurants``, ``attractions``, and ``lodging`` collections. Documents in the 
+``restaurants``, ``attractions``, and ``lodging`` collections all contain a 
+``city`` field. 
+
+The ``documentFilter`` document in this example filters for documents where the 
+``city`` field is either ``Los Angeles``, ``New York``, or ``San Francisco``. 
+
+.. code-block:: json
+
+   "documentFilter" : {
+             field : "city",
+             matchValues: [ "Los Angeles", "New York", "San Francisco" ]
+         }
+
+Learn More 
+----------
+
+- :ref:`c2c-beta-program`
+- :ref:`c2c-api-start`

--- a/source/reference/beta-program/many-to-one.txt
+++ b/source/reference/beta-program/many-to-one.txt
@@ -1,0 +1,100 @@
+.. _c2c-beta-many-to-one:
+
+======================
+Many-to-One Migrations
+======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+.. include:: /includes/many-to-one-cluster.rst
+
+Syntax 
+------
+
+To sync multiple source clusters with one destination cluster, run the following 
+commands when starting :ref:`mongosync <c2c-mongosync>`: 
+
+.. code-block:: shell
+
+   ./bin/mongosync \
+         --cluster0 <source-A-connection-string> \
+         --cluster1 <destination-connection-string> \
+         --migrationName <string>
+
+   ./bin/mongosync \
+         --cluster0 <source-B-connection-string> \
+         --cluster1 <destination-connection-string> \
+         --migrationName <string>
+
+To start the sync operation between the source clusters and the
+destination cluster, see :ref:`c2c-quickstart-synchronize`.
+
+Behavior 
+--------
+
+A namespace is a ``database_name.collection_name`` combination. You can only 
+sync namespaces that don't conflict. 
+   
+For example, consider this scenario:
+
+- Two source clusters S1 and S2.
+- A destination cluster D.
+- Databases named ``inventory`` and ``sales`` on both S1 and S2.
+- Collections named ``products``, ``orderLines``, ``orderStatus``, and 
+  ``orders`` on both S1 and S2.
+- You can sync both of these combinations:
+  
+  - ``inventory.products`` and ``sales.orderStatus`` on S1 with D.
+  - ``inventory.orderLines`` and ``sales.orders`` on S2 with D.
+
+- You cannot sync both of these combinations because they conflict:
+
+  - ``inventory.products`` and ``inventory.orderLines`` on S1 with D. If D is 
+    initially empty, you can sync S1 with D. ``inventory.products`` and 
+    ``inventory.orderLines`` are copied from S1 to D.
+  - ``inventory.products`` and ``inventory.orderLines`` on S2 with D. You cannot 
+    sync S2 with D because ``inventory.products`` and ``inventory.orderLines`` 
+    conflict with the namespaces already on D from the scenario in the previous 
+    point.
+
+Migration Name 
+~~~~~~~~~~~~~~
+
+.. include:: /includes/migration-name-limitation.rst
+
+.. _c2c-beta-many-to-one-example: 
+
+Example 
+-------
+
+The following example connects source clusters running on port ``27000``
+and ``27001`` with a destination cluster running on port ``35000``. The command 
+also sets the :option:`--migrationName` option to 
+describe the operations and store migration metadata for each sync.
+
+.. code-block:: shell
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27000" \
+         --cluster1 "mongodb://localhost:35000" \
+         --migrationName "cluster_27000_to_cluster_35000_sync"
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27001" \
+         --cluster1 "mongodb://localhost:35000" \
+         --migrationName "cluster_27001_to_cluster_35000_sync"
+
+Learn More 
+----------
+
+- :ref:`c2c-beta-program`
+- :ref:`c2c-config`
+- :ref:`c2c-mongosync`

--- a/source/reference/beta-program/namespace-remapping.txt
+++ b/source/reference/beta-program/namespace-remapping.txt
@@ -1,0 +1,140 @@
+.. _c2c-beta-namespace-remapping:
+
+===================
+Namespace Remapping
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+.. include:: /includes/namespace-remapping-intro.rst
+
+To use namespace remapping, both the source cluster and destination cluster must 
+use MongoDB 6.0 or later. 
+
+Syntax
+------
+
+The :ref:`/start <c2c-api-start>` API endpoint accepts an optional ``namespaceRemap``
+parameter with the following syntax:
+
+.. code-block:: sh
+
+   curl <host>:<port>/api/v1/start -XPOST \
+   --data '
+      {
+         "source": "cluster0",
+         "destination": "cluster1"
+         "namespaceRemap": [
+            {
+               "from": {
+                  "database": "<source-database>"
+               },
+               "to": {
+                  "database": "<destination-database>"
+               }
+            }
+         ]
+      } '
+
+Parameter Fields
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 20 13 13 54
+
+   * - Field
+     - Type
+     - Required
+     - Description
+   * - ``namespaceRemap``
+     - array
+     - Optional
+     - Array of documents that specify namespace changes to make during sync.
+
+       .. versionadded:: 1.8 Beta
+
+   * - ``namespaceRemap[n].`` ``from``
+     - document
+     - Required
+     - Document that specifies the database on the source cluster
+       to migrate from in the remapping operation.
+
+       .. versionadded:: 1.8 Beta
+
+   * - ``namespaceRemap[n].`` ``from.database``
+     - string
+     - Required
+     - Database to migrate from on the source cluster.
+
+       .. versionadded:: 1.8 Beta
+
+   * - ``namespaceRemap[n].`` ``to``
+     - document
+     - Required
+     - Document that specifies the database on the destination cluster
+       to migrate to in the remapping operation.
+
+       .. versionadded:: 1.8 Beta
+
+   * - ``namespaceRemap[n].`` ``to.database``
+     - string
+     - Required
+     - Database to migrate to on the destination cluster.
+
+       .. versionadded:: 1.8 Beta
+
+
+Behavior
+--------
+
+Valid Namespace Remapping
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/fact-valid-namespace-remap
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+
+   .. step:: Connect the source and destination clusters
+
+      The following example connects a source cluster (``cluster0``)
+      with a destination cluster (``cluster1``):
+
+      .. code-block:: shell
+
+         mongosync \
+            --cluster0 "mongodb://localhost:27000" \
+            --cluster1 "mongodb://localhost:35000"
+
+   .. step:: Sync the clusters with namespace remapping
+
+      The following :ref:`/start <c2c-api-start>` call starts sync and remaps the
+      ``accounts`` database on the source cluster to
+      ``sales`` database on the destination cluster:
+
+      .. literalinclude:: /includes/api/requests/start-namespace-remap.sh
+         :language: shell
+
+      Example response:
+
+      .. literalinclude:: /includes/api/responses/success.json
+         :language: json
+         :copyable: false
+
+Learn More
+----------
+
+- :ref:`/start <c2c-api-start>`

--- a/source/reference/beta-program/orr.txt
+++ b/source/reference/beta-program/orr.txt
@@ -1,0 +1,66 @@
+.. _c2c-beta-orr:
+
+=========================
+Oplog Rollover Resilience
+=========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/beta-feature.rst
+
+Starting in {+c2c-beta-program-short+} 1.8, you can enable Oplog Rollover 
+Resilience (ORR). With ORR,  ``mongosync`` applies changes made on 
+the source cluster to the destination cluster concurrently with initial sync.
+
+By applying changes earlier in the sync process, ``mongosync`` maintains a more 
+recent position in the :term:`oplog`. For source clusters with a high write 
+rate, ORR significantly lowers the risk of oplog rollover during initial sync 
+and reduces the need to restart the sync.
+
+Syntax 
+------
+
+To enable ORR, use ``--oplogRolloverResilienceIntervalSeconds`` and specify the 
+interval, in seconds, in which ``mongosync`` checks for eligible change events 
+in the oplog. The default value is ``-1``, which disables ORR.
+
+For example, to start ``mongosync`` with the 
+``oplogRolloverResilienceIntervalSeconds`` set to ``60`` seconds, run the 
+following command: 
+
+.. code-block:: shell 
+   :copyable: false
+
+   ./bin/mongosync \
+         --cluster0 "mongodb://localhost:27000" \
+         --cluster1 "mongodb://localhost:27001" \
+         --oplogRolloverResilienceIntervalSeconds 60
+
+Behavior 
+--------
+
+ORR increases the resilience of ``mongosync`` to oplog rollover during initial 
+sync but does not prevent rollover entirely.
+
+You might exceed the :term:`oplog window` if you: 
+
+- Sync from a high write rate source cluster for an extended
+  period.
+- Pause sync for an extended period.
+
+To increase the size of the oplog on the source cluster, use
+:setting:`~replication.oplogSizeMB`. 
+
+Learn More 
+----------
+
+- :ref:`c2c-beta-program`
+- :ref:`Change Oplog Size <tutorial-change-oplog-size>`
+- :ref:`Workloads that Might Requre a Large Oplog Size 
+  <replica-set-large-oplog-required>`

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -111,6 +111,17 @@ Options
    To set the ``logPath`` setting from the command line, see the
    :option:`--logPath` option.
 
+.. setting:: migrationName
+
+   *Type*: string 
+
+   .. include:: /includes/beta-feature.rst
+
+   .. include:: /includes/opts/migrationName.rst
+   
+   To set the ``migrationName`` setting from the command line, see the
+   :option:`--migrationName` option.
+
 .. setting:: port
 
    *Type*: integer

--- a/source/reference/disaster-recovery.txt
+++ b/source/reference/disaster-recovery.txt
@@ -1,8 +1,8 @@
 .. _c2c-failure-recovery:
 
-=======================================
-Use ``mongosync`` for Disaster Recovery 
-=======================================
+=============================================
+Recover from a Failed ``mongosync`` Operation
+=============================================
 
 .. default-domain:: mongodb
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -77,14 +77,14 @@ Command Line Options
 Global Options
 ~~~~~~~~~~~~~~
 
-.. option:: --cluster0 <URI>
+.. option:: --cluster0 <uri>
 
    .. include:: /includes/opts/cluster0.rst
 
    To set the ``--cluster0`` option from a configuration file,
    see the :setting:`cluster0` setting.
 
-.. option:: --cluster1 <URI>
+.. option:: --cluster1 <uri>
 
    .. include:: /includes/opts/cluster1.rst
 
@@ -113,7 +113,7 @@ Global Options
 
    Prints usage information to stdout.
 
-.. option:: --id <ID>
+.. option:: --id <id>
 
    .. include:: /includes/opts/id.rst
 
@@ -131,7 +131,7 @@ Global Options
 
    .. include:: /includes/opts/loadlevel-warning.rst
    
-.. option:: --logPath <DIR>
+.. option:: --logPath <directory>
 
    .. include:: /includes/opts/logPath.rst
 
@@ -141,6 +141,15 @@ Global Options
    .. note:: 
 
       .. include:: /includes/fact-log-rotation-usr1-signal
+
+.. option:: --migrationName <name>
+
+   .. include:: /includes/beta-feature.rst
+
+   .. include:: /includes/opts/migrationName.rst
+
+   To set the ``--migrationName`` option from a configuration file,
+   see the :setting:`migrationName` setting.
 
 .. option:: --port
 

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -16,10 +16,13 @@ Release Notes for mongosync 1.8
 
 .. include:: /includes/in-dev.rst
 
+This page describes changes and new features introduced in  
+{+c2c-full-product-name+} {+version-dev+} and the {+c2c-full-beta-program+}.
+
 1.8.0 Release
 -------------
 
-**Upcoming**
+**August 2, 2024**
 
 Updates to ``mongosync`` ``/progress`` API endpoint
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -68,6 +71,59 @@ Issues Fixed:
 - Fixed a bug introduced in v1.0.0 that caused the ``mongosync`` 
   ``/progress`` endpoint to potentially return incorrect 
   ``totalBytes`` for sharded clusters.
+
+
+{+c2c-full-beta-program+}
+------------------------------------
+
+.. include:: /includes/beta-program-intro.rst
+
+In addition to the beta features, {+c2c-beta-program-short+} includes all 
+changes and new features from ``mongosync`` {+version-dev+}.
+
+To learn more, see :ref:`c2c-beta-program`.
+
+A->B->C Migrations
+~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/abc-migration-intro.rst
+
+To learn more, see :ref:`c2c-beta-abc-migration`.
+
+Many-to-One Migrations
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/many-to-one-cluster.rst
+
+To learn more, see :ref:`c2c-beta-many-to-one`.
+
+Document Filtering
+~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/document-filtering-intro.rst
+
+To learn more, see :ref:`c2c-beta-document-filtering`.
+
+Handle Destination Data with destinationDataHandling Option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/destinationDataHandling-introduction.rst
+
+For details, see :ref:`c2c-beta-destination-data-handling`.
+
+Namespace Remapping
+~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/namespace-remapping-intro.rst
+
+For more information, see :ref:`c2c-beta-namespace-remapping`.
+
+Oplog Rollover Resilience
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/orr-intro.rst
+
+To learn more, see :ref:`c2c-beta-orr`.
 
 
 Minimum Supported Version


### PR DESCRIPTION
Reverts mongodb/docs-cluster-to-cluster-sync#371

- **Context for 2x revert**: At the end of last week, we merged & published the C2C Beta docs (#370), but a last minute upstream change in the release date forced us to revert those changes and un-publish the docs. Now, we're reverting that previous revert to re-publish the C2C beta docs. Sorry for any confusion! 

Build from original merge operation:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66ad4fb0824f175afd28bbef