### PR TITLE
[v1.8] DOCSP-44678-mongosync-8.0-support (#451)

### DIFF
--- a/source/includes/fact-no-8.0-support.rst
+++ b/source/includes/fact-no-8.0-support.rst
@@ -1,0 +1,2 @@
+``mongosync`` does not yet support migrations to and from clusters that use
+ MongoDB 8.0.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -37,6 +37,8 @@ To get started with ``mongosync``, refer to the :ref:`Quick Start Guide
 Compatibility
 -------------
 
+- .. include:: /includes/fact-no-8.0-support.rst
+
 - .. include:: /includes/fact-minimum-server-version-support.rst
      
   You can migrate data on clusters (source) with versions of MongoDB

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -15,6 +15,8 @@ MongoDB Server Version Compatibility
 Before you run {+c2c-product-name+}, consider the following MongoDB server 
 version limitations and requirements: 
 
+- .. include:: /includes/fact-no-8.0-support.rst
+
 - .. include:: /includes/fact-minimum-server-version-support.rst
 
 - ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
@@ -36,6 +38,8 @@ Synchronize Data Between Clusters with Different MongoDB Server Major Versions
 destination MongoDB server versions. 
 
 .. list-table:: 
+   :header-rows: 1
+   :stub-columns: 1
    :widths: 40 30 30 
 
    * - 
@@ -49,3 +53,28 @@ destination MongoDB server versions.
    * - **7.0** Source
      -  
      - √
+
+Synchronize Data From a Pre-8.0 Source Cluster to an 8.0 Destination Cluster 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To migrate data from a 6.0 or 7.0 source cluster to an 8.0 destination 
+cluster: 
+
+- Use ``mongosync`` to migrate data from your source cluster to a 7.0 
+  destination cluster.
+- Upgrade the 7.0 destination cluster to 8.0.
+
+Synchronize Data Between Two 8.0 Clusters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To migrate data between two 8.0 clusters:
+
+- Use :ref:`mongodump` to export data from the source cluster.
+- Use :ref:`mongorestore` to import the data into the destination cluster.
+
+For limitations on using ``mongodump`` and ``mongorestore``, see 
+:ref:`mongorestore-behavior-access-usage`.
+
+Alternatively, you can :ref:`downgrade your 8.0 source cluster <8.0-downgrade>` 
+to 7.0, migrate your data into a 7.0 destination cluster, and then upgrade the 
+destination cluster to 8.0.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-44678-mongosync-8.0-support (#451)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/451)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)