### PR TITLE
DOCSP-45117-sharded-cluster-behavior

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -372,7 +372,7 @@ The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
 
 For more information, see :ref:`Sharded Cluster Behavior
-<c2c-sharded-clusters>. 
+<c2c-sharded-clusters>`. 
 
 .. _c2c-supporting-index-behavior:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -359,14 +359,6 @@ State
 If the ``start`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
 
-Pre-Split Chunks
-~~~~~~~~~~~~~~~~
-
-When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
-for sharded collections on the destination cluster. For each sharded collection, 
-``mongosync`` creates twice as many chunks as there are shards in the 
-destination cluster. 
-
 .. _c2c-shard-replica-sets:
 
 Shard Replica Sets 
@@ -378,6 +370,9 @@ collections.
 
 The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
+
+For more information, see :ref:`Sharded Cluster Behavior
+<c2c-sharded-clusters>. 
 
 .. _c2c-supporting-index-behavior:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -372,7 +372,7 @@ The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
 
 For more information, see :ref:`Sharded Cluster Behavior
-<c2c-sharded-clusters>`. 
+<c2c-sharded-cluster-behavior>`. 
 
 .. _c2c-supporting-index-behavior:
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -60,15 +60,9 @@ Sharded Clusters
 ~~~~~~~~~~~~~~~~
 
 {+c2c-product-name+} supports replication between sharded clusters.
-Individual shards are replicated in parallel from the source cluster to
-the destination cluster, however a :ref:`chunk migration
-<sharding-chunk-migration>` or similar source update could move
-documents to a new source shard during replication.
-
-Even if documents move between source shards during replication,
-{+c2c-product-name+} maintains the :term:`eventual consistency`
-guarantee on the destination cluster. For more information, see 
-:ref:`c2c-sharded-clusters`.
+``mongosync`` replicates individual shards in parallel from the source
+cluster to the destination cluster. However ``mongosync`` does not
+preserve the source cluster's sharding configuration.
 
 Pre-Split Chunks
 ````````````````

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -54,7 +54,7 @@ For information on available settings, see :ref:`Configuration <c2c-config>`.
 Cluster and Collection Types
 ----------------------------
 
-.. _c2c-sharded-clusters:
+.. _c2c-sharded-cluster-behavior:
 
 Sharded Clusters
 ~~~~~~~~~~~~~~~~

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -65,7 +65,7 @@ cluster to the destination cluster. However ``mongosync`` does not
 preserve the source cluster's sharding configuration.
 
 Pre-Split Chunks
-````````````````
+''''''''''''''''
 
 When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
 for sharded collections on the destination cluster. For each sharded collection, 
@@ -73,7 +73,7 @@ for sharded collections on the destination cluster. For each sharded collection,
 destination cluster. 
 
 Primary Shards
-``````````````
+''''''''''''''
 
 When you sync to a sharded destination cluster, ``mongosync`` assigns a
 primary shard to each database by means of a round-robin. 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -54,6 +54,8 @@ For information on available settings, see :ref:`Configuration <c2c-config>`.
 Cluster and Collection Types
 ----------------------------
 
+.. _c2c-sharded-clusters:
+
 Sharded Clusters
 ~~~~~~~~~~~~~~~~
 
@@ -67,6 +69,27 @@ Even if documents move between source shards during replication,
 {+c2c-product-name+} maintains the :term:`eventual consistency`
 guarantee on the destination cluster. For more information, see 
 :ref:`c2c-sharded-clusters`.
+
+Pre-Split Chunks
+````````````````
+
+When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
+for sharded collections on the destination cluster. For each sharded collection, 
+``mongosync`` creates twice as many chunks as there are shards in the 
+destination cluster. 
+
+Primary Shards
+``````````````
+
+When ``mongosync`` syncs to a sharded destination cluster, it assigns a
+primary shard to each database by means of a round-robin. 
+
+.. warning::
+
+   Running :dbcommand:`movePrimary` on the source or desintation cluster
+   during migration may result in a fatal error or require you to
+   restart the migration from scratch. For more information, see
+   :ref:`c2c-sharded-limitations`. 
 
 Multiple Clusters
 ~~~~~~~~~~~~~~~~~
@@ -161,13 +184,6 @@ snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.
    call the :ref:`c2c-api-reverse` endpoint to keep the clusters in sync.
    Otherwise, start a new continuous sync operation by using a new empty 
    destination cluster. 
-
-Sharded Clusters 
-~~~~~~~~~~~~~~~~
-
-When running continuous sync with sharded clusters, you must stop 
-:ref:`balancers <sharding-balancing>` on both the source and the destination 
-for the lifetime of the sync until commit.
 
 Temporary Changes to Collection Characteristics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -81,14 +81,14 @@ destination cluster.
 Primary Shards
 ``````````````
 
-When ``mongosync`` syncs to a sharded destination cluster, it assigns a
+When you sync to a sharded destination cluster, ``mongosync`` assigns a
 primary shard to each database by means of a round-robin. 
 
 .. warning::
 
    Running :dbcommand:`movePrimary` on the source or desintation cluster
    during migration may result in a fatal error or require you to
-   restart the migration from scratch. For more information, see
+   restart the migration from the start. For more information, see
    :ref:`c2c-sharded-limitations`. 
 
 Multiple Clusters


### PR DESCRIPTION
## DESCRIPTION

Adds info on shared cluster behavior and moves sections to the general mongosync behavior page

## STAGING

https://deploy-preview-472--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#sharded-clusters
https://deploy-preview-472--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#behavior

## JIRA

https://jira.mongodb.org/browse/DOCSP-45117

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
