### PR TITLE
DOCSP-45859 Version Compatibility

### DIFF
--- a/source/includes/cross-version-sync.rst
+++ b/source/includes/cross-version-sync.rst
@@ -1,9 +1,3 @@
 Starting in 1.7.0, ``mongosync`` can perform version migration from 
 certain lower major version source clusters to certain higher major
 version destination clusters. 
-
-Cross-version migration requires additional preparation and
-configuration when migrating from a pre-6.0 release. To perform a cross-version 
-migration from a pre-6.0 version of the MongoDB Server using
-``mongosync``, please `contact <https://mongodb.com/contact>`__ your
-account team to inquire about Professional Services.

--- a/source/includes/fact-minimum-fcv.rst
+++ b/source/includes/fact-minimum-fcv.rst
@@ -1,2 +1,0 @@
-The minimum supported server :ref:`feature compatibility version <view-fcv>` 
-is 6.0.

--- a/source/includes/fact-version-compatibility.rst
+++ b/source/includes/fact-version-compatibility.rst
@@ -1,0 +1,2 @@
+For information on minimum supported versions, see 
+:ref:`c2c-server-version-compatibility`.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -38,14 +38,6 @@ Compatibility
 -------------
 
 - .. include:: /includes/fact-no-8.0-support.rst
-     
-  You can migrate data on clusters (source) with versions of MongoDB
-  lower than 6.0 to an Atlas cluster (destination). Migration from clusters with
-  lower version requires additional preparation and configuration in
-  the clusters with the lower version. `Contact
-  <https://mongodb.com/contact>`__ your account team to inquire about 
-  Professional Services.  
-
 - ``mongosync`` supports replica sets and sharded clusters.
 - Standalone MongoDB instances are not supported. :ref:`Convert the
   standalone instance <server-replica-set-deploy-convert>` to a

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -38,8 +38,6 @@ Compatibility
 -------------
 
 - .. include:: /includes/fact-no-8.0-support.rst
-
-- .. include:: /includes/fact-minimum-server-version-support.rst
      
   You can migrate data on clusters (source) with versions of MongoDB
   lower than 6.0 to an Atlas cluster (destination). Migration from clusters with

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -17,14 +17,14 @@ version limitations and requirements:
 
 - .. include:: /includes/fact-no-8.0-support.rst
 
-- ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
-
 - Your source cluster must run one of the following major supported versions: 
   
   - 4.4 (*New in version 1.10.0*)
   - 5.0 (*New in version 1.10.0*)
   - 6.0
   - 7.0
+
+- ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
 
 The following table lists the minimum MongoDB server version requirements for  
 clusters:

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -19,16 +19,23 @@ version limitations and requirements:
 
 - ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
 
-Minimum Supported Versions 
---------------------------
+- Your source cluster must run one of the following major supported versions: 
+  
+  - 4.4 (*New in version 1.10.0*)
+  - 5.0 (*New in version 1.10.0*)
+  - 6.0
+  - 7.0
+
+The following table lists the minimum MongoDB server version requirements for  
+source clusters:
 
 .. list-table::
    :header-rows: 1
    :class: compatibility 
 
    * - Major Version 
-     - Minimum Supported Patch Version 
-     - Minimum :ref:`Feature Compatibility Version <view-fcv>`
+     - Patch Version 
+     - Minimum Feature Compatibility Version
 
    * - 4.4
      - 4.4.23

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -17,22 +17,44 @@ version limitations and requirements:
 
 - .. include:: /includes/fact-no-8.0-support.rst
 
-- .. include:: /includes/fact-minimum-server-version-support.rst
-
 - ``mongosync`` doesn't support MongoDB rapid releases, such as 6.1 or 6.2.
 
-- .. include:: /includes/fact-minimum-fcv.rst 
+Minimum Supported Versions 
+--------------------------
 
-Synchronize Data Between Clusters Running Older MongoDB Server Versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. list-table::
+   :header-rows: 1
+   :class: compatibility 
 
-.. include:: /includes/fact-minimum-versions.rst
+   * - Major Version 
+     - 4.4 
+     - 5.0 
+     - 6.0
+     - 7.0 
 
+   * - Minimum Supported Patch Version 
+     - 4.4.23
+     - 5.0.29
+     - 6.0.16
+     - 7.0.9
+
+   * - Minimum :ref:`Feature Compatibility Version <view-fcv>`
+     - 4.4
+     - 5.0
+     - 6.0
+     - 6.0   
 
 Synchronize Data Between Clusters with Different MongoDB Server Major Versions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------------------------------------------------
 
 .. include:: /includes/cross-version-sync.rst
+
+Starting in version 1.10.0, ``mongosync`` supports migrations from pre-6.0 
+source clusters. 
+
+- 4.4 source clusters to 6.0 destination clusters
+- 5.0 source clusters to 6.0 destination clusters
+- 5.0 source clusters to 7.0 destination clusters
 
 ``mongosync`` supports syncs between the following source and
 destination MongoDB server versions. 
@@ -42,9 +64,17 @@ destination MongoDB server versions.
    :stub-columns: 1
    :widths: 40 30 30 
 
-   * - 
+   * -
      - **6.0** Destination
      - **7.0** Destination
+
+   * - **4.4** Source
+     - √
+     - 
+
+   * - **5.0** Source
+     - √
+     - √
 
    * - **6.0** Source
      - √

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -70,22 +70,22 @@ destination MongoDB server versions.
    :widths: 40 30 30 
 
    * -
-     - **6.0** Destination
-     - **7.0** Destination
+     -  **6.0 Destination** 
+     -  **7.0 Destination** 
 
-   * - **4.4** Source
+   * - **4.4 Source**
      - √
      - 
 
-   * - **5.0** Source
+   * - **5.0 Source**
      - √
      - √
 
-   * - **6.0** Source
+   * - **6.0 Source**
      - √
      - √
 
-   * - **7.0** Source
+   * - **7.0 Source**
      -  
      - √
 

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -27,7 +27,7 @@ version limitations and requirements:
   - 7.0
 
 The following table lists the minimum MongoDB server version requirements for  
-source clusters:
+clusters:
 
 .. list-table::
    :header-rows: 1
@@ -60,6 +60,10 @@ Synchronize Data Between Clusters with Different MongoDB Server Major Versions
 
 Starting in version 1.10.0, ``mongosync`` supports migrations from pre-6.0 
 source clusters. 
+
+.. important:: 
+   
+   ``mongosync`` does not support migrations to pre-6.0 destination clusters.
 
 ``mongosync`` supports syncs between the following source and
 destination MongoDB server versions. 

--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -27,22 +27,24 @@ Minimum Supported Versions
    :class: compatibility 
 
    * - Major Version 
-     - 4.4 
-     - 5.0 
-     - 6.0
-     - 7.0 
+     - Minimum Supported Patch Version 
+     - Minimum :ref:`Feature Compatibility Version <view-fcv>`
 
-   * - Minimum Supported Patch Version 
+   * - 4.4
      - 4.4.23
-     - 5.0.29
-     - 6.0.16
-     - 7.0.9
-
-   * - Minimum :ref:`Feature Compatibility Version <view-fcv>`
      - 4.4
+
+   * - 5.0
+     - 5.0.29
      - 5.0
+
+   * - 6.0
+     - 6.0.16
      - 6.0
-     - 6.0   
+
+   * - 7.0
+     - 7.0.9
+     - 6.0
 
 Synchronize Data Between Clusters with Different MongoDB Server Major Versions
 ------------------------------------------------------------------------------
@@ -51,10 +53,6 @@ Synchronize Data Between Clusters with Different MongoDB Server Major Versions
 
 Starting in version 1.10.0, ``mongosync`` supports migrations from pre-6.0 
 source clusters. 
-
-- 4.4 source clusters to 6.0 destination clusters
-- 5.0 source clusters to 6.0 destination clusters
-- 5.0 source clusters to 7.0 destination clusters
 
 ``mongosync`` supports syncs between the following source and
 destination MongoDB server versions. 

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -18,3 +18,10 @@ Release Notes for mongosync 1.10
 
 This page describes changes and new features introduced in  
 {+c2c-full-product-name+} 1.10 and the {+c2c-full-beta-program+}.
+
+Minimum Supported Version
+-------------------------
+
+.. include:: /includes/fact-version-compatibility.rst
+
+.. include:: /includes/migration-upgrade-recommendation.rst

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -17,7 +17,7 @@ Release Notes for mongosync 1.10
 .. _1.10.0-c2c-release-notes:
 
 This page describes changes and new features introduced in  
-{+c2c-full-product-name+} 1.10 and the {+c2c-full-beta-program+}.
+{+c2c-full-product-name+} 1.10.
 
 Minimum Supported Version
 -------------------------


### PR DESCRIPTION
## DESCRIPTION 
- Update C2C Version Compatibility page to reflect older version support 
- Added minimum supported version table to document major versions, patch versions, and minimum fcv 
- Added 4.4 and 5.0 to source & destination cluster compatibility table

## STAGING 
- [Version Compatibility](https://deploy-preview-518--docs-cluster-to-cluster-sync.netlify.app/reference/supported-server-version/)
- [1.10 release notes](https://deploy-preview-518--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.10/)
## JIRA
https://jira.mongodb.org/browse/DOCSP-45859