### PR TITLE
DOCSP-45350-mongosync-limitations-always-in-effect-v1.9-backport (505)

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -21,6 +21,10 @@ Limitations
    these limitations could lead to undefined behavior on the destination
    cluster.
 
+   You must adhere to these limitations for the full duration of the the
+   migration, including when the migration is paused or stopped if it will be
+   resumed.
+
 General Limitations
 -------------------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-45350-mongosync-limitations-always-in-effect (#505)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/505)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)