### PR TITLE
(DOCSP-45638) [C2C] Backport to v1.8: Add limitation for in-place major & minor server version upgrades #519 #520

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -33,6 +33,8 @@ General Limitations
   For information on MongoDB server compatility, see
   :ref:`c2c-server-version-compatibility`.
 
+- ``mongosync`` does not support in-place server version upgrades that change the major or minor version during a migration. ``mongosync`` does allow patch version upgrades. 
+  To learn more, see the :ref:`server upgrade instructions <upgrade-to-latest-revision>`.
 - The destination cluster must be empty.
 - ``mongosync`` doesn't validate that the clusters or the environment
   are properly configured.


### PR DESCRIPTION
## BACKPORT 

This will backport [(DOCSP-45638) [C2C] Add limitation for in-place major & minor server version upgrades (#519)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/519) to v1.8

## DESCRIPTION
We're going to add a guardrail for this in [REP-5303](https://jira.mongodb.org/browse/REP-5303), but we should clarify it ahead of time in our General Limitations:

> `mongosync` does not support in-place server version upgrades that change the major or minor version during a migration. `mongosync` does allow patch version upgrades. See the [server upgrade instructions](https://www.mongodb.com/docs/manual/tutorial/upgrade-revision/) for more details.

## JIRA
[DOCSP-45638](https://jira.mongodb.org/browse/DOCSP-45638)