### PR TITLE
DOCSP-44120-clarify-mongosync-sharding-behavior-v1.8-backport (487)

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -187,3 +187,11 @@ Does ``mongosync`` Support TTL Indexes?
 {+c2c-product-name+} supports syncing :ref:`index-feature-ttl` from the source
 to the destination cluster.
 
+
+Can I customize chunk distributions when syncing into a sharded cluster?
+------------------------------------------------------------------------
+
+No, you can't configure ``mongosync`` to customize chunk distributions
+on a destination sharded cluster.  ``mongosync`` samples each collection
+during initialization to determine how to distribute documents
+efficiently across the destination cluster’s shards after migration.

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -74,6 +74,19 @@ for sharded collections on the destination cluster. For each sharded collection,
 ``mongosync`` creates twice as many chunks as there are shards in the 
 destination cluster. 
 
+Chunk Distribution
+''''''''''''''''''
+
+``mongosync`` does not preserve chunk distribution from the source to
+the destination, even with multiple ``mongosync`` instances. It is not
+possible to reproduce a particular pre-split of chunks from a source
+cluster on the destination cluster. 
+
+The only sharding configuration that ``mongosync`` preserves from the
+source cluster to the destination cluster is the sharding key. Once the
+migration finishes, you can enable the destination cluster's balancer which
+distributes documents independently of the source cluster's distribution. 
+
 Primary Shards
 ''''''''''''''
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-44120-clarify-mongosync-sharding-behavior (#487)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/487)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)