### PR TITLE
(DOCSP-45695) [C2C] Add banner that mongosync is not supported with non-genuine MongoDB

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -43,3 +43,12 @@ c2c-product-name = "Cluster-to-Cluster Sync"
 version = "{+version+}"
 version-dev = "{+version-dev+}"
 
+[[banners]]
+# Warning for non-genuine deployment usage with tool binaries.
+targets = [
+        "index.txt"
+        ]
+variant = "warning"
+value = """\
+        MongoDB Command Line Database Tool binaries are not supported or tested for use with non-genuine MongoDB deployments. While the tools may work on these deployments, compatibility is not guaranteed.
+        """


### PR DESCRIPTION
## DESCRIPTION
Similarly to our disclaimer for [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/#mongodump) and other database tools, we should add a disclaimer to mongosync that it is not supported with non-genuine mongodb.

## STAGING


## JIRA
[DOCSP-45695](https://jira.mongodb.org/browse/DOCSP-45695)

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
