### PR TITLE
DOCSP-39103 Minimum Server Versions

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -30,7 +30,7 @@ toc_landing_pages = ["/quickstart",
 [constants]
 version = "1.9"
 version-previous = "1.8"
-latest-version="1.8.0"
+latest-version="1.9.0"
 version-dev = "1.9"
 c2c-product-name = "Cluster-to-Cluster Sync"
 c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"

--- a/source/includes/fact-minimum-server-version-support.rst
+++ b/source/includes/fact-minimum-server-version-support.rst
@@ -1,1 +1,1 @@
-The minimum supported server versions of MongoDB are 6.0.13 and 7.0.8.
+The minimum supported server versions of MongoDB are 6.0.16 and 7.0.9.

--- a/source/reference/beta-program/document-filtering.txt
+++ b/source/reference/beta-program/document-filtering.txt
@@ -17,7 +17,7 @@ Document Filtering
 .. include:: /includes/document-filtering-intro.rst
 
 To use document filtering, both the source cluster and destination cluster must 
-use MongoDB 6.0 or later. 
+use a :ref:`supported MongoDB version <c2c-server-version-compatibility>`.
 
 Syntax 
 ------

--- a/source/reference/beta-program/namespace-remapping.txt
+++ b/source/reference/beta-program/namespace-remapping.txt
@@ -17,7 +17,7 @@ Namespace Remapping
 .. include:: /includes/namespace-remapping-intro.rst
 
 To use namespace remapping, both the source cluster and destination cluster must 
-use MongoDB 6.0 or later. 
+use :ref:`supported MongoDB version <c2c-server-version-compatibility>`.
 
 Syntax
 ------

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -222,6 +222,6 @@ Issues Fixed:
 Minimum Supported Version
 -------------------------
 
-In 1.7.2, the minimum supported version of MongoDB is 6.0.13 and 7.0.8.
+In 1.7.3, the minimum supported version of MongoDB is 6.0.13 and 7.0.6.
 
 .. include:: /includes/migration-upgrade-recommendation.rst


### PR DESCRIPTION
## DESCRIPTION
- Updates minimum supported server version for 1.8+
  - Note the values will be adjusted in the 1.7 backport
 - Updates minimum supported server version in 1.7.3

## STAGING 
- [mongosync reference - compatibility](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-39103-min-server-versions/reference/mongosync/#compatibility)
- [server version compatibility](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-39103-min-server-versions/reference/supported-server-version/#mongodb-server-version-compatibility) 
- [1.8 release notes](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-39103-min-server-versions/release-notes/1.8/#minimum-supported-version)
- [1.7 release notes](https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-39103-min-server-versions/release-notes/1.7/#minimum-supported-version)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-39103

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66be5b148e811ae6723689bb