### PR TITLE
DOCSP-42285-mongosync-move-primary

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -107,6 +107,13 @@ When the CEA phase begins, ``mongosync`` applies the change events
 that are received during the collection copy phase before processing the 
 events that are received during the CEA phase. 
 
+.. note::
+
+   Starting in MongoDB 8.0, ``movePrimary`` doesn't invalidate
+   collections that have change streams. The change streams can continue
+   to read events from collections after the collections are moved to a
+   new shard.
+
 Pause Sync
 ~~~~~~~~~~
 

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -110,9 +110,9 @@ events that are received during the CEA phase.
 .. note::
 
    Starting in MongoDB 8.0, the :dbcommand:`movePrimary` command doesn't
-   invalidate collections that have change streams. The change streams
-   can continue to read events from collections after the collections
-   are moved to a new shard.
+   invalidate collections that have change streams. Change streams
+   continue to read events from collections after the collections are
+   moved to a new shard.
 
 Pause Sync
 ~~~~~~~~~~

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -109,10 +109,10 @@ events that are received during the CEA phase.
 
 .. note::
 
-   Starting in MongoDB 8.0, ``movePrimary`` doesn't invalidate
-   collections that have change streams. The change streams can continue
-   to read events from collections after the collections are moved to a
-   new shard.
+   Starting in the MongoDB 8.0 server, ``movePrimary`` doesn't
+   invalidate collections that have change streams. The change streams
+   can continue to read events from collections after the collections
+   are moved to a new shard.
 
 Pause Sync
 ~~~~~~~~~~

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -111,8 +111,8 @@ events that are received during the CEA phase.
 
    Starting in MongoDB 8.0, the :dbcommand:`movePrimary` command doesn't
    invalidate collections that have change streams. Change streams
-   continue to read events from collections after the collections are
-   moved to new shards.
+   continue to read events from collections after the collections move
+   to new shards.
 
 Pause Sync
 ~~~~~~~~~~

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -109,10 +109,10 @@ events that are received during the CEA phase.
 
 .. note::
 
-   Starting in the MongoDB 8.0 server, ``movePrimary`` doesn't
-   invalidate collections that have change streams. The change streams
-   can continue to read events from collections after the collections
-   are moved to a new shard.
+   Starting in the MongoDB 8.0 server, the :dbcommand:`movePrimary`
+   command doesn't invalidate collections that have change streams. The
+   change streams can continue to read events from collections after the
+   collections are moved to a new shard.
 
 Pause Sync
 ~~~~~~~~~~

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -109,10 +109,10 @@ events that are received during the CEA phase.
 
 .. note::
 
-   Starting in the MongoDB 8.0 server, the :dbcommand:`movePrimary`
-   command doesn't invalidate collections that have change streams. The
-   change streams can continue to read events from collections after the
-   collections are moved to a new shard.
+   Starting in MongoDB 8.0, the :dbcommand:`movePrimary` command doesn't
+   invalidate collections that have change streams. The change streams
+   can continue to read events from collections after the collections
+   are moved to a new shard.
 
 Pause Sync
 ~~~~~~~~~~

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -112,7 +112,7 @@ events that are received during the CEA phase.
    Starting in MongoDB 8.0, the :dbcommand:`movePrimary` command doesn't
    invalidate collections that have change streams. Change streams
    continue to read events from collections after the collections are
-   moved to a new shard.
+   moved to new shards.
 
 Pause Sync
 ~~~~~~~~~~


### PR DESCRIPTION
Additions to C2C per JIRA:
https://jira.mongodb.org/browse/DOCSP-42285

Just needs a short note for this C2C update. The main updates are already done in the internal docs server repo:
https://github.com/10gen/docs-mongodb-internal/commit/a3a27ced2a62bcef9ee1a6929155a0f3baf6f8d0

Staging:
https://deploy-preview-415--docs-cluster-to-cluster-sync.netlify.app/about-mongosync/#change-event-application
