### PR TITLE
DOCSP-45041-adding-rolling-limitation-to-behavior

### DIFF
--- a/source/includes/rolling-build-limitation.rst
+++ b/source/includes/rolling-build-limitation.rst
@@ -1,0 +1,10 @@
+``mongosync`` does not support :ref:`rolling index builds
+<index-building-replica-sets>` during migration. To avoid building
+indexes in a rolling fashion during migration, use one of the following
+methods to ensure that your destination indexes match your source
+indexes:
+
+- Build the index on the source before migration.
+- Build the index on the source during migration with a non-rolling
+  index build. 
+- Build the index on the destination after migration. 

--- a/source/includes/rolling-build-limitation.rst
+++ b/source/includes/rolling-build-limitation.rst
@@ -5,6 +5,6 @@ methods to ensure that your destination indexes match your source
 indexes:
 
 - Build the index on the source before migration.
-- Build the index on the source during migration with a non-rolling
-  index build. 
+- Build the index on the source during migration with a :ref:`default
+  index build <index-creation-background>`. 
 - Build the index on the destination after migration. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -175,13 +175,4 @@ System Collections
 Rolling Index Builds
 --------------------
 
-``mongosync`` does not support :ref:`rolling index builds
-<index-building-replica-sets>` during migration. To avoid building
-indexes in a rolling fashion during migration, use one of the following
-methods to ensure that your destination indexes match your source
-indexes:
-
-- Build the index on the source before migration.
-- Build the index on the source during migration with a non-rolling
-  index build. 
-- Build the index on the destination after migration. 
+.. include:: /includes/collections/rolling-build-limitation.rst

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -175,4 +175,4 @@ System Collections
 Rolling Index Builds
 --------------------
 
-.. include:: /includes/collections/rolling-build-limitation.rst
+.. include:: /includes/rolling-build-limitation.rst

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -208,6 +208,11 @@ synchronization. The original values are restored during the commit process.
      - In some cases, synchronization may create dummy indexes on the 
        destination to support writes on sharded or collated collections. 
 
+Rolling Index Builds
+~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/collections/rolling-build-limitation.rst
+
 Destination Clusters
 --------------------
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -211,7 +211,7 @@ synchronization. The original values are restored during the commit process.
 Rolling Index Builds
 ~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/collections/rolling-build-limitation.rst
+.. include:: /includes/rolling-build-limitation.rst
 
 Destination Clusters
 --------------------


### PR DESCRIPTION
## DESCRIPTION

Adds rolling build limitation to mongosync behavior page under continuous sync considerations

## STAGING

https://deploy-preview-462--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#rolling-index-builds
https://deploy-preview-462--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#rolling-index-builds

## JIRA

https://jira.mongodb.org/browse/DOCSP-45041

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x]  Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
