### PR TITLE
DOCSP-43406-write-blocking-limitation-clarification

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -131,10 +131,10 @@ call the :ref:`commit <c2c-api-commit>` endpoint.
    You must block writes to the source cluster before you begin the
    the commit process. 
 
-   If you set ``enableUserWriteBlocking`` to ``true`` when you used the
-   :ref:`start <c2c-api-start>` endpoint, ``mongosync`` automatically
-   blocks writes on the source cluster when you use the ``commit``
-   endpoint. 
+   If you previously set ``enableUserWriteBlocking`` to ``true`` when
+   you used the :ref:`start <c2c-api-start>` endpoint, ``mongosync``
+   automatically blocks writes on the source cluster when you use the
+   ``commit`` endpoint. 
 
    If you did not set ``enableUserWriteBlocking`` to ``true``, run
    :dbcommand:`setUserWriteBlockMode` on the source cluster to

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -136,8 +136,8 @@ call the :ref:`commit <c2c-api-commit>` endpoint.
    blocks writes on the source cluster when you use the ``commit``
    endpoint. 
 
-   If you did not set ``enableUserWriteBlocking`` to ``true``, use the
-   :dbcommand:`setUserWriteBlockMode` command on the source cluster to
+   If you did not set ``enableUserWriteBlocking`` to ``true``, run
+   :dbcommand:`setUserWriteBlockMode` on the source cluster to
    block writes. 
 
 The ``commit`` endpoint starts the :ref:`COMMITTING <c2c-state-committing>` 

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -126,6 +126,20 @@ Finalize Sync
 To finalize the sync between the source and destination clusters, 
 call the :ref:`commit <c2c-api-commit>` endpoint. 
 
+.. note::
+
+   You must block writes to the source cluster before you begin the
+   the commit process. 
+
+   If you set ``enableUserWriteBlocking`` to ``true`` when you used the
+   :ref:`start <c2c-api-start>` endpoint, ``mongosync`` automatically
+   blocks writes on the source cluster when you use the ``commit``
+   endpoint. 
+
+   If you did not set ``enableUserWriteBlocking`` to ``true``, use the
+   :dbcommand:`setUserWriteBlockMode` command on the source cluster to
+   block writes. 
+
 The ``commit`` endpoint starts the :ref:`COMMITTING <c2c-state-committing>` 
 state, which is when ``mongosync`` stops continuous sync between the source and 
 destination clusters. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -35,7 +35,7 @@ General Limitations
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
 - If you want to start the :ref:`commit <c2c-api-commit>`
-  process and if you previously disabled :ref:`write blocking
+  process and you previously disabled :ref:`write blocking
   <c2c-write-blocking>`, you must :ref:`prevent writes <c2c-api-start>`
   to the source cluster before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -35,9 +35,10 @@ General Limitations
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
 - If you want to start the :ref:`commit <c2c-api-commit>`
-  process and you previously disabled :ref:`write blocking
-  <c2c-write-blocking>`, you must :ref:`prevent writes <c2c-api-start>`
-  to the source cluster before you start the commit process. 
+  process and you did not set ``enableUserWriteBlocking`` to ``true``
+  when you used the :ref:`c2c-api-start` endpoint, you
+  must :ref:`prevent writes <c2c-api-start>` to the source cluster
+  before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't
   replicated.
 - Documents that have dollar (``$``) prefixed field names aren't

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,9 +34,10 @@ General Limitations
   are properly configured.
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
-- If write blocking is disabled, the client must :ref:`prevent writes
-  <c2c-api-start>` to the source cluster before starting the commit
-  process.
+- If you want to start the :ref:`c2c-api-commit`
+  process and if you previously disabled :ref:`write blocking
+  c2c-write-blocking`, you must :ref:`prevent writes <c2c-api-start>` to
+  the source cluster before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't
   replicated.
 - Documents that have dollar (``$``) prefixed field names aren't

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -35,9 +35,9 @@ General Limitations
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
 - If you want to start the :ref:`c2c-api-commit`
-  process and if you previously disabled :ref:`write blocking
-  c2c-write-blocking`, you must :ref:`prevent writes <c2c-api-start>` to
-  the source cluster before you start the commit process. 
+  process and if you previously disabled :ref:`c2c-write-blocking`, you
+  must :ref:`prevent writes <c2c-api-start>` to the source cluster
+  before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't
   replicated.
 - Documents that have dollar (``$``) prefixed field names aren't

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,7 +34,7 @@ General Limitations
   are properly configured.
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
-- If you want to start the :ref:`commit <c2c-api-commit`>
+- If you want to start the :ref:`commit <c2c-api-commit>`
   process and if you previously disabled :ref:`write blocking
   <c2c-write-blocking>`, you must :ref:`prevent writes <c2c-api-start>`
   to the source cluster before you start the commit process. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,10 +34,10 @@ General Limitations
   are properly configured.
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
-- If you want to start the :ref:`c2c-api-commit`
-  process and if you previously disabled :ref:`c2c-write-blocking`, you
-  must :ref:`prevent writes <c2c-api-start>` to the source cluster
-  before you start the commit process. 
+- If you want to start the :ref:`commit <c2c-api-commit`>
+  process and if you previously disabled :ref:`write blocking
+  <c2c-write-blocking>`, you must :ref:`prevent writes <c2c-api-start>`
+  to the source cluster before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't
   replicated.
 - Documents that have dollar (``$``) prefixed field names aren't


### PR DESCRIPTION
## DESCRIPTION

Adds links and clarifications around when write blocking is needed

## STAGING

https://deploy-preview-489--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#general-limitations
https://deploy-preview-489--docs-cluster-to-cluster-sync.netlify.app/about-mongosync/#finalize-sync

## JIRA

https://jira.mongodb.org/browse/DOCSP-43406

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
