### PR TITLE
[v1.7] DOCSP-44700-pre-split-chunks (#452)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -352,22 +352,15 @@ If the ``start`` request is successful, ``mongosync`` enters the
 Pre-Split Chunks
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 1.1
-
-When ``mongosync`` syncs to a sharded cluster, it pre-splits chunks for
-sharded collections on the destination cluster.  This is supported in the
-following configurations:
-
-* Sync from a replica set to a sharded cluster.
-
-* Sync between sharded clusters that differ in the number of shards.
+When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
+for sharded collections on the destination cluster. For each sharded collection, 
+``mongosync`` creates twice as many chunks as there are shards in the 
+destination cluster. 
 
 .. _c2c-shard-replica-sets:
 
 Shard Replica Sets 
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 Sync from a replica set to a sharded cluster requires the 
 ``sharding`` option. This option configures how ``mongosync`` shards
@@ -380,8 +373,6 @@ Collections that are not listed in this array replicate as unsharded.
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 ``mongosync`` syncs indexes from the source cluster to the destination
 cluster.  But, when syncing from a replica set to a sharded cluster,
@@ -423,8 +414,6 @@ collections.
 
 Rename During Sync
 ~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 1.1
 
 Collections listed in the ``sharding.shardingEntries`` array 
 when synced from a replica set to a sharded cluster 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.7`:
 - [DOCSP-44700-pre-split-chunks (#452)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/452)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)