### PR TITLE
DOCSP-43492-blocking-link-reverse-sync

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,12 +44,11 @@ To use the ``reverse`` endpoint:
   - ``reversible`` to ``true``
   - ``enableUserWriteBlocking`` to ``true``.
 
-  You cannot update these options after the sync starts. 
-
 .. note::
 
    :ref:`c2c-write-blocking` is a prerequisite for running ``reverse``.
 
+  You cannot update these options after the sync starts. 
 
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - The destination cluster oplog must not roll over between 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,11 +44,11 @@ To use the ``reverse`` endpoint:
   - ``reversible`` to ``true``
   - ``enableUserWriteBlocking`` to ``true``.
 
+You cannot update these options after the sync starts. 
+
 .. note::
 
    :ref:`c2c-write-blocking` is a prerequisite for running ``reverse``.
-
-  You cannot update these options after the sync starts. 
 
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - The destination cluster oplog must not roll over between 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -42,7 +42,7 @@ To use the ``reverse`` endpoint:
   call to the :ref:`/start <c2c-api-start>` API endpoint must set:
   
   - ``reversible`` to ``true``
-  - ``enableUserWriteBlocking`` to ``true``
+  - :ref:`c2c-write-blocking` to ``true``
   
   You cannot update these options after the sync starts.
 - ``mongosync`` must be in the ``COMMITTED`` state.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -44,11 +44,11 @@ To use the ``reverse`` endpoint:
   - ``reversible`` to ``true``
   - ``enableUserWriteBlocking`` to ``true``.
 
-You cannot update these options after the sync starts. 
-
 .. note::
 
    :ref:`c2c-write-blocking` is a prerequisite for running ``reverse``.
+
+You cannot update these options after the sync starts. 
 
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - The destination cluster oplog must not roll over between 

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -42,9 +42,15 @@ To use the ``reverse`` endpoint:
   call to the :ref:`/start <c2c-api-start>` API endpoint must set:
   
   - ``reversible`` to ``true``
-  - :ref:`c2c-write-blocking` to ``true``
-  
-  You cannot update these options after the sync starts.
+  - ``enableUserWriteBlocking`` to ``true``.
+
+  You cannot update these options after the sync starts. 
+
+.. note::
+
+   :ref:`c2c-write-blocking` is a prerequisite for running ``reverse``.
+
+
 - ``mongosync`` must be in the ``COMMITTED`` state.
 - The destination cluster oplog must not roll over between 
   ``mongosync`` reaching ``canWrite=true`` and receiving


### PR DESCRIPTION
## DESCRIPTION

Added a link to the write blocking page on the reverse API page.

## STAGING

https://deploy-preview-426--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/

## JIRA

https://jira.mongodb.org/browse/DOCSP-43492

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)