### PR TITLE
DOCSP-23892 adds warning for cluster options

### DIFF
--- a/source/includes/warn-option-cluster-password-visibility.rst
+++ b/source/includes/warn-option-cluster-password-visibility.rst
@@ -1,0 +1,8 @@
+.. warning::
+   On some systems, providing a password in a connection string with 
+   the ``--cluster0`` or ``--cluster1`` options may make the password 
+   visible to system status programs, such as ``ps``, that may be invoked 
+   by other users.
+
+   Consider using the :option:`--config` option to specify a 
+   configuration file containing the password instead.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -84,12 +84,16 @@ Global Options
    To set the ``--cluster0`` option from a configuration file,
    see the :setting:`cluster0` setting.
 
+   .. warning:: /includes/warn-option-cluster-password-visibility.rst
+
 .. option:: --cluster1 <uri>
 
    .. include:: /includes/opts/cluster1.rst
 
    To set the ``--cluster1`` option from a configuration file,
    see the :setting:`cluster1` setting.
+
+   .. warning:: /includes/warn-option-cluster-password-visibility.rst
 
 .. option:: --config <filename>
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -84,7 +84,7 @@ Global Options
    To set the ``--cluster0`` option from a configuration file,
    see the :setting:`cluster0` setting.
 
-   .. warning:: /includes/warn-option-cluster-password-visibility.rst
+   .. include:: /includes/warn-option-cluster-password-visibility.rst
 
 .. option:: --cluster1 <uri>
 
@@ -93,7 +93,7 @@ Global Options
    To set the ``--cluster1`` option from a configuration file,
    see the :setting:`cluster1` setting.
 
-   .. warning:: /includes/warn-option-cluster-password-visibility.rst
+   .. include:: /includes/warn-option-cluster-password-visibility.rst
 
 .. option:: --config <filename>
 


### PR DESCRIPTION
# Description
Adds a warning to the `--cluster0` and `--cluster1` options about password visibility when using these options.

# JIRA Ticket
https://jira.mongodb.org/browse/DOCSP-23892

# Staging
[--cluster0](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-23892/reference/mongosync/#std-option-mongosync.--cluster0)
[--cluster1](https://preview-mongodbjwilsonmdb.gatsbyjs.io/cluster-sync/DOCSP-23892/reference/mongosync/#std-option-mongosync.--cluster1)

# Build Log
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66be69b38e811ae6723b7e1a