### PR TITLE
DOCSP-44972-syntax-bug

### DIFF
--- a/source/includes/fact-no-8.0-support.rst
+++ b/source/includes/fact-no-8.0-support.rst
@@ -1,2 +1,3 @@
 ``mongosync`` does not yet support migrations to and from clusters that use 
-MongoDB 8.0.
+MongoDB 8.0. For instructions on migrating data to 8.0 destination clusters, 
+see :ref:`c2c-server-pre-8.0-to-8.0` and :ref:`c2c-server-8.0-to-8.0`.

--- a/source/includes/fact-no-8.0-support.rst
+++ b/source/includes/fact-no-8.0-support.rst
@@ -1,2 +1,2 @@
-``mongosync`` does not yet support migrations to and from clusters that use
- MongoDB 8.0.
+``mongosync`` does not yet support migrations to and from clusters that use 
+MongoDB 8.0.

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -54,6 +54,8 @@ destination MongoDB server versions.
      -  
      - √
 
+.. _c2c-server-pre-8.0-to-8.0:
+
 Synchronize Data From a Pre-8.0 Source Cluster to an 8.0 Destination Cluster 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -63,6 +65,8 @@ cluster:
 - Use ``mongosync`` to migrate data from your source cluster to a 7.0 
   destination cluster.
 - Upgrade the 7.0 destination cluster to 8.0.
+
+.. _c2c-server-8.0-to-8.0:
 
 Synchronize Data Between Two 8.0 Clusters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION 
- Fixes syntax bug that caused the list item to be bolded. 
- Also adds ref links to the sections that instruct users on how to migrate to 8.0 clusters for clarity 

## STAGING 
https://deploy-preview-458--docs-cluster-to-cluster-sync.netlify.app/reference/supported-server-version/
## JIRA
https://jira.mongodb.org/browse/DOCSP-44972