### PR TITLE
DOCSP-43751-mongosync-beta-reverse

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -159,4 +159,6 @@ Limitations
 
 The ``reverse`` endpoint does not support :ref:`filtered sync <c2c-filtered-sync>`.
 
+Mongosync ``reverse`` mode is not compatible with any beta features. 
+
 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -159,6 +159,4 @@ Limitations
 
 The ``reverse`` endpoint does not support :ref:`filtered sync <c2c-filtered-sync>`.
 
-Mongosync ``reverse`` mode is not compatible with any beta features. 
-
 

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -100,7 +100,7 @@ Beta Features
 .. note:: 
 
    Mongosync :ref:`c2c-api-reverse` mode is not compatible with any beta 
-   features. 
+   features except :ref:`c2c-beta-orr`.
 
 Feature Compatibility Matrix
 ----------------------------

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -109,12 +109,12 @@ The following table shows supported combinations of beta features:
    Unsupported feature combinations do not have guardrails and can result in 
    undefined behavior.  
 
-.. include:: /includes/table-beta-compatibility.rst
-
 .. note:: 
 
    Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
    any of the above beta features. 
+
+.. include:: /includes/table-beta-compatibility.rst
 
 .. toctree::
    :titlesonly:

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -113,7 +113,7 @@ The following table shows supported combinations of beta features:
 
 .. note:: 
 
-   Currently, mongosync :ref:`.. _c2c-api-reverse:` mode is not compatible with 
+   Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
    any of the above beta features. 
 
 .. toctree::

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -112,7 +112,7 @@ The following table shows supported combinations of beta features:
 .. note:: 
 
    Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
-   any of the above beta features. 
+   any of the beta features below. 
 
 .. include:: /includes/table-beta-compatibility.rst
 

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -97,6 +97,11 @@ Beta Features
        guidelines and restrictions for migrating between older server 
        versions, you must have access to the {+c2c-beta-program-short+} binary.
 
+.. note:: 
+
+   Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
+   any beta features. 
+
 Feature Compatibility Matrix
 ----------------------------
 
@@ -108,11 +113,6 @@ The following table shows supported combinations of beta features:
 
    Unsupported feature combinations do not have guardrails and can result in 
    undefined behavior.  
-
-.. note:: 
-
-   Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
-   any of the beta features below. 
 
 .. include:: /includes/table-beta-compatibility.rst
 

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -99,8 +99,8 @@ Beta Features
 
 .. note:: 
 
-   Currently, mongosync :ref:`c2c-api-reverse` mode is not compatible with 
-   any beta features. 
+   Mongosync :ref:`c2c-api-reverse` mode is not compatible with any beta 
+   features. 
 
 Feature Compatibility Matrix
 ----------------------------

--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -111,6 +111,11 @@ The following table shows supported combinations of beta features:
 
 .. include:: /includes/table-beta-compatibility.rst
 
+.. note:: 
+
+   Currently, mongosync :ref:`.. _c2c-api-reverse:` mode is not compatible with 
+   any of the above beta features. 
+
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
## DESCRIPTION

Added a note explaining that mongosync reverse mode is not compatible with beta features. 

## STAGING

https://deploy-preview-424--docs-cluster-to-cluster-sync.netlify.app/reference/beta-program/

## JIRA

https://jira.mongodb.org/browse/DOCSP-43751

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)