### PR TITLE
DOCSP-45060-ignorePreExistingNamespaces-incompatibility-v1.8-backport (500)

### DIFF
--- a/source/reference/beta-program/destinationDataHandling.txt
+++ b/source/reference/beta-program/destinationDataHandling.txt
@@ -53,6 +53,9 @@ The following table shows the strings you can set for
        cluster. Ensure your destination namespaces are different from
        those ``mongosync`` replicates from the source cluster.
 
+       ``"ignorePreExistingNamespaces"`` is not compatible with
+       :ref:`c2c-api-reverse`.     
+
 If you omit a ``"destinationDataHandling"`` string, and the destination
 cluster has user data, ``mongosync`` returns an error. Otherwise,
 ``mongosync`` continues the sync operation.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-45060-ignorePreExistingNamespaces-incompatibility (#500)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/500)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)