### PR TITLE
DOCSP-44700-pre-split-chunks

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -365,7 +365,11 @@ Pre-Split Chunks
 When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
 for sharded collections on the destination cluster. For each sharded collection, 
 ``mongosync`` creates twice as many chunks as there are shards in the 
-destination cluster.
+destination cluster. This is supported in the following configurations:
+
+- Sync from a replica set to a sharded cluster.
+
+- Sync between sharded clusters.
 
 .. _c2c-shard-replica-sets:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -362,22 +362,15 @@ If the ``start`` request is successful, ``mongosync`` enters the
 Pre-Split Chunks
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.1
-
-When ``mongosync`` syncs to a sharded cluster, it pre-splits chunks for
-sharded collections on the destination cluster.  This is supported in the
-following configurations:
-
-* Sync from a replica set to a sharded cluster.
-
-* Sync between sharded clusters that differ in the number of shards.
+When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
+for sharded collections on the destination cluster. For each sharded collection, 
+``mongosync`` creates twice as many chunks as there are shards in the 
+destination cluster.
 
 .. _c2c-shard-replica-sets:
 
 Shard Replica Sets 
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 Sync from a replica set to a sharded cluster requires the 
 ``sharding`` option. This option configures how ``mongosync`` shards
@@ -390,8 +383,6 @@ Collections that are not listed in this array replicate as unsharded.
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 ``mongosync`` syncs indexes from the source cluster to the destination
 cluster.  But, when syncing from a replica set to a sharded cluster,
@@ -433,8 +424,6 @@ collections.
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 Collections listed in the ``sharding.shardingEntries`` array 
 when synced from a replica set to a sharded cluster 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -365,11 +365,7 @@ Pre-Split Chunks
 When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
 for sharded collections on the destination cluster. For each sharded collection, 
 ``mongosync`` creates twice as many chunks as there are shards in the 
-destination cluster. The following configurations pre-split chunks:
-
-- Sync from a replica set to a sharded cluster.
-
-- Sync between sharded clusters.
+destination cluster. 
 
 .. _c2c-shard-replica-sets:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -365,7 +365,7 @@ Pre-Split Chunks
 When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
 for sharded collections on the destination cluster. For each sharded collection, 
 ``mongosync`` creates twice as many chunks as there are shards in the 
-destination cluster. This is supported in the following configurations:
+destination cluster. The following configurations pre-split chunks:
 
 - Sync from a replica set to a sharded cluster.
 


### PR DESCRIPTION
## DESCRIPTION 
- Clarifies the number of chunks that are created when syncing to a sharded cluster. 

## STAGING 
https://deploy-preview-452--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#pre-split-chunks

## JIRA
https://jira.mongodb.org/browse/DOCSP-44700