### PR TITLE
DOCSP-42974-c2c-nested-components

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -44,11 +44,9 @@
        ``mongosync`` applied to the destination cluster and the latest
        timestamp on the source cluster for this instance of ``mongosync``.
 
-       .. note::
-
-          ``mongosync`` performs periodic no-op writes on the source cluster,
-          which may prevent the value of the ``lagTimeSeconds`` field from
-          reaching zero until ``mongosync`` commits the migration.
+       ``mongosync`` performs periodic no-op writes on the source cluster,
+       which may prevent the value of the ``lagTimeSeconds`` field from
+       reaching zero until ``mongosync`` commits the migration.
 
        Due to constant no-ops on the source cluster, the time difference
        is often a few seconds above zero, even if there are no real
@@ -76,13 +74,12 @@
        ``mongosync`` instances during the initial copying of
        collections.
        
-       .. note::
 
-         ``mongosync`` approximates the estimated total number of bytes
-         prior to migration and does not update this value during the
-         synchronization process. This value does not reflect changes
-         made to the source cluster during sync and is not an accurate
-         indicator of migration progress. 
+       ``mongosync`` approximates the estimated total number of bytes
+       prior to migration and does not update this value during the
+       synchronization process. This value does not reflect changes
+       made to the source cluster during sync and is not an accurate
+       indicator of migration progress. 
 
    * - ``collectionCopy``
        ``.estimatedCopiedBytes``
@@ -96,13 +93,12 @@
        and divide the result by the value of the ``estimatedTotalBytes`` field
        . Then, multiply the result by 100.
 
-       .. note::
 
-         The value of ``estimatedCopiedBytes`` may be larger than the
-         value of the ``estimatedTotalBytes`` due to retried operations.
-         A comparison of ``estimatedTotalBytes`` and
-         ``estimatedCopiedBytes`` is not an accurate indicator of
-         migration progress.  
+       The value of ``estimatedCopiedBytes`` may be larger than the
+       value of the ``estimatedTotalBytes`` due to retried operations.
+       A comparison of ``estimatedTotalBytes`` and
+       ``estimatedCopiedBytes`` is not an accurate indicator of
+       migration progress.  
 
    * - ``directionMapping``
      - object

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -171,7 +171,7 @@ characteristics that ``mongosync`` alters during the synchronization process.
        - On the destination cluster during sync.
        - On the source cluster when ``commit`` is received.
 
-       .. seealso:: 
+       See also:
 
           :ref:`c2c-write-blocking`
   

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -172,8 +172,7 @@ characteristics that ``mongosync`` alters during the synchronization process.
        - On the source cluster when ``commit`` is received.
 
        See also:
-
-          :ref:`c2c-write-blocking`
+       :ref:`c2c-write-blocking`
   
    * - Capped Collections
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -95,11 +95,9 @@ Request Body Parameters
          during sync.  This can improve migration performance, especially with 
          index heavy workloads.
 
-         .. warning::
-
-            Do **not** manually build indexes while ``mongosync`` is 
-            performing a migration.  Wait until the migration is fully 
-            committed.
+         :red:`WARNING:` Do **not** manually build indexes while ``mongosync`` is 
+         performing a migration.  Wait until the migration is fully 
+         committed.
 
          For more information on the indexes it does build, see 
          :ref:`c2c-required-indexes`.


### PR DESCRIPTION
## DESCRIPTION

Removed admonitions in tables.

## STAGING

https://deploy-preview-416--docs-cluster-to-cluster-sync.netlify.app/reference/api/commit/

https://deploy-preview-416--docs-cluster-to-cluster-sync.netlify.app/reference/api/progress/

https://deploy-preview-416--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/

## JIRA

https://jira.mongodb.org/browse/DOCSP-42974

## BUILD LOG

https://app.netlify.com/sites/docs-cluster-to-cluster-sync/deploys/66e9d7caba87220008efcfe4
