### PR TITLE
DOCSP-44974-v1.8-backport (#478)

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -7,17 +7,15 @@ Cluster-to-Cluster Sync
 .. default-domain:: mongodb
 
 {+c2c-product-name+} provides continuous data synchronization or a 
-one-time data migration between MongoDB clusters. You can enable
-{+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
+one-time data migration between MongoDB clusters. For notes and caveats on 
+continuous sync, see the :ref:`<mongosync-considerations>` page. You can 
+enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 ``mongosync`` can continuously synchronize data between two clusters.
 You can use ``mongosync`` to create dedicated analytics, development,
 or testing clusters that mirror your production environment.
 Synchronized clusters can also support locality requirements for audit
 and data residency compliance. 
-
-In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters. 
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-44974-cluster-to-cluster-considerations-for-continuous-sync](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/478)

# Staging
https://deploy-preview-480--docs-cluster-to-cluster-sync.netlify.app/