### PR TITLE
DOCSP-45117-sharded-cluster-behavior-v1.8-backport (472)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -356,14 +356,6 @@ State
 If the ``start`` request is successful, ``mongosync`` enters the
 ``RUNNING`` state.
 
-Pre-Split Chunks
-~~~~~~~~~~~~~~~~
-
-When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
-for sharded collections on the destination cluster. For each sharded collection, 
-``mongosync`` creates twice as many chunks as there are shards in the 
-destination cluster. 
-
 .. _c2c-shard-replica-sets:
 
 Shard Replica Sets 
@@ -375,6 +367,11 @@ collections.
 
 The ``sharding.shardingEntries`` array specifies the collections to shard.
 Collections that are not listed in this array replicate as unsharded.
+
+For more information, see :ref:`Sharded Cluster Behavior
+<c2c-sharded-cluster-behavior>`. 
+
+.. _c2c-supporting-index-behavior:
 
 Supporting Indexes
 ~~~~~~~~~~~~~~~~~~

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -54,19 +54,36 @@ For information on available settings, see :ref:`Configuration <c2c-config>`.
 Cluster and Collection Types
 ----------------------------
 
+.. _c2c-sharded-cluster-behavior:
+
 Sharded Clusters
 ~~~~~~~~~~~~~~~~
 
 {+c2c-product-name+} supports replication between sharded clusters.
-Individual shards are replicated in parallel from the source cluster to
-the destination cluster, however a :ref:`chunk migration
-<sharding-chunk-migration>` or similar source update could move
-documents to a new source shard during replication.
+``mongosync`` replicates individual shards in parallel from the source
+cluster to the destination cluster. However ``mongosync`` does not
+preserve the source cluster's sharding configuration.
 
-Even if documents move between source shards during replication,
-{+c2c-product-name+} maintains the :term:`eventual consistency`
-guarantee on the destination cluster. For more information, see 
-:ref:`c2c-sharded-clusters`.
+Pre-Split Chunks
+''''''''''''''''
+
+When ``mongosync`` syncs to a sharded destination cluster, it pre-splits chunks 
+for sharded collections on the destination cluster. For each sharded collection, 
+``mongosync`` creates twice as many chunks as there are shards in the 
+destination cluster. 
+
+Primary Shards
+''''''''''''''
+
+When you sync to a sharded destination cluster, ``mongosync`` assigns a
+primary shard to each database by means of a round-robin. 
+
+.. warning::
+
+   Running :dbcommand:`movePrimary` on the source or desintation cluster
+   during migration may result in a fatal error or require you to
+   restart the migration from the start. For more information, see
+   :ref:`c2c-sharded-limitations`. 
 
 Multiple Clusters
 ~~~~~~~~~~~~~~~~~
@@ -154,13 +171,6 @@ snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.
    call the :ref:`c2c-api-reverse` endpoint to keep the clusters in sync.
    Otherwise, start a new continuous sync operation by using a new empty 
    destination cluster. 
-
-Sharded Clusters 
-~~~~~~~~~~~~~~~~
-
-When running continuous sync with sharded clusters, you must stop 
-:ref:`balancers <sharding-balancing>` on both the source and the destination 
-for the lifetime of the sync until commit.
 
 Temporary Changes to Collection Characteristics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-45117-sharded-cluster-behavior (#472)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/472)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)