### PR TITLE
DOCSP-45310-c2c-beta-invite-only

### DIFF
--- a/source/reference/beta-program.txt
+++ b/source/reference/beta-program.txt
@@ -24,12 +24,11 @@ Get Started
 
 .. note:: 
 
-   Filing a support ticket does  *not* guarantee access to the 
-   {+c2c-beta-program-short+} binaries. 
+   The {+c2c-beta-program-short+} binaries program is invite only
+   at this time.
 
-To request access to the {+c2c-beta-program-short+} binaries, read the 
-following disclaimer and file a ticket with 
-`support <https://support.mongodb.com/>`_:
+After receiving an invitation to the {+c2c-beta-program-short+} binaries,
+read the following disclaimer:
 
 .. code-block:: shell
    :copyable: false


### PR DESCRIPTION
## DESCRIPTION
(Temporarily) removes the link to file a support ticket from the [beta program page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/beta-program/#cluster-to-cluster-sync-beta-program) and indicates instead that the program is invite only.

## STAGING
https://deploy-preview-493--docs-cluster-to-cluster-sync.netlify.app/reference/beta-program/#cluster-to-cluster-sync-beta-program

## JIRA
https://jira.mongodb.org/browse/DOCSP-45310

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
