### PR TITLE
DOCSP-44360-chunk-migration-balancers-v1.9-backport (490)

### DIFF
--- a/source/includes/fact-mongosync-balancer.rst
+++ b/source/includes/fact-mongosync-balancer.rst
@@ -1,0 +1,7 @@
+.. important::
+
+   When the source or destination cluster is a sharded cluster, you must stop 
+   the balancer on both clusters and not run the :dbcommand:`moveChunk` or
+   :dbcommand:`moveRange` commands for the duration of the migration. To stop 
+   the balancer, run the :dbcommand:`balancerStop` command and wait for the 
+   command to complete.

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -101,6 +101,8 @@ Sharded Clusters
 cluster to the destination cluster. However ``mongosync`` does not
 preserve the source cluster's sharding configuration.
 
+.. include:: /includes/fact-mongosync-balancer.rst
+
 Pre-Split Chunks
 ''''''''''''''''
 

--- a/source/topologies/multiple-mongosyncs.txt
+++ b/source/topologies/multiple-mongosyncs.txt
@@ -18,13 +18,7 @@ There are two ways to synchronize :ref:`sharded clusters
 loaded clusters, use one ``mongosync`` instance for each shard on the
 source cluster.
 
-.. important::
-
-   When the source or destination cluster is a sharded cluster, stop the
-   balancer on both clusters and don't run the :dbcommand:`moveChunk` or
-   :dbcommand:`moveRange` commands for the entire lifetime of the
-   migration. To stop the balancer, run the :dbcommand:`balancerStop`
-   command and wait for the command to complete.
+.. include:: /includes/fact-mongosync-balancer.rst
 
 .. _c2c-sharded-config-single:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-44360-chunk-migration-balancers (#490)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/490)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)