### PR TITLE
DOCSP-44528-cutover-failure-warnings

### DIFF
--- a/source/includes/cluster-shutdown-warning.rst
+++ b/source/includes/cluster-shutdown-warning.rst
@@ -1,0 +1,3 @@
+If the source cluster shuts down before ``mongosync`` can commit, such as in 
+a disaster scenario, the destination cluster might not have a consistent 
+snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -31,10 +31,10 @@ any additional writes that occur during the migration.
    If you do not properly cutover from your source to your
    destination, you may face the following issues:
 
-   - Garbage data on the destination cluster
+   - Unstructured or unneeded data on the destination cluster
    - Commit failures with no option to rollback the sync
    - Unrecoverable and undiagnosable ``mongosync`` errors
-   - Reduced application availibility, especially if there is
+   - Reduced application availability, especially if there is
      application-side enforcement of document schema or other
      characteristics
    - Missing transactions on the destination cluster

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -16,14 +16,20 @@ You can finalize a migration and transfer your application
 workload from the source to the destination cluster using the
 :ref:`mongosync <c2c-mongosync>` cutover process.
 
+.. note::
+
+   Before you switch your application workload to the
+   destination cluster, you should always verify a successful sync.
+   For more information, see :ref:`c2c-verification`.
+
 ``mongosync`` should remain active until it reaches the
 :ref:`COMMITTED <c2c-state-committed>` state. This allows ``mongosync`` to sync
 any additional writes that occur during the migration.
 
 .. warning::
 
-   Failing to properly cutover from your source cluster to your
-   destination may result in the following application issues:
+   If you do not properly cutover from your source to your
+   destination, you may face the following issues:
 
    - Garbage data on the destination cluster
    - Commit failures with no option to rollback the sync

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -20,11 +20,22 @@ workload from the source to the destination cluster using the
 :ref:`COMMITTED <c2c-state-committed>` state. This allows ``mongosync`` to sync
 any additional writes that occur during the migration.
 
-.. note::
+.. warning::
 
-   Before you switch your application workload to the
-   destination cluster, you should always verify a successful sync.
-   For more information, see :ref:`c2c-verification`.
+   Failing to properly cutover from your source cluster to your
+   destination may result in the following application issues:
+
+   - Garbage data on the destination cluster
+   - Commit failures with no option to rollback the sync
+   - Unrecoverable and undiagnosable ``mongosync`` errors
+   - Reduced application availibility, especially if there is
+     application-side enforcement of document schema or other
+     characteristics
+   - Missing transactions on the destination cluster
+   - Other unexpected cluster behavior
+
+   You must use the following steps to safely finalize your cutover process and achieve
+   expected ``mongosync`` behavior. 
 
 Steps
 -----

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -31,16 +31,15 @@ any additional writes that occur during the migration.
    If you do not properly cutover from your source to your
    destination, you may face the following issues:
 
-   - Unstructured or unneeded data on the destination cluster
-   - Commit failures with no option to rollback the sync
+   - Inaccurate data on the destination cluster
    - Unrecoverable and undiagnosable ``mongosync`` errors
    - Reduced application availability, especially if there is
      application-side enforcement of document schema or other
      characteristics
-   - Missing transactions on the destination cluster
+   - Incomplete transactions on the destination cluster
    - Other unexpected cluster behavior
 
-   You must use the following steps to safely finalize your cutover process and achieve
+   Use the following steps to safely finalize your cutover process and achieve
    expected ``mongosync`` behavior. 
 
 Steps
@@ -138,10 +137,7 @@ Steps
 
       .. warning::
 
-         If the source cluster shuts down before mongosync can commit, such
-         as in a disaster scenario, the destination cluster might not have
-         a consistent snapshot of the source data. To learn more, see
-         :ref:`c2c-behavior-consistency`.
+         .. include:: /includes/cluster-shutdown-warning
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -132,11 +132,16 @@ Steps
          :language: json
          :copyable: false
 
-      .. note::
+      After you submit a ``commit`` request, call the ``progress`` endpoint
+      to ensure that the ``mongosync`` state is ``COMMITTING`` or
+      ``COMMITTED``.
 
-         After you submit a ``commit`` request, call the ``progress`` endpoint
-         to ensure that the ``mongosync`` state is ``COMMITTING`` or
-         ``COMMITTED``.
+      .. warning::
+
+         If the source cluster shuts down before mongosync can commit, such
+         as in a disaster scenario, the destination cluster might not have
+         a consistent snapshot of the source data. To learn more, see
+         Consistency.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -141,7 +141,7 @@ Steps
          If the source cluster shuts down before mongosync can commit, such
          as in a disaster scenario, the destination cluster might not have
          a consistent snapshot of the source data. To learn more, see
-         Consistency.
+         :ref:`c2c-behavior-consistency`.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -203,9 +203,7 @@ For any continuous synchronization use cases with ``mongosync``, ensure that
 ``mongosync`` commits before cutting over from the source to the 
 destination.
 
-If the source cluster shuts down before ``mongosync`` can commit, such as in 
-a disaster scenario, the destination cluster might not have a consistent 
-snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.
+.. include:: /includes/cluster-shutdown-warning
 
 .. note:: 
   


### PR DESCRIPTION
## DESCRIPTION

Adding cutover warnings 

## STAGING

https://deploy-preview-485--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/
https://deploy-preview-485--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#considerations-for-continuous-sync

## JIRA

https://jira.mongodb.org/browse/DOCSP-44528

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
