### PR TITLE
DOCSP-35777 Source Writes After Commit

### DIFF
--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -23,8 +23,13 @@ Requirements
 
 Before using the ``commit`` endpoint:
 
-- Stop your application. This ensures that no additional writes occur on
-  the source cluster.
+- Stop your application to prevent any further writes to the source cluster. 
+  During commit, you may still read from the source cluster.
+  
+  .. warning:: 
+
+     If you write to the source cluster during commit, you might experience 
+     data loss. 
 
 - Use the :ref:`progress <c2c-api-progress>` endpoint to confirm the
   following values:


### PR DESCRIPTION
## DESCRIPTION
- Reword `commit` limitation regarding mongosync forbidding source writes until commit
- Add warning for potential data loss

## STAGING 
https://preview-mongodbajhuhmdb.gatsbyjs.io/cluster-sync/DOCSP-35777-source-writes-requirement/reference/api/commit/#requirements

## JIRA 
https://jira.mongodb.org/browse/DOCSP-35777

## BUILD
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66be6f8d8e811ae6723d0d6b