### PR TITLE
DOCSP-42728 ignorePreExistingNamespaces

### DIFF
--- a/source/reference/beta-program/destinationDataHandling.txt
+++ b/source/reference/beta-program/destinationDataHandling.txt
@@ -48,7 +48,7 @@ The following table shows the strings you can set for
      - ``mongosync`` requires databases on the destination
        cluster that you want to replicate from the source
        cluster are empty. ``"requireEmptyDestination"`` is the default.
-   * - ``"ignorePreExistingData"``
+   * - ``"ignorePreExistingNamespaces"``
      - ``mongosync`` ignores existing databases on the destination
        cluster. Ensure your destination namespaces are different from
        those ``mongosync`` replicates from the source cluster.
@@ -77,7 +77,7 @@ Steps
    .. step:: Set the destinationDataHandling string
 
       The following example sets ``"destinationDataHandling"`` to
-      ``"ignorePreExistingData"``:
+      ``"ignorePreExistingNamespaces"``:
 
       .. code-block:: shell
          :emphasize-lines: 6
@@ -87,7 +87,7 @@ Steps
             {
                "source": "cluster0",
                "destination": "cluster1",
-               "destinationDataHandling": "ignorePreExistingData"
+               "destinationDataHandling": "ignorePreExistingNamespaces"
             } '
 
       The sync operation continues.


### PR DESCRIPTION
## DESCRIPTION 
- Replaces mis-documented `ignorePreExistingData` field with `ignorePreExistingNamespaces`

## STAGING 


## JIRA 
https://jira.mongodb.org/browse/DOCSP-42728

## BUILD  