### PR TITLE
(DOCSP-45695) Backport to v1.8: [C2C] Add banner that mongosync is not supported with non-genuine MongoDB #523 #527

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -41,3 +41,14 @@ c2c-product-name = "Cluster-to-Cluster Sync"
 version = "{+version+}"
 version-dev = "{+version-dev+}"
 
+[[banners]]
+# Warning for non-genuine deployment usage with tool binaries.
+targets = [
+        "index.txt",
+        "about-mongosync.txt",
+        "mongosync.txt"
+        ]
+variant = "warning"
+value = """\
+        MongoDB Command Line Database Tool binaries are not supported or tested for use with non-genuine MongoDB deployments. While the tools may work on these deployments, compatibility is not guaranteed.
+        """


### PR DESCRIPTION
## BACKPORT
Backport https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/523 to v1.8

## DESCRIPTION
Similarly to our disclaimer for [mongodump](https://www.mongodb.com/docs/database-tools/mongodump/#mongodump) and other database tools, we should add a disclaimer to mongosync that it is not supported with non-genuine mongodb.

## JIRA
[DOCSP-45695](https://jira.mongodb.org/browse/DOCSP-45695)