### PR TITLE
DOCSP-44360-chunk-migration-balancers

### DIFF
--- a/source/includes/fact-mongosync-balancer.rst
+++ b/source/includes/fact-mongosync-balancer.rst
@@ -1,0 +1,7 @@
+.. important::
+
+   When the source or destination cluster is a sharded cluster, stop the
+   balancer on both clusters and don't run the :dbcommand:`moveChunk` or
+   :dbcommand:`moveRange` commands for the entire lifetime of the
+   migration. To stop the balancer, run the :dbcommand:`balancerStop`
+   command and wait for the command to complete.

--- a/source/includes/fact-mongosync-balancer.rst
+++ b/source/includes/fact-mongosync-balancer.rst
@@ -1,7 +1,7 @@
 .. important::
 
-   When the source or destination cluster is a sharded cluster, stop the
-   balancer on both clusters and don't run the :dbcommand:`moveChunk` or
-   :dbcommand:`moveRange` commands for the entire lifetime of the
-   migration. To stop the balancer, run the :dbcommand:`balancerStop`
-   command and wait for the command to complete.
+   When the source or destination cluster is a sharded cluster, you must stop 
+   the balancer on both clusters and not run the :dbcommand:`moveChunk` or
+   :dbcommand:`moveRange` commands for the duration of the migration. To stop 
+   the balancer, run the :dbcommand:`balancerStop` command and wait for the 
+   command to complete.

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -101,9 +101,7 @@ Sharded Clusters
 cluster to the destination cluster. However ``mongosync`` does not
 preserve the source cluster's sharding configuration.
 
-.. seealso:: 
-
-   :ref:`Sharded Cluster Limitations <c2c-sharded-limitations>`
+.. include:: /includes/fact-mongosync-balancer.rst
 
 Pre-Split Chunks
 ''''''''''''''''

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -101,6 +101,10 @@ Sharded Clusters
 cluster to the destination cluster. However ``mongosync`` does not
 preserve the source cluster's sharding configuration.
 
+.. seealso:: 
+
+   :ref:`Sharded Cluster Limitations <c2c-sharded-limitations>`
+
 Pre-Split Chunks
 ''''''''''''''''
 

--- a/source/topologies/multiple-mongosyncs.txt
+++ b/source/topologies/multiple-mongosyncs.txt
@@ -18,13 +18,7 @@ There are two ways to synchronize :ref:`sharded clusters
 loaded clusters, use one ``mongosync`` instance for each shard on the
 source cluster.
 
-.. important::
-
-   When the source or destination cluster is a sharded cluster, stop the
-   balancer on both clusters and don't run the :dbcommand:`moveChunk` or
-   :dbcommand:`moveRange` commands for the entire lifetime of the
-   migration. To stop the balancer, run the :dbcommand:`balancerStop`
-   command and wait for the command to complete.
+.. include:: /includes/fact-mongosync-balancer.rst
 
 .. _c2c-sharded-config-single:
 


### PR DESCRIPTION
## DESCRIPTION 
- The first ask of the ticket regarding chunk migrations has already been addressed in #472. 
- Added `important:` note regarding stopping the balancer, not running moveChunk or moveRange during migration, and how to stop the balancer.

## STAGING 
https://deploy-preview-490--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#sharded-clusters

## JIRA 
https://jira.mongodb.org/browse/DOCSP-44360