### PR TITLE
(DOCSP-45638) [C2C] Add limitation for in-place major & minor server version upgrades

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -33,6 +33,8 @@ General Limitations
   For information on MongoDB server compatibility, see
   :ref:`c2c-server-version-compatibility`.
 
+- ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
+  To learn more, see the :manual:`server upgrade instructions </tutorial/upgrade-revision/>`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,7 +34,7 @@ General Limitations
   :ref:`c2c-server-version-compatibility`.
 
 - ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
-  To learn more, see :manual:`Upgrade to the Latest Self-Managed Patch Release of MongoDB </tutorial/upgrade-revision/>`.
+  To learn more, see :ref:`upgrade-to-latest-revision`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,7 +34,7 @@ General Limitations
   :ref:`c2c-server-version-compatibility`.
 
 - ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
-  To learn more, see :ref:`upgrade-to-latest-revision`.
+  To learn more, see the :ref:`server upgrade instructions <upgrade-to-latest-revision>`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,7 +34,7 @@ General Limitations
   :ref:`c2c-server-version-compatibility`.
 
 - ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
-  To learn more, see :manual:`</tutorial/upgrade-revision/>`.
+  To learn more, see :manual:`Upgrade to the Latest Self-Managed Patch Release of MongoDB </tutorial/upgrade-revision/>`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -34,7 +34,7 @@ General Limitations
   :ref:`c2c-server-version-compatibility`.
 
 - ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
-  To learn more, see the :manual:`server upgrade instructions </tutorial/upgrade-revision/>`.
+  To learn more, see :manual:`</tutorial/upgrade-revision/>`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.


### PR DESCRIPTION
## DESCRIPTION
We're going to add a guardrail for this in [REP-5303](https://jira.mongodb.org/browse/REP-5303), but we should clarify it ahead of time in our General Limitations:

> `mongosync` does not support in-place server version upgrades that change the major or minor version during a migration. `mongosync` does allow patch version upgrades. See the [server upgrade instructions](https://www.mongodb.com/docs/manual/tutorial/upgrade-revision/) for more details.

## [STAGING](https://deploy-preview-519--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/)

## [DOCSP-45638](https://jira.mongodb.org/browse/DOCSP-45638)

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
