### PR TITLE
DOCSP-44977 notes index build behavior during sync

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -30,6 +30,11 @@ If you write to a synced namespace before issuing a :ref:`commit
 undefined. To ensure that you don't write to any synced namespaces, enable 
 :ref:`write blocking <c2c-write-blocking>`.
 
+.. note::
+   
+   Index builds on the destination cluster are treated as writes 
+   while ``mongosync`` is syncing.
+
 To check the value of ``canWrite``, call the :ref:`progress <c2c-api-progress>` 
 API endpoint.
 


### PR DESCRIPTION
## DESCRIPTION
Adds note to FAQ stating index builds on destination clusters are treated as writes

## STAGING
https://deploy-preview-463--docs-cluster-to-cluster-sync.netlify.app/faq/#can-i-perform-reads-or-writes-to-my-destination-cluster-while-mongosync-is-syncing-

## JIRA
https://jira.mongodb.org/browse/DOCSP-44977

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
 See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files)
- [x]  Is this free of any warnings or errors in the RST?
- [x]  Is this free of spelling errors?
- [x]  Is this free of grammatical errors?
- [x]  Is this free of staging / rendering issues?
- [x]  Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS
[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)