### PR TITLE
DOCSP-45310-remove-beta-v1.8-backport (513)

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -54,3 +54,6 @@ raw: ${prefix}/current/installation/install-on-windows/ -> ${base}/current/
 
 # DOCSP-41999 redirect disaster recovery to mongosync behavior page
 [*]: ${prefix}/${version}/reference/disaster-recovery -> ${base}/${version}/about-mongosync/#considerations-for-continuous-sync
+
+# DOCSP-45310 Remove Beta docs from public view
+[*]: ${prefix}/${version}/reference/beta-program -> ${base}/${version}/

--- a/snooty.toml
+++ b/snooty.toml
@@ -21,7 +21,6 @@ toc_landing_pages = ["/quickstart",
                      "/multiple-mongosyncs",
                      "/release-notes/release-notes",
                      "/faq",
-                     "/reference/beta-program",
                      "/reference/collection-level-filtering",
                      "/reference/verification",
                      "/reference/mongosync"

--- a/source/includes/beta-program-intro.rst
+++ b/source/includes/beta-program-intro.rst
@@ -1,3 +1,3 @@
-Starting in version 1.8.0, {+c2c-product-name+} introduces the 
+Starting in version 1.8.0, {+c2c-product-name+} introduces the invite-only
 {+c2c-full-beta-program+}. With {+c2c-beta-program-short+}, you can use 
 experimental features with direct support and assistance from MongoDB.

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -66,4 +66,3 @@ Reference
    Data Transfer Verification </reference/verification>
    Versioning </reference/versioning>
    Version Compatibility </reference/supported-server-version>
-   Beta Program </reference/beta-program>

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -110,17 +110,6 @@ Request Body Parameters
 
        .. versionadded:: 1.3.0
 
-   * - ``documentFilter``
-     - document
-     - Optional
-     - .. include:: /includes/beta-feature-non-admonition.rst
-
-       .. include:: /includes/document-filtering-intro.rst
-       
-       To learn more, see :ref:`c2c-beta-document-filtering`.
-
-       .. versionadded:: 1.8 Beta
-
    * - ``enableUserWriteBlocking``
      - boolean
      - Optional
@@ -158,17 +147,6 @@ Request Body Parameters
        .. include:: /includes/api/facts/namespace-explanation.rst
 
        .. versionadded:: 1.6
-
-   * - ``namespaceRemap``
-     - array
-     - Optional
-     - .. include:: /includes/beta-feature-non-admonition.rst
-
-       Array of documents that specify namespace changes to make during sync.
-
-       For more information, see :ref:`c2c-beta-namespace-remapping`.
-
-       .. versionadded:: 1.8 Beta
 
    * - ``reversible``
      - boolean

--- a/source/reference/beta-program-private.txt
+++ b/source/reference/beta-program-private.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-program:
 
 ====================================
@@ -17,19 +22,8 @@
 Each ``mongosync`` release has a corresponding {+c2c-beta-program-short+} 
 build that includes its own set of experimental features.
 
-.. _c2c-beta-program-disclaimer:
-
-Get Started 
------------
-
-.. note:: 
-
-   Filing a support ticket does  *not* guarantee access to the 
-   {+c2c-beta-program-short+} binaries. 
-
-To request access to the {+c2c-beta-program-short+} binaries, read the 
-following disclaimer and file a ticket with 
-`support <https://support.mongodb.com/>`_:
+When you first run the {+c2c-beta-program-short+} binary, it will prompt you 
+to accept the following disclaimer:
 
 .. code-block:: shell
    :copyable: false
@@ -51,9 +45,6 @@ following disclaimer and file a ticket with
    supervised migrations (e.g., not for continuous sync or automated 
    migrations). Beta capabilities are not intended for use to migrate 
    production workloads.
-
-When you first run the {+c2c-beta-program-short+} binary, it will prompt you 
-to accept the disclaimer.
 
 .. seealso:: 
 
@@ -119,9 +110,9 @@ The following table shows supported combinations of beta features:
 .. toctree::
    :titlesonly:
 
-   A->B->C Migrations </reference/beta-program/abc-migration>
-   Many-To-One Migrations </reference/beta-program/many-to-one>
-   Document Filtering </reference/beta-program/document-filtering>
-   Pre-Existing Data Handling </reference/beta-program/destinationDataHandling> 
-   Namespace Remapping </reference/beta-program/namespace-remapping>
-   Oplog Rollover Resilience </reference/beta-program/orr> 
+   A->B->C Migrations </reference/beta-program-private/abc-migration>
+   Many-To-One Migrations </reference/beta-program-private/many-to-one>
+   Document Filtering </reference/beta-program-private/document-filtering>
+   Pre-Existing Data Handling </reference/beta-program-private/destinationDataHandling> 
+   Namespace Remapping </reference/beta-program-private/namespace-remapping>
+   Oplog Rollover Resilience </reference/beta-program-private/orr> 

--- a/source/reference/beta-program-private/abc-migration.txt
+++ b/source/reference/beta-program-private/abc-migration.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-abc-migration:
 
 ==================
@@ -50,7 +55,7 @@ before the second migration (B->C) starts committing.
 
    Before you use any experimental {+c2c-beta-program-short+} features, 
    review the :ref:`{+c2c-full-beta-program+} Disclaimer 
-   <c2c-beta-program-disclaimer>`.
+   <c2c-beta-program>`.
 
 
 For better performance, ensure that the first migration (A->B) reaches 
@@ -79,9 +84,8 @@ The following example performs two consecutive migrations that:
 #. Connect the source cluster on port ``27001`` with a destination cluster 
    running on port ``27002``.
 
-The command also sets :option:`--migrationName`
-to describe the operations and store migration metadata for each 
-sync.
+The command also sets ``--migrationName`` to describe the operations and store 
+migration metadata for each sync.
 
 .. code-block:: shell
 

--- a/source/reference/beta-program-private/destinationDataHandling.txt
+++ b/source/reference/beta-program-private/destinationDataHandling.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-destination-data-handling:
 
 ===========================================

--- a/source/reference/beta-program-private/document-filtering.txt
+++ b/source/reference/beta-program-private/document-filtering.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-document-filtering:
 
 ==================

--- a/source/reference/beta-program-private/many-to-one.txt
+++ b/source/reference/beta-program-private/many-to-one.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-many-to-one:
 
 ======================
@@ -77,8 +82,8 @@ Example
 
 The following example connects source clusters running on port ``27000``
 and ``27001`` with a destination cluster running on port ``35000``. The command 
-also sets the :option:`--migrationName` option to 
-describe the operations and store migration metadata for each sync.
+also sets the ``--migrationName`` option to describe the operations and store 
+migration metadata for each sync.
 
 .. code-block:: shell
 

--- a/source/reference/beta-program-private/namespace-remapping.txt
+++ b/source/reference/beta-program-private/namespace-remapping.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-namespace-remapping:
 
 ===================

--- a/source/reference/beta-program-private/orr.txt
+++ b/source/reference/beta-program-private/orr.txt
@@ -1,3 +1,8 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
 .. _c2c-beta-orr:
 
 =========================

--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -113,17 +113,6 @@ Options
    To set the ``logPath`` setting from the command line, see the
    :option:`--logPath` option.
 
-.. setting:: migrationName
-
-   *Type*: string 
-
-   .. include:: /includes/beta-feature.rst
-
-   .. include:: /includes/opts/migrationName.rst
-   
-   To set the ``migrationName`` setting from the command line, see the
-   :option:`--migrationName` option.
-
 .. setting:: port
 
    *Type*: integer

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -150,15 +150,6 @@ Global Options
 
       .. include:: /includes/fact-log-rotation-usr1-signal
 
-.. option:: --migrationName <name>
-
-   .. include:: /includes/beta-feature.rst
-
-   .. include:: /includes/opts/migrationName.rst
-
-   To set the ``--migrationName`` option from a configuration file,
-   see the :setting:`migrationName` setting.
-
 .. option:: --port
 
    .. include:: /includes/opts/port.rst

--- a/source/release-notes/1.8.txt
+++ b/source/release-notes/1.8.txt
@@ -13,7 +13,7 @@ Release Notes for mongosync 1.8
    :class: singlecol
 
 This page describes changes and new features introduced in  
-{+c2c-full-product-name+} {+version+} and the {+c2c-full-beta-program+}.
+{+c2c-full-product-name+} 1.8.
 
 Patch Releases
 --------------
@@ -102,59 +102,6 @@ mongosync Authentication with Atlas Workload Identity Federation
 .. include:: /includes/mongosync-and-oidc.rst
 
 For details, see :ref:`c2c-authentication`.
-
-{+c2c-full-beta-program+}
-------------------------------------
-
-.. include:: /includes/beta-program-intro.rst
-
-In addition to the beta features, {+c2c-beta-program-short+} includes all 
-changes and new features from ``mongosync`` {+version+}.
-
-To learn more, see :ref:`c2c-beta-program`.
-
-A->B->C Migrations
-~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/abc-migration-intro.rst
-
-To learn more, see :ref:`c2c-beta-abc-migration`.
-
-Many-to-One Migrations
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/many-to-one-cluster.rst
-
-To learn more, see :ref:`c2c-beta-many-to-one`.
-
-Document Filtering
-~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/document-filtering-intro.rst
-
-To learn more, see :ref:`c2c-beta-document-filtering`.
-
-Handle Destination Data with destinationDataHandling Option
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/destinationDataHandling-introduction.rst
-
-For details, see :ref:`c2c-beta-destination-data-handling`.
-
-Namespace Remapping
-~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/namespace-remapping-intro.rst
-
-For more information, see :ref:`c2c-beta-namespace-remapping`.
-
-Oplog Rollover Resilience
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/orr-intro.rst
-
-To learn more, see :ref:`c2c-beta-orr`.
-
 
 Minimum Supported Version
 -------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-45310-remove-beta (#513)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/513)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)