### PR TITLE
DOCSP-44635-global-cluster-limit

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -90,7 +90,7 @@ Sharded Clusters
 - ``mongosync`` doesn't support sync to a sharded cluster 
   topology with one or more arbiters.
 - ``mongosync`` doesn't support sync to or from :ref:`global clusters 
-  <global-clusters>`
+  <global-clusters>`.
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -89,6 +89,8 @@ Sharded Clusters
   to a replica set.
 - ``mongosync`` doesn't support sync to a sharded cluster 
   topology with one or more arbiters.
+- ``mongosync`` doesn't support sync to or from :ref:`global clusters 
+  <global-clusters>`
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 


### PR DESCRIPTION
## DESCRIPTION 
- Add to sharded cluster limitations that global clusters aren't supported as a source or destination

## STAGING 
https://deploy-preview-444--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#sharded-clusters:~:text=mongosync%20doesn%27t%20support%20sync%20to%20or%20from%20global%20clusters

## JIRA 
https://jira.mongodb.org/browse/DOCSP-44635