### PR TITLE
DOCSP-43721-v1.7-backport (#445)

### DIFF
--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -99,14 +99,17 @@ Migration Verifier connects to the source and destination clusters and performs
 a series of verification checks, comparing documents, views, and indexes to
 confirm the sync was successful.
 
+Migration Verifier does not support DDL operations. Do not run any DDL 
+operations on the source cluster while verifying data with Migration Verifier. 
+
 .. important::
 
    Migration Verifier is an experimental and unsupported tool.
 
-   For installation instructions, see
+   For installation instructions and usage limitations, see
    `GitHub <https://github.com/mongodb-labs/migration-verifier>`__.
 
-Unlike other verification methods, Migration Verifier can run concurrent
+Unlike other verification methods, Migration Verifier can run concurrently
 with ``mongosync``, checking documents on the destination cluster as they
 sync.
 

--- a/source/reference/verification/verifier.txt
+++ b/source/reference/verification/verifier.txt
@@ -28,9 +28,14 @@ transferring your application load from the source to the destination cluster.
 About This Task
 ---------------
 
+.. note::
+
+   Migration Verifier does not support DDL operations. Do not run any DDL 
+   operations on the source cluster while verifying data with Migration Verifier. 
+
 Migration Verifier is an experimental and unsupported tool.
 
-For installation instructions, see
+For installation instructions and usage limitations, see
 `GitHub <https://github.com/mongodb-labs/migration-verifier>`__.
 
 Steps


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.7`:
 - [DOCSP-43721-migration-verifier-disclaimer #445](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/445)

# Staging

https://deploy-preview-449--docs-cluster-to-cluster-sync.netlify.app/reference/verification/#migration-verifier
https://deploy-preview-449--docs-cluster-to-cluster-sync.netlify.app/reference/verification/verifier/
