### PR TITLE
DOCSP-45860-older-version-limitations

### DIFF
--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -1,12 +1,13 @@
 - Writes that produce DDL events cannot occur on the source cluster during the 
   migration. The following events cannot occur: 
   
+  - ``collMod``
   - ``create``
+  - ``createIndexes``
   - ``drop``
   - ``dropDatabase``
-  - ``createIndexes``
   - ``dropIndexes``
-  - ``collModrefineCollectionShardKey``
+  - ``refineCollectionShardKey``  
   - ``rename``
   - ``reshardCollection``
   - ``shardCollection``
@@ -23,14 +24,14 @@
 
 - ``geoHaystack`` indexes are not supported.
 
-- :ref:`/reverse <c2c-api-reverse>` endpoints are not supported. You can't 
+- :ref:`/reverse <c2c-api-reverse>` endpoint is not supported. You can't 
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
   request. 
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
-  <c2c-api-start-sharding>` with a pre-6.0 cluster. 
+  <c2c-api-start-sharding>`. 
 
 - Indexes with inconsistent specs or that are missing on some shards are not 
   supported. To check for index inconsistencies, see 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -21,7 +21,7 @@
      Writes that produce DDL events on source collections outside of the 
      :ref:`namespace filter <c2c-filtered-sync>` are allowed.
 
-- geoHaystack indexes <index-geohaystack-index>` are not supported.
+- ``geoHaystack`` indexes are not supported.
 
 - :ref:`/reverse <c2c-api-reverse>` endpoints are not supported. You can't 
   enable ``reversible`` in the :ref:`/start <c2c-api-start>` request.

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -1,5 +1,6 @@
-- Writes that produce DDL events cannot occur on the source cluster during the 
-  migration. The following events cannot occur: 
+- Writes that produce :term:`DDL <DDL (Data Definition Language)>` events cannot 
+  occur on the source cluster during the migration. The following events cannot 
+  occur: 
   
   - ``collMod``
   - ``create``
@@ -28,13 +29,15 @@
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request. 
+  request. Ensure that no writes are made to the source or destination cluster 
+  during the migration.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
-  <c2c-api-start-sharding>`. 
+  <c2c-api-start-sharding>`. Instead, create an index to support your shard key 
+  on the source cluster. 
 
-- Indexes with inconsistent specs or that are missing on some shards are not 
-  supported. To check for index inconsistencies, see 
+- If there are any indexes with inconsistent specs or that are missing 
+  ``mongosync`` returns an error. To check for index inconsistencies, see 
   :ref:`manage-indexes-find-inconsistent-indexes`.
 
 - For source clusters running MongoDB 4.4, :ref:`SRV connection strings 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -1,0 +1,40 @@
+- Writes that produce DDL events cannot occur on the source cluster during the 
+  migration. The following events cannot occur: 
+  
+  - create
+  - drop
+  - dropDatabase
+  - createIndexes
+  - dropIndexes
+  - collModrefineCollectionShardKey
+  - rename
+  - reshardCollection
+  - shardCollection
+
+  This includes operations that may create new collections such as 
+  :dbcommand:`mapReduce`, :pipeline:`$out`, and :pipeline:`$merge`. This also 
+  includes collections created implicitly from inserts. Only writes that produce 
+  CRUD events can occur during the migration.
+
+  .. note:: 
+   
+     Writes that produce DDL events on source collections outside of the 
+     :ref:`namespace filter <c2c-filtered-sync>` are allowed.
+
+- :ref:`GeoHaystack indexes <index-geohaystack-index>` are not supported.
+
+- :ref:`/reverse <c2c-api-reverse>` endpoints are not supported. You can't 
+  enable ``reversible`` in the :ref:`/start <c2c-api-start>` request.
+
+- You can't enable the ``enableUserWriteBlocking`` in the ``/start`` request. 
+
+- :ref:`SRV connection strings <connections-dns-seedlist>` for 4.4 source 
+  clusters are not supported. You must use a :ref:`standard connection string
+  <connections-standard-connection-string-format>`.
+
+- You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
+  <c2c-api-start-sharding>` with a pre-6.0 cluster. 
+
+- Indexes with inconsistent specs or are missing on some shards are not 
+  supported. To check for index inconsistencies, see 
+  :ref:`manage-indexes-find-inconsistent-indexes`.

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -1,15 +1,15 @@
 - Writes that produce DDL events cannot occur on the source cluster during the 
   migration. The following events cannot occur: 
   
-  - create
-  - drop
-  - dropDatabase
-  - createIndexes
-  - dropIndexes
-  - collModrefineCollectionShardKey
-  - rename
-  - reshardCollection
-  - shardCollection
+  - ``create``
+  - ``drop``
+  - ``dropDatabase``
+  - ``createIndexes``
+  - ``dropIndexes``
+  - ``collModrefineCollectionShardKey``
+  - ``rename``
+  - ``reshardCollection``
+  - ``shardCollection``
 
   This includes operations that may create new collections such as 
   :dbcommand:`mapReduce`, :pipeline:`$out`, and :pipeline:`$merge`. This also 
@@ -21,12 +21,13 @@
      Writes that produce DDL events on source collections outside of the 
      :ref:`namespace filter <c2c-filtered-sync>` are allowed.
 
-- :ref:`GeoHaystack indexes <index-geohaystack-index>` are not supported.
+- geoHaystack indexes <index-geohaystack-index>` are not supported.
 
 - :ref:`/reverse <c2c-api-reverse>` endpoints are not supported. You can't 
   enable ``reversible`` in the :ref:`/start <c2c-api-start>` request.
 
-- You can't enable the ``enableUserWriteBlocking`` in the ``/start`` request. 
+- You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
+  request. 
 
 - :ref:`SRV connection strings <connections-dns-seedlist>` for 4.4 source 
   clusters are not supported. You must use a :ref:`standard connection string
@@ -35,6 +36,6 @@
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>` with a pre-6.0 cluster. 
 
-- Indexes with inconsistent specs or are missing on some shards are not 
+- Indexes with inconsistent specs or that are missing on some shards are not 
   supported. To check for index inconsistencies, see 
   :ref:`manage-indexes-find-inconsistent-indexes`.

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -24,7 +24,7 @@
 - ``geoHaystack`` indexes are not supported.
 
 - :ref:`/reverse <c2c-api-reverse>` endpoints are not supported. You can't 
-  enable ``reversible`` in the :ref:`/start <c2c-api-start>` request.
+  enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
   request. 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -29,13 +29,14 @@
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
   request. 
 
-- :ref:`SRV connection strings <connections-dns-seedlist>` for 4.4 source 
-  clusters are not supported. You must use a :ref:`standard connection string
-  <connections-standard-connection-string-format>`.
-
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>` with a pre-6.0 cluster. 
 
 - Indexes with inconsistent specs or that are missing on some shards are not 
   supported. To check for index inconsistencies, see 
   :ref:`manage-indexes-find-inconsistent-indexes`.
+
+- For source clusters running MongoDB 4.4, :ref:`SRV connection strings 
+  <connections-dns-seedlist>` are not supported. You must use a 
+  :ref:`standard connection string 
+  <connections-standard-connection-string-format>`.

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -198,3 +198,11 @@ cluster.
 
 .. include:: /includes/fact-verifier-limitations
 
+Pre-6.0 Migrations 
+------------------
+
+Starting in 1.10, ``mongosync`` supports migrations from source clusters running 
+MongoDB server versions older than 6.0. For information on supported migration 
+paths, see :ref:`c2c-server-version-compatibility`.
+
+.. include:: /includes/fact-older-version-limitations.rst

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -115,7 +115,7 @@ Sharded Clusters
 - Shards cannot be added or removed while syncing.
 - ``mongosync`` only syncs indexes that exist on all shards.
 - ``mongosync`` only syncs indexes that have consistent index
-  specifications on all shards.
+  specifications on all shards. 
 
   .. note::
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -205,4 +205,6 @@ Starting in 1.10, ``mongosync`` supports migrations from source clusters running
 MongoDB server versions older than 6.0. For information on supported migration 
 paths, see :ref:`c2c-server-version-compatibility`.
 
+The following limitations apply to pre-6.0 migrations:
+
 .. include:: /includes/fact-older-version-limitations.rst


### PR DESCRIPTION
## DESCRIPTION 
- Documents limits of Older Version Support in C2C

## STAGING 
https://deploy-preview-522--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#pre-6.0-migrations

## JIRA
[DOCSP-45860](https://jira.mongodb.org/browse/DOCSP-45860)