### PR TITLE
DOCSP-42292-update-redirects-config

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,6 +1,6 @@
 define: prefix docs/cluster-to-cluster-sync
 define: base https://www.mongodb.com/docs/cluster-to-cluster-sync
-define: versions v0.9 v1.7 master
+define: versions v0.9 v1.7 v1.8 master
 
 # raw: <source file> -> ${base}/<destination>
 

--- a/snooty.toml
+++ b/snooty.toml
@@ -28,9 +28,9 @@ toc_landing_pages = ["/quickstart",
                     ]
 
 [constants]
-version = "1.7"
-latest-version="1.7.2"
-version-dev = "1.8"
+version = "1.8"
+latest-version="1.8.0"
+version-dev = "1.9"
 c2c-product-name = "Cluster-to-Cluster Sync"
 c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"
 mdb-download-center = "`MongoDB Download Center <https://www.mongodb.com/try/download/mongosync>`__"

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -60,7 +60,7 @@ following disclaimer:
 Beta Features
 -------------
 
-{+c2c-beta-program-short+} {+version-dev+} includes the following features:
+{+c2c-beta-program-short+} {+version+} includes the following features:
 
 .. list-table::
    :header-rows: 1

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -15,7 +15,7 @@ Release Notes for mongosync 1.8
 .. _1.8.0-c2c-release-notes:
 
 This page describes changes and new features introduced in  
-{+c2c-full-product-name+} {+version-dev+} and the {+c2c-full-beta-program+}.
+{+c2c-full-product-name+} {+version+} and the {+c2c-full-beta-program+}.
 
 1.8.0 Release
 -------------
@@ -77,7 +77,7 @@ Issues Fixed:
 .. include:: /includes/beta-program-intro.rst
 
 In addition to the beta features, {+c2c-beta-program-short+} includes all 
-changes and new features from ``mongosync`` {+version-dev+}.
+changes and new features from ``mongosync`` {+version+}.
 
 To learn more, see :ref:`c2c-beta-program`.
 


### PR DESCRIPTION
## DESCRIPTION 
- Update redirects file to include 1.8 in `versions` variable.
- Update snooty.toml version constants for version
- Edited constants used to refer to beta program in 1.8 docs

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-42292-update-version-flipper/reference/beta-program/

## JIRA 
https://jira.mongodb.org/browse/DOCSP-42292

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66b4e57a824f175afdc93be3