### PR TITLE
DOCSP-44006-mongosync-behavior-converting-legacy-indexes

### DIFF
--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -133,12 +133,12 @@ Read Preference
 connecting to the source and destination clusters. For more information,
 see :ref:`connections-read-preference`. 
 
-Legacy Index Value Rewrites
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Legacy Index Handling 
+~~~~~~~~~~~~~~~~~~~~~
 
-``mongosync`` does not support legacy index values, like ``0`` or an empty
-string. Legacy index values from the source are rewritten to ``1`` on the 
-destination.
+``mongosync`` rewrites legacy index values, like ``0`` or an empty
+string, to ``1`` on the destination. ``mongosync`` also removes any 
+invalid index options on the destination.
 
 .. _mongosync-considerations:
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -136,8 +136,8 @@ see :ref:`connections-read-preference`.
 Rewrites
 ~~~~~~~~
 
-``mongosync`` rewrites any legacy index values from the source to ``1``, 
-a valid value, on the destination. Legacy index values include ``0`` or an empty
+``mongosync`` rewrites any legacy index values from the source to ``1``
+on the destination. Legacy index values include ``0`` or an empty
 string. 
 
 .. _mongosync-considerations:

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -133,12 +133,12 @@ Read Preference
 connecting to the source and destination clusters. For more information,
 see :ref:`connections-read-preference`. 
 
-Rewrites
-~~~~~~~~
+Legacy Index Value Rewrites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``mongosync`` rewrites any legacy index values from the source to ``1``
-on the destination. Legacy index values include ``0`` or an empty
-string. 
+``mongosync`` does not support legacy index values, like ``0`` or an empty
+string. Legacy index values from the source are rewritten to ``1`` on the 
+destination.
 
 .. _mongosync-considerations:
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -133,6 +133,13 @@ Read Preference
 connecting to the source and destination clusters. For more information,
 see :ref:`connections-read-preference`. 
 
+Rewrites
+~~~~~~~~
+
+``mongosync`` rewrites any legacy index values from the source to ``1``, 
+a valid value, on the destination. Legacy index values include ``0`` or an empty
+string. 
+
 .. _mongosync-considerations:
 
 Considerations for Continuous Sync


### PR DESCRIPTION
## DESCRIPTION
Mongosync rewrites any legacy index key values that is 0 or an empty string from the source to a valid value (1) on the destination. This should be documented on the [mongosync behavior page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/mongosync/mongosync-behavior).

## STAGING
https://deploy-preview-442--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#legacy-index-value-rewrites

## JIRA
https://jira.mongodb.org/browse/DOCSP-44006

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
