### PR TITLE
DOCSP-38635 sync active source cluster

### DIFF
--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -37,6 +37,10 @@ the rest of the {+c2c-product-name+} documentation.
   meet the minimum patch :ref:`version requirements
   <c2c-server-version-compatibility>`.
 
+- The source cluster may remain active during sync. After it
+  performs the initial sync, ``mongosync`` continues to sync new
+  writes on the source cluster to the destination.
+
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.
 

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -39,7 +39,7 @@ the rest of the {+c2c-product-name+} documentation.
 
 - The source cluster may remain active during sync. After it
   performs the initial sync, ``mongosync`` continues to sync new
-  writes on the source cluster to the destination.
+  writes from the source cluster.
 
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -37,9 +37,9 @@ the rest of the {+c2c-product-name+} documentation.
   meet the minimum patch :ref:`version requirements
   <c2c-server-version-compatibility>`.
 
-- The source cluster remains active during sync. ``mongosync``
-  syncs new writes on the source cluster for the duration of the
-  migration.
+- The source cluster can remain active until commit because 
+  ``mongosync`` syncs writes on the source cluster for the 
+  duration of the migration.
 
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -37,9 +37,9 @@ the rest of the {+c2c-product-name+} documentation.
   meet the minimum patch :ref:`version requirements
   <c2c-server-version-compatibility>`.
 
-- The source cluster may remain active during sync. After it
-  performs the initial sync, ``mongosync`` continues to sync new
-  writes from the source cluster.
+- The source cluster may remain active during sync.
+  ``mongosync`` continues to sync new writes from the source
+  cluster for the duration of the migration.
 
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -39,7 +39,7 @@ the rest of the {+c2c-product-name+} documentation.
 
 - The source cluster can remain active until commit because 
   ``mongosync`` syncs writes on the source cluster for the 
-  duration of the migration.
+  duration of the migration until commit is called.
 
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -37,9 +37,9 @@ the rest of the {+c2c-product-name+} documentation.
   meet the minimum patch :ref:`version requirements
   <c2c-server-version-compatibility>`.
 
-- The source cluster may remain active during sync.
-  ``mongosync`` continues to sync new writes from the source
-  cluster for the duration of the migration.
+- The source cluster remains active during sync. ``mongosync``
+  syncs new writes on the source cluster for the duration of the
+  migration.
 
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.


### PR DESCRIPTION
## Description

Adds note to quickstart that the source cluster can remain active during sync.

## Staging

[Quickstart](https://preview-mongodbkennethdyer.gatsbyjs.io/cluster-sync/DOCSP-38635-active-source/quickstart/), last bullet.

## JIRA
[DOCSP-38635](https://jira.mongodb.org/browse/DOCSP-38635)

## Build
* [2024-08-22](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66c784fe40f3e3c8734df2d4)