### PR TITLE
[v1.8] DOCSP-44635-global-cluster-limit (#444)

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -89,6 +89,8 @@ Sharded Clusters
   to a replica set.
 - ``mongosync`` doesn't support sync to a sharded cluster 
   topology with one or more arbiters.
+- ``mongosync`` doesn't support sync to or from :ref:`global clusters 
+  <global-clusters>`.
 - Sync from a replica set to a sharded cluster has the following
   limitations:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-44635-global-cluster-limit (#444)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/444)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)