### PR TITLE
DOCSP-45350-mongosync-limitations-always-in-effect

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -21,6 +21,10 @@ Limitations
    these limitations could lead to undefined behavior on the destination
    cluster.
 
+   You must adhere to these limitations for the full duration of the the
+   migration, including when the migration is paused or stopped and will be
+   resumed.
+
 General Limitations
 -------------------
 
@@ -63,11 +67,6 @@ General Limitations
   <storage-wiredtiger>` storage engine.
 - You can't sync a collection with any documents that have an empty timestamp,
   such as ``Timestamp(0,0)`` on pre-6.0 source clusters. 
-
-.. important::
-
-   ``mongosync`` enforces the limitations, regardless of whether
-   ``mongosync`` is running, paused, or stopped.
 
 MongoDB Community Edition
 -------------------------

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -66,7 +66,7 @@ General Limitations
 
 .. important::
 
-   ``mongosync`` enforces the documented limitations, regardless of whether
+   ``mongosync`` enforces the limitations, regardless of whether
    ``mongosync`` is running, paused, or stopped.
 
 MongoDB Community Edition

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -22,7 +22,7 @@ Limitations
    cluster.
 
    You must adhere to these limitations for the full duration of the the
-   migration, including when the migration is paused or stopped and will be
+   migration, including when the migration is paused or stopped if it will be
    resumed.
 
 General Limitations

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -64,6 +64,11 @@ General Limitations
 - You can't sync a collection with any documents that have an empty timestamp,
   such as ``Timestamp(0,0)`` on pre-6.0 source clusters. 
 
+.. important::
+
+   ``mongosync`` enforces the documented limitations, regardless of whether
+   ``mongosync`` is running, paused, or stopped.
+
 MongoDB Community Edition
 -------------------------
 


### PR DESCRIPTION
## DESCRIPTION
Add an `important` admonition that clarifies that the limitations are still in effect even after pausing/stopping mongosync.

## STAGING
https://deploy-preview-505--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#limitations

## JIRA
https://jira.mongodb.org/browse/DOCSP-45350

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
