### PR TITLE
DOCSP-44549-v1.7-backport (448)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -218,6 +218,9 @@ The ``sharding`` option has the following parameters:
      - Optional. Sets whether sync creates a supporting index 
        for the shard key, if none exists.  Defaults to ``false``.
 
+       For more information and limitations, see 
+       :ref:`c2c-supporting-index-behavior`.
+
    * - ``shardingEntries``
      - array of documents
      - Required. Sets the namespace and key of collections to shard 
@@ -372,6 +375,8 @@ collections.
 
 The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
+
+.. _c2c-supporting-index-behavior:
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.7`:
 - [DOCSP-44549-specify-supporting-index-behavior #448](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/448)

# Staging

https://deploy-preview-450--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#sharding-parameters