### PR TITLE
DOCSP-44478-hardware-specs-v1.9-backport (488)

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -47,6 +47,22 @@ have to run on the servers that host your MongoDB instances. When
 (OS) that is different than the OS on the source or destination
 clusters.
 
+What hardware specifications should the destination cluster have?
+-----------------------------------------------------------------
+
+For most migrations, the destination cluster should have higher hardware 
+specifications than the source cluster, including the following properties:
+
+- CPU
+- Memory
+- Disk I/O 
+
+These hardware specifications ensure that the destination cluster can handle 
+``mongosync`` writes and that the sync can keep up with the source cluster's 
+workload.
+
+.. include:: /includes/fact-oplog-disk-storage.rst
+
 .. _c2c-faq-increase-oplog:
 
 Should I increase the size of the ``oplog`` in the source cluster?

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -1,0 +1,13 @@
+The destination cluster must have enough disk storage to accommodate the logical 
+data size being migrated and the destination oplog entries from the initial 
+sync. For example, to migrate 10 GB of data, the destination cluster must have
+at least 10 GB available for the data and another 10 GB for the insert oplog 
+entries from the initial sync.
+
+To reduce the overhead of the destination oplog entries, you can: 
+
+- Use the :setting:`~replication.oplogSizeMB` setting to lower the destination 
+  cluster's oplog size.
+
+- Use to :setting:`~storage.oplogMinRetentionHours` setting to lower or remove 
+  the destination cluster's minimum oplog retention period.

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -78,6 +78,10 @@ Setup
       The number of nodes in the destination replica set does not have
       to equal the number of nodes in the source replica set.
 
+      .. important:: 
+         
+         .. include:: /includes/fact-oplog-disk-storage.rst
+
       If your clusters are self-managed, they must be MongoDB
       Enterprise clusters. {+c2c-product-name+} is only supported on
       MongoDB Community Edition in a limited number of cases. For more

--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -20,6 +20,11 @@ be within the ``oplog`` time range.
 
 .. include:: /includes/fact-oplog-background
 
+Considerations 
+--------------
+
+.. include:: /includes/fact-oplog-disk-storage.rst
+
 Monitor oplog Size Needed for Initial Sync
 ------------------------------------------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-44478-hardware-specs (#488)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/488)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)