### PR TITLE
DOCSP-42568 Cluster B Size for ABC Migration

### DIFF
--- a/source/reference/beta-program/abc-migration.txt
+++ b/source/reference/beta-program/abc-migration.txt
@@ -58,6 +58,13 @@ For better performance, ensure that the first migration (A->B) reaches
 see if a migration reached ``change event application``, check the ``info`` 
 field in the :ref:`c2c-api-progress` response document.
 
+Cluster Size
+~~~~~~~~~~~~
+
+Writes from cluster A and reads from cluster C can result in heavy loads for
+cluster B. Ensure that cluster B is sufficiently sized and can handle simultaneous
+read and write loads.
+
 Migration Name 
 ~~~~~~~~~~~~~~
 

--- a/source/reference/beta-program/abc-migration.txt
+++ b/source/reference/beta-program/abc-migration.txt
@@ -58,8 +58,8 @@ For better performance, ensure that the first migration (A->B) reaches
 see if a migration reached ``change event application``, check the ``info`` 
 field in the :ref:`c2c-api-progress` response document.
 
-Cluster Size
-~~~~~~~~~~~~
+Cluster B Size
+~~~~~~~~~~~~~~
 
 Writes from cluster A and reads from cluster C can result in heavy loads for
 cluster B. Ensure that cluster B is sufficiently sized and can handle simultaneous


### PR DESCRIPTION
## Description

Adds note about sizing cluster B to handle a heavy load from A and C.

## Staging
[Cluster B Size](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-42568-abc-notice/reference/beta-program/abc-migration/#cluster-size)

## Jira
[DOCSP-42568](https://jira.mongodb.org/browse/DOCSP-42568)

## Build
* [2024-08-16](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66bf92c18e811ae6727c5c18)
* [2024-08-16 / 1](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66bfcb0c8e811ae6728fdcba)