### PR TITLE
DOCSP-36050 mongosync restarts with different source or destination 

### DIFF
--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -52,6 +52,9 @@ Other Changes:
 
 - ``mongosync`` now sends hostnames as telemetry.
 
+- ``mongosync`` now exits with an error if it stops and restarts with a
+  different source or destination cluster than previously specified. 
+
 - Improved performance of the initialization process by eliminating 
   the creation of unnecessary dummy indexes. ``mongosync`` now creates 
   dummy indexes for sharded collections only if the destination 


### PR DESCRIPTION
## DESCRIPTION 
- Add into 1.8 release notes that `mongosync` now errors if a sync restarts with different source/destination clusters

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-36050-mongosync-diff-source-error/release-notes/1.8/#other-notes:~:text=mongosync%20now%20exits%20with%20an%20error%20if%20it%20stops%20and%20restarts%20with%20a%20different%20source%20or%20destination%20cluster%20than%20previously%20specified.

## JIRA 
https://jira.mongodb.org/browse/DOCSP-36050

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66be60dd8e811ae672391f34