### PR TITLE
DOCSP-44182-stable-release

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -11,13 +11,13 @@ more information on types of MongoDB releases, see
 To see changes in {+c2c-product-name+} releases, see the following
 release notes.
 
-Current Stable Release
-~~~~~~~~~~~~~~~~~~~~~~
+Current Release
+~~~~~~~~~~~~~~~
 
 - :ref:`c2c-release-notes-1.8`
 
-Previous Rapid Releases
-~~~~~~~~~~~~~~~~~~~~~~~
+Previous Releases
+~~~~~~~~~~~~~~~~~
 
 - :ref:`c2c-release-notes-1.7`
 - :ref:`c2c-release-notes-1.6`

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -11,19 +11,15 @@ more information on types of MongoDB releases, see
 To see changes in {+c2c-product-name+} releases, see the following
 release notes.
 
-Upcoming Stable Release
-~~~~~~~~~~~~~~~~~~~~~~~
-
-- :ref:`c2c-release-notes-1.8`
-
 Current Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`c2c-release-notes-1.7`
+- :ref:`c2c-release-notes-1.8`
 
 Previous Rapid Releases
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+- :ref:`c2c-release-notes-1.7`
 - :ref:`c2c-release-notes-1.6`
 - :ref:`c2c-release-notes-1.5`
 - :ref:`c2c-release-notes-1.4`


### PR DESCRIPTION
## DESCRIPTION 
- Updated current stable release on release notes for v1.8 branch. 
- **NOTE**: removed the "upcoming stable release" section since the 1.9 release notes aren't available on the v1.8 branch. The upcoming release section is visible on the [v1.9 branch](https://www.mongodb.com/docs/cluster-to-cluster-sync/upcoming/release-notes/)

## STAGING 
https://deploy-preview-425--docs-cluster-to-cluster-sync.netlify.app/release-notes/

## JIRA
https://jira.mongodb.org/browse/DOCSP-44182