### PR TITLE
DOCSP-43406-write-blocking-limitation-clarification-v1.9-backport (489)

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -124,6 +124,20 @@ Finalize Sync
 To finalize the sync between the source and destination clusters, 
 call the :ref:`commit <c2c-api-commit>` endpoint. 
 
+.. note::
+
+   You must block writes to the source cluster before you begin the
+   the commit process. 
+
+   If you previously set ``enableUserWriteBlocking`` to ``true`` when
+   you used the :ref:`start <c2c-api-start>` endpoint, ``mongosync``
+   automatically blocks writes on the source cluster when you use the
+   ``commit`` endpoint. 
+
+   If you did not set ``enableUserWriteBlocking`` to ``true``, run
+   :dbcommand:`setUserWriteBlockMode` on the source cluster to
+   block writes. 
+
 The ``commit`` endpoint starts the :ref:`COMMITTING <c2c-state-committing>` 
 state, which is when ``mongosync`` stops continuous sync between the source and 
 destination clusters. 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,9 +34,11 @@ General Limitations
   are properly configured.
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
-- If write blocking is disabled, the client must :ref:`prevent writes
-  <c2c-api-start>` to the source cluster before starting the commit
-  process.
+- If you want to start the :ref:`commit <c2c-api-commit>`
+  process and you did not set ``enableUserWriteBlocking`` to ``true``
+  when you used the :ref:`c2c-api-start` endpoint, you
+  must :ref:`prevent writes <c2c-api-start>` to the source cluster
+  before you start the commit process. 
 - :ref:`system.* collections <metadata-system-collections>` aren't
   replicated.
 - Documents that have dollar (``$``) prefixed field names aren't


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-43406-write-blocking-limitation-clarification (#489)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/489)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)