### PR TITLE
DOCSP-43489-reverse-filtered-sync-compat

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -135,7 +135,7 @@ Response
 Behavior
 --------
 
-The reverse endpoint starts the ``REVERSING`` state. ``mongosync`` swaps the 
+The ``reverse`` endpoint starts the ``REVERSING`` state. ``mongosync`` swaps the 
 source and destination clusters and resumes applying change events.
 
 If the ``reverse`` sync is successful, ``mongosync`` enters the
@@ -157,6 +157,6 @@ Endpoint Protection
 Limitations
 ~~~~~~~~~~~
 
-The reverse endpoint does not support :ref:`filtered sync <c2c-filtered-sync>`.
+The ``reverse`` endpoint does not support :ref:`filtered sync <c2c-filtered-sync>`.
 
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -147,10 +147,16 @@ To view the mapping direction for the synchronization of the source and
 destination clusters, use the :ref:`progress <c2c-api-progress>`
 endpoint and check the ``directionMapping`` object.
 
+
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~
 
 .. |endpoint| replace:: ``reverse``
 .. include:: /includes/fact-api-endpoint
+
+Limitations
+~~~~~~~~~~~
+
+The reverse endpoint does not support :ref:`filtered sync <c2c-filtered-sync>`.
 
 


### PR DESCRIPTION
## DESCRIPTION 
- Adds limitation to `reverse` endpoint documentation that it isn't supported with filtered sync.

## STAGING 
https://deploy-preview-409--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/#limitations

## JIRA
https://jira.mongodb.org/browse/DOCSP-43489

