### PR TITLE
DOCSP-44006-v1.7-backport 

### DIFF
--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -133,6 +133,13 @@ Read Preference
 connecting to the source and destination clusters. For more information,
 see :ref:`connections-read-preference`. 
 
+Legacy Index Handling 
+~~~~~~~~~~~~~~~~~~~~~
+
+``mongosync`` rewrites legacy index values, like ``0`` or an empty
+string, to ``1`` on the destination. ``mongosync`` also removes any 
+invalid index options on the destination.
+
 .. _mongosync-considerations:
 
 Considerations for Continuous Sync


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.7`:
 - [DOCSP-44006-mongosync-behavior-converting-legacy-indexes (#442)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/442)
 - [build log](https://app.netlify.com/sites/docs-cluster-to-cluster-sync/deploys/6717f1becfda6f00087e68d5)
