### PR TITLE
DOCSP-45321-1.10-in-dev

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -12,6 +12,8 @@ About ``mongosync``
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/in-dev.rst
+
 The :ref:`mongosync <c2c-mongosync>` binary is the primary process used in 
 {+c2c-product-name+}. ``mongosync`` migrates data from a source cluster to a 
 destination cluster and keeps the clusters in continuous sync until you 

--- a/source/connecting.txt
+++ b/source/connecting.txt
@@ -14,6 +14,8 @@ Connecting ``mongosync``
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/in-dev.rst
+
 To configure a connection with :ref:`mongosync <c2c-mongosync>`, refer
 to the connection documentation that matches your environment:
 

--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -12,6 +12,8 @@ Connect Two Atlas Clusters
    :depth: 1
    :class: twocols
 
+.. include:: /includes/in-dev.rst
+
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect Atlas clusters using

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -13,6 +13,8 @@ Connect a Self-Managed Cluster to Atlas
    :depth: 1
    :class: twocols
 
+.. include:: /includes/in-dev.rst
+
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect a self-managed cluster to an

--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -13,6 +13,8 @@ Connect Two Self-Managed Clusters
    :depth: 1
    :class: twocols
 
+.. include:: /includes/in-dev.rst
+
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect self-managed clusters using

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,6 +6,8 @@ Cluster-to-Cluster Sync
 
 .. default-domain:: mongodb
 
+.. include:: /includes/in-dev.rst
+
 {+c2c-product-name+} provides continuous data synchronization or a 
 one-time data migration between MongoDB clusters. For notes and caveats on 
 continuous sync, see the :ref:`<mongosync-considerations>` page. You can 

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -11,6 +11,8 @@ Installation
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/in-dev.rst
+
 These documents provide instructions to install {+c2c-full-product-name+}.
 
 :ref:`c2c-install-linux`

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -16,6 +16,8 @@
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/in-dev.rst
+
 Overview
 --------
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -12,6 +12,7 @@
    :depth: 2
    :class: singlecol
 
+.. include:: /includes/in-dev.rst
 
 {+c2c-product-name+} uses `Semantic Versioning 2.0.0
 <https://semver.org/>`__. Version numbers have the form ``X.Y.Z``, where

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -14,16 +14,17 @@ release notes.
 Upcoming Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`c2c-release-notes-1.9`
+- :ref:`c2c-release-notes-1.10`
 
 Current Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~
 
+- :ref:`c2c-release-notes-1.9`
+
+Previous Releases
+~~~~~~~~~~~~~~~~~
+
 - :ref:`c2c-release-notes-1.8`
-
-Previous Rapid Releases
-~~~~~~~~~~~~~~~~~~~~~~~
-
 - :ref:`c2c-release-notes-1.7`
 - :ref:`c2c-release-notes-1.6`
 - :ref:`c2c-release-notes-1.5`
@@ -39,6 +40,7 @@ Previous Rapid Releases
 .. toctree::
    :titlesonly: 
 
+   1.10 </release-notes/1.10>
    1.9 </release-notes/1.9>
    1.8 </release-notes/1.8>
    1.7 </release-notes/1.7>

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -1,0 +1,20 @@
+.. _c2c-release-notes-1.10:
+
+================================
+Release Notes for mongosync 1.10
+================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. include:: /includes/in-dev.rst
+
+.. _1.10.0-c2c-release-notes:
+
+This page describes changes and new features introduced in  
+{+c2c-full-product-name+} 1.10 and the {+c2c-full-beta-program+}.


### PR DESCRIPTION
## DESCRIPTION 
- Adds `in-dev` include across top-level docs pages 
- Creates 1.10 release notes page 
- Update list of upcoming, stable, and previous releases on the main "Release Notes" page

**NOTE:** The Snooty variable used in the in-dev.rst include will be updated to say 1.10 in #483. Will be holding off merge of this PR until then.

## STAGING 
https://deploy-preview-484--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.10/

https://deploy-preview-484--docs-cluster-to-cluster-sync.netlify.app/release-notes/

## JIRA
https://jira.mongodb.org/browse/DOCSP-45321