### PR TITLE
DOCSP-37061-mongosync-timestamp-limitation

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -61,8 +61,8 @@ General Limitations
   <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>`__.
 - ``mongosync`` only supports clusters that use the :ref:`WiredTiger 
   <storage-wiredtiger>` storage engine.
-- ``mongosync`` does not support migrating documents that have an empty 
-  top-level timestamp, such as ``Timestamp(0,0)``.
+- You can't sync a collection with any documents that have an empty timestamp,
+  such as ``Timestamp(0,0)``. 
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -61,6 +61,8 @@ General Limitations
   <https://www.mongodb.com/docs/atlas/atlas-search/create-index/>`__.
 - ``mongosync`` only supports clusters that use the :ref:`WiredTiger 
   <storage-wiredtiger>` storage engine.
+- ``mongosync`` does not support migrating documents that have an empty 
+  top-level timestamp, ``Timestamp(0,0)``.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -62,7 +62,7 @@ General Limitations
 - ``mongosync`` only supports clusters that use the :ref:`WiredTiger 
   <storage-wiredtiger>` storage engine.
 - ``mongosync`` does not support migrating documents that have an empty 
-  top-level timestamp, ``Timestamp(0,0)``.
+  top-level timestamp, such as ``Timestamp(0,0)``.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
## DESCRIPTION
- Add timestamp limitation 

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-37061-mongosync-timestamp-limitation/reference/limitations/#general-limitations

## JIRA 
https://jira.mongodb.org/browse/DOCSP-37061

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66ba647a83839571177a6a44