### PR TITLE
DOCSP-42724-invalid-document-filter-behavior

### DIFF
--- a/source/reference/beta-program/document-filtering.txt
+++ b/source/reference/beta-program/document-filtering.txt
@@ -59,6 +59,13 @@ Limitations
 
 .. include:: /includes/document-filtering-limitations.rst
 
+.. note:: Invalid Document Filter Handling
+
+   If you provide an invalid document filter in the start request, ``mongosync``
+   does not crash. Instead, the start request fails. You can then re-issue the
+   start request with a valid document filter without needing to restart 
+   ``mongosync``.
+
 Examples 
 --------
 

--- a/source/reference/beta-program/document-filtering.txt
+++ b/source/reference/beta-program/document-filtering.txt
@@ -62,7 +62,7 @@ Limitations
 .. note:: Invalid Document Filter Handling
 
    If you provide an invalid document filter in the start request, ``mongosync``
-   does not crash. Instead, the start request fails. You can then re-issue the
+   does not crash. Instead, the start request fails. You can re-issue the
    start request with a valid document filter without needing to restart 
    ``mongosync``.
 


### PR DESCRIPTION
## DESCRIPTION
As of 1.8.0, an invalid document filter in the start request will no longer crash mongosync; instead, the start request will fail and the user can correct the problem and re-issue the corrected start request without needing to restart mongosync. This information is now reflected in the [document filtering page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/beta-program/document-filtering/) of the beta program in c2c sync. 

## STAGING
https://deploy-preview-464--docs-cluster-to-cluster-sync.netlify.app/reference/beta-program/document-filtering/#limitations

## JIRA
https://jira.mongodb.org/browse/DOCSP-42724

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)