### PR TITLE
Revert "DOCSP-44528-cutover-failure-warnings-v1.8-backport (485)"

### DIFF
--- a/source/includes/cluster-shutdown-warning.rst
+++ b/source/includes/cluster-shutdown-warning.rst
@@ -1,3 +1,0 @@
-If the source cluster shuts down before ``mongosync`` can commit, such as in 
-a disaster scenario, the destination cluster might not have a consistent 
-snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -16,31 +16,15 @@ You can finalize a migration and transfer your application
 workload from the source to the destination cluster using the
 :ref:`mongosync <c2c-mongosync>` cutover process.
 
+``mongosync`` should remain active until it reaches the
+:ref:`COMMITTED <c2c-state-committed>` state. This allows ``mongosync`` to sync
+any additional writes that occur during the migration.
+
 .. note::
 
    Before you switch your application workload to the
    destination cluster, you should always verify a successful sync.
    For more information, see :ref:`c2c-verification`.
-
-``mongosync`` should remain active until it reaches the
-:ref:`COMMITTED <c2c-state-committed>` state. This allows ``mongosync`` to sync
-any additional writes that occur during the migration.
-
-.. warning::
-
-   If you do not properly cutover from your source to your
-   destination, you may face the following issues:
-
-   - Inaccurate data on the destination cluster
-   - Unrecoverable and undiagnosable ``mongosync`` errors
-   - Reduced application availability, especially if there is
-     application-side enforcement of document schema or other
-     characteristics
-   - Incomplete transactions on the destination cluster
-   - Other unexpected cluster behavior
-
-   Use the following steps to safely finalize your cutover process and achieve
-   expected ``mongosync`` behavior. 
 
 Steps
 -----
@@ -119,13 +103,11 @@ Steps
          :language: json
          :copyable: false
 
-      After you submit a ``commit`` request, call the ``progress`` endpoint
-      to ensure that the ``mongosync`` state is ``COMMITTING`` or
-      ``COMMITTED``.
+      .. note::
 
-      .. warning::
-
-         .. include:: /includes/cluster-shutdown-warning
+         After you submit a ``commit`` request, call the ``progress`` endpoint
+         to ensure that the ``mongosync`` state is ``COMMITTING`` or
+         ``COMMITTED``.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -174,7 +174,9 @@ For any continuous synchronization use cases with ``mongosync``, ensure that
 ``mongosync`` commits before cutting over from the source to the 
 destination.
 
-.. include:: /includes/cluster-shutdown-warning
+If the source cluster shuts down before ``mongosync`` can commit, such as in 
+a disaster scenario, the destination cluster might not have a consistent 
+snapshot of the source data. To learn more, see :ref:`c2c-behavior-consistency`.
 
 .. note:: 
   


### PR DESCRIPTION
Reverts mongodb/docs-cluster-to-cluster-sync#502