### PR TITLE
DOCSP-45060-ignorePreExistingNamespaces-incompatibility

### DIFF
--- a/source/reference/beta-program/destinationDataHandling.txt
+++ b/source/reference/beta-program/destinationDataHandling.txt
@@ -53,6 +53,9 @@ The following table shows the strings you can set for
        cluster. Ensure your destination namespaces are different from
        those ``mongosync`` replicates from the source cluster.
 
+       ``"ignorePreExistingNamespaces"`` is not compatible with
+       :ref:`c2c-api-reverse`.     
+
 If you omit a ``"destinationDataHandling"`` string, and the destination
 cluster has user data, ``mongosync`` returns an error. Otherwise,
 ``mongosync`` continues the sync operation.


### PR DESCRIPTION
## DESCRIPTION

adds that ignorePreExistingNamespaces is incompatible with reverse

## STAGING

https://deploy-preview-500--docs-cluster-to-cluster-sync.netlify.app/reference/beta-program/destinationDataHandling/#command-option

## JIRA

https://jira.mongodb.org/browse/DOCSP-45060

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
