### PR TITLE
DOCSP-45858-mongosync-doesnt-support-docs-with-duplicate-fields

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -69,6 +69,9 @@ General Limitations
   <storage-wiredtiger>` storage engine.
 - You can't sync a collection with any documents that have an empty timestamp,
   such as ``Timestamp(0,0)`` on pre-6.0 source clusters. 
+- ``mongosync`` does not support documents with duplicate field names.
+  For details, see :manual:`MongoDB does not support duplicate field names
+  </reference/limits/#mongodb-does-not-support-duplicate-field-names>`.
 
 MongoDB Community Edition
 -------------------------


### PR DESCRIPTION
# DESCRIPTION

Documents that ``mongosync`` does not support documents with duplicate field names.

# JIRA

https://jira.mongodb.org/browse/DOCSP-45858