### PR TITLE
DOCSP-42176-c2c-1.8-fast-follow

### DIFF
--- a/source/includes/fact-valid-namespace-remap.rst
+++ b/source/includes/fact-valid-namespace-remap.rst
@@ -11,6 +11,9 @@ The following restrictions apply to namespace remapping:
 
 - Remapped database names on the destination cluster cannot differ only in case.
 
+- You can't specify a namespace remap and set the ``reversible`` flag to
+  ``true``.
+
 - The remap cannot produce namespace conflicts on the destination cluster.
 
   For example:

--- a/source/index.txt
+++ b/source/index.txt
@@ -4,8 +4,6 @@
 Cluster-to-Cluster Sync
 =======================
 
-.. include:: /includes/in-dev.rst
-
 .. default-domain:: mongodb
 
 {+c2c-product-name+} provides continuous data synchronization or a 

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -14,8 +14,6 @@ Release Notes for mongosync 1.8
 
 .. _1.8.0-c2c-release-notes:
 
-.. include:: /includes/in-dev.rst
-
 This page describes changes and new features introduced in  
 {+c2c-full-product-name+} {+version-dev+} and the {+c2c-full-beta-program+}.
 


### PR DESCRIPTION
## DESCRIPTION 
- Add limitation to namespace remapping 
- Remove in-dev.rst banners

## STAGING 
- [mongosync Landing page (removed in-dev banner)](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-42176-c2c-1.8-fast-follow/)
- [1.8 release notes (removed in-dev banner)](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-42176-c2c-1.8-fast-follow/release-notes/1.8/)
- [Namespace Remapping limitation](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-42176-c2c-1.8-fast-follow/reference/beta-program/namespace-remapping/#std-label-c2c-beta-namespace-remapping:~:text=You%20can%27t%20specify%20a%20namespace%20remap%20and%20set%20the%20reversible%20flag%20to%20true.)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-42176

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66b288f4824f175afd37f564