### PR TITLE
DOCSP-44549-specify-supporting-index-behavior

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -228,7 +228,7 @@ The ``sharding`` option has the following parameters:
      - Optional. Sets whether sync creates a supporting index 
        for the shard key, if none exists.  Defaults to ``false``.
 
-       For more information and current limitations, see 
+       For more information and limitations, see 
        :ref:`c2c-supporting-index-behavior`.
 
    * - ``shardingEntries``

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -228,6 +228,9 @@ The ``sharding`` option has the following parameters:
      - Optional. Sets whether sync creates a supporting index 
        for the shard key, if none exists.  Defaults to ``false``.
 
+       For more information and current limitations, see 
+       :ref:`c2c-supporting-index-behavior`.
+
    * - ``shardingEntries``
      - array of documents
      - Required. Sets the namespace and key of collections to shard 
@@ -382,6 +385,8 @@ collections.
 
 The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
+
+.. _c2c-supporting-index-behavior:
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION

- the `mongosync` docs do mention that unique indexes on the source cluster that are part of sharded collections on the destination cluster *must have* the shard key as a prefix
    - but this info is only in the[ “Supporting Indexes”](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/start/#supporting-indexes) section!
    - this can be an issue if the user is looking at the ["Sharding Parameters"](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/start/#sharding-parameters) table and misses this info – can cause a failure during the commit phase of `mongosync`, which can take a while to get to!

This PR adds a link to the "Supporting Indexes" section in the `createSupportingIndexes` description under the "Sharding Parameters" table to ensure users don't miss this key detail.

## STAGING
https://deploy-preview-448--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#sharding-parameters

## JIRA
https://jira.mongodb.org/browse/DOCSP-44549

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
