### PR TITLE
(DOCSP-45308) [c2c] add note on how to verify shard keys

### DIFF
--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -118,6 +118,15 @@ source to the destination cluster.
        :method:`db.getCollectionInfos` method on the source and
        destination clusters and compare the results.
 
+   * - .._c2c-shardkey-comparison: 
+
+       Shard Key Comparison
+     - To verify the transfer of shard keys, run a query on the source and 
+       destination clusters that searches the ``config.collections``
+       for a document with an ``_id`` value that matches the current namespace. 
+       The document's ``key`` value should remain consistent between the 
+       source and destination clusters. 
+
    * - :ref:`Migration Verifier <c2c-migration-verifier>`
      - Migration Verifier connects to the source and destination
        clusters and performs a series of verification checks,

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -121,12 +121,12 @@ source to the destination cluster.
    * - .. _c2c-shardkey-comparison: 
 
        Shard Key Comparison
-     - To verify the transfer of shard keys in a synced collection, run a query on the ``config.collections``
+     - To verify the transfer of shard keys to a synced collection, run a query on the ``config.collections``
        collection to find a document whose ``_id`` value is the namespace of the target collection. 
        Compare the ``key`` value of this document in the source and destination clusters.
 
-       For a collection named ``pets`` in the ``records`` database, you can find the shard key
-       using the following command in :binary:`mongosh`: 
+       For a collection named ``pets`` in the ``records`` database, you can verify the shard key
+       using the following query in :binary:`mongosh`: 
 
        .. io-code-block:: 
           :copyable: true

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -118,15 +118,15 @@ source to the destination cluster.
        :method:`db.getCollectionInfos` method on the source and
        destination clusters and compare the results.
 
-   * - .._c2c-shardkey-comparison: 
+   * - .. _c2c-shardkey-comparison: 
 
        Shard Key Comparison
      - To verify the transfer of shard keys in a synced collection, run a query on the :data:`~config.collections`
        collection to find a document whose ``_id`` value is the namespace of the target collection. 
        Compare the ``key`` field value of this document in the source and destination clusters.
 
-       For a collection named ``pets`` in the ``records`` database, you identify the shard key 
-       using the following query in :binary:`mongosh`:
+       You can identify the shard key for a collection named ``pets`` in the ``records`` database 
+       using the following query in :binary:`mongosh`: 
 
        .. io-code-block:: 
           :copyable: true
@@ -134,14 +134,16 @@ source to the destination cluster.
           .. input::
              :language: javascript 
 
-             db.collections.find({ _id : "db.collection" }) 
+             use config
+
+             db.collections.find({ _id : "records.pets" }) 
 
           .. output:: 
              :language: javascript
              :emphasize-lines: 5-7
 
              {
-                 "_id" : "db.collection",
+                 "_id" : "records.pets",
                  "lastmod" : ISODate("2021-07-21T15:48:15.193Z"),
                  "timestamp": Timestamp(1626882495, 1),
                  "key" : {
@@ -150,7 +152,7 @@ source to the destination cluster.
                  "unique" : false,
                  "lastmodEpoch" : ObjectId("5078407bd58b175c5c225fdc"),
                  "uuid" :  UUID("f8669e52-5c1b-4ea2-bbdc-a00189b341da")
-            }
+             }
 
    * - :ref:`Migration Verifier <c2c-migration-verifier>`
      - Migration Verifier connects to the source and destination

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -134,7 +134,7 @@ source to the destination cluster.
           .. input::
              :language: javascript 
 
-             db.getSiblingDB("config").find({ _id : "records.pets" }) 
+             db.getSiblingDB("config").collections.find({ _id : "records.pets" }) 
 
           .. output:: 
              :language: javascript

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -121,11 +121,11 @@ source to the destination cluster.
    * - .. _c2c-shardkey-comparison: 
 
        Shard Key Comparison
-     - To verify the transfer of shard keys in a synced collection, run a query on the :data:`~config.collections`
+     - To verify the transfer of shard keys in a synced collection, run a query on the ``config.collections``
        collection to find a document whose ``_id`` value is the namespace of the target collection. 
        Compare the ``key`` field value of this document in the source and destination clusters.
 
-       You can identify the shard key for a collection named ``pets`` in the ``records`` database 
+       For a collection named ``pets`` in the ``records`` database, you can identify the shard key
        using the following query in :binary:`mongosh`: 
 
        .. io-code-block:: 
@@ -134,13 +134,12 @@ source to the destination cluster.
           .. input::
              :language: javascript 
 
-             use config
-
-             db.collections.find({ _id : "records.pets" }) 
+             db.getSiblingDB("config").find({ _id : "records.pets" }) 
 
           .. output:: 
              :language: javascript
              :emphasize-lines: 5-7
+             :visible: false
 
              {
                  "_id" : "records.pets",

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -125,7 +125,7 @@ source to the destination cluster.
        collection to find a document whose ``_id`` value is the namespace of the target collection. 
        Compare the ``key`` value of this document in the source and destination clusters.
 
-       For a collection named ``pets`` in the ``records`` database, you can verify the shard key
+       For example, for a collection named ``pets`` in the ``records`` database, you can verify the shard key
        using the following query in :binary:`mongosh`: 
 
        .. io-code-block:: 

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -121,11 +121,36 @@ source to the destination cluster.
    * - .._c2c-shardkey-comparison: 
 
        Shard Key Comparison
-     - To verify the transfer of shard keys, run a query on the source and 
-       destination clusters that searches the ``config.collections``
-       for a document with an ``_id`` value that matches the current namespace. 
-       The document's ``key`` value should remain consistent between the 
-       source and destination clusters. 
+     - To verify the transfer of shard keys in a synced collection, run a query on the :data:`~config.collections`
+       collection to find a document whose ``_id`` value is the namespace of the target collection. 
+       Compare the ``key`` field value of this document in the source and destination clusters.
+
+       For a collection named ``pets`` in the ``records`` database, you identify the shard key 
+       using the following query in :binary:`mongosh`:
+
+       .. io-code-block:: 
+          :copyable: true
+
+          .. input::
+             :language: javascript 
+
+             db.collections.find({ _id : "db.collection" }) 
+
+          .. output:: 
+             :language: javascript
+             :emphasize-lines: 5-7
+
+             {
+                 "_id" : "db.collection",
+                 "lastmod" : ISODate("2021-07-21T15:48:15.193Z"),
+                 "timestamp": Timestamp(1626882495, 1),
+                 "key" : {
+                       "_id" : 1
+                 },
+                 "unique" : false,
+                 "lastmodEpoch" : ObjectId("5078407bd58b175c5c225fdc"),
+                 "uuid" :  UUID("f8669e52-5c1b-4ea2-bbdc-a00189b341da")
+            }
 
    * - :ref:`Migration Verifier <c2c-migration-verifier>`
      - Migration Verifier connects to the source and destination

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -123,10 +123,10 @@ source to the destination cluster.
        Shard Key Comparison
      - To verify the transfer of shard keys in a synced collection, run a query on the ``config.collections``
        collection to find a document whose ``_id`` value is the namespace of the target collection. 
-       Compare the ``key`` field value of this document in the source and destination clusters.
+       Compare the ``key`` value of this document in the source and destination clusters.
 
-       For a collection named ``pets`` in the ``records`` database, you can identify the shard key
-       using the following query in :binary:`mongosh`: 
+       For a collection named ``pets`` in the ``records`` database, you can find the shard key
+       using the following command in :binary:`mongosh`: 
 
        .. io-code-block:: 
           :copyable: true


### PR DESCRIPTION
## DESCRIPTION
currently, we don't document how to verify that shard keys are migrated during a sync. that said, it is important that users do this, so it'd be great to add this note.

From [Felipe Gasper](https://jira.mongodb.org/secure/ViewProfile.jspa?name=felipe.gasper%40mongodb.com):

> To find a collection’s shard key, look in `config.collections` for a document whose _id is the namespace in question, then look at that document’s key. So to manually check shard keys, run such a query on both source & destination, and compare the results.

## STAGING
https://deploy-preview-526--docs-cluster-to-cluster-sync.netlify.app/reference/verification/

## JIRA
[DOCSP-45308](https://jira.mongodb.org/browse/DOCSP-45308)

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
