### PR TITLE
DOCSP-44876-rolling-index-limitation

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -178,7 +178,7 @@ Rolling Index Builds
 ``mongosync`` does not sync source cluster indexes that use a `rolling
 index build
 <https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/>`_.
-If your source cluster has an index with a rolling build, use on of the
+If your source cluster has an index with a rolling build, use one of the
 following options to ensure that your destination indexes match your
 source indexes:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -177,7 +177,7 @@ Rolling Index Builds
 
 ``mongosync`` does not sync source cluster indexes that use a `rolling
 index build
-<https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/>_.
+<https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/>`_.
 If your source cluster has an index with a rolling build, use on of the
 following options to ensure that your destination indexes match your
 source indexes:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -171,3 +171,18 @@ System Collections
 ------------------
 
 .. include:: /includes/collections/behavior-system-collections.rst
+
+Rolling Index Builds
+--------------------
+
+``mongosync`` does not sync source cluster indexes that use a `rolling
+index build
+<https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/>_.
+If your source cluster has an index with a rolling build, use on of the
+following options to ensure that your destination indexes match your
+source indexes:
+
+- Build the index on the source before migration.
+- Build the index on the source during migration with a non-rolling
+  index build. 
+- Build the index on the destination after migration. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -176,7 +176,7 @@ Rolling Index Builds
 --------------------
 
 ``mongosync`` does not sync source cluster indexes that use a
-ref:`rolling index build <index-building-replica-sets>`. If your source
+:ref:`rolling index build <index-building-replica-sets>`. If your source
 cluster has an index with a rolling build, use one of the following
 options to ensure that your destination indexes match your source
 indexes:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -175,10 +175,10 @@ System Collections
 Rolling Index Builds
 --------------------
 
-``mongosync`` does not sync source cluster indexes that use a
-:ref:`rolling index build <index-building-replica-sets>`. If your source
-cluster has an index with a rolling build, use one of the following
-options to ensure that your destination indexes match your source
+``mongosync`` does not support :ref:`rolling index builds
+<index-building-replica-sets>` during migration. To avoid building
+indexes in a rolling fashion during migration, use one of the following
+methods to ensure that your destination indexes match your source
 indexes:
 
 - Build the index on the source before migration.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -175,12 +175,11 @@ System Collections
 Rolling Index Builds
 --------------------
 
-``mongosync`` does not sync source cluster indexes that use a `rolling
-index build
-<https://www.mongodb.com/docs/manual/tutorial/build-indexes-on-replica-sets/>`_.
-If your source cluster has an index with a rolling build, use one of the
-following options to ensure that your destination indexes match your
-source indexes:
+``mongosync`` does not sync source cluster indexes that use a
+ref:`rolling index build <index-building-replica-sets>`. If your source
+cluster has an index with a rolling build, use one of the following
+options to ensure that your destination indexes match your source
+indexes:
 
 - Build the index on the source before migration.
 - Build the index on the source during migration with a non-rolling


### PR DESCRIPTION
## DESCRIPTION

Adds rolling index limitation 

## STAGING

https://deploy-preview-457--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#rolling-index-builds

## JIRA

https://jira.mongodb.org/browse/DOCSP-44876


## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
