### PR TITLE
(DOCSP-45816) [C2C] Clarify documentations on continuous sync

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -18,6 +18,8 @@ The :ref:`mongosync <c2c-mongosync>` binary is the primary process used in
 {+c2c-product-name+}. ``mongosync`` migrates data from a source cluster to a 
 destination cluster and keeps the clusters in continuous sync until you 
 :ref:`finalize <c2c-about-finalizing>` the sync. 
+In addition to continuous data synchronization, ``mongosync`` can also
+facilitate a one time data migration between clusters.
 
 ``mongosync`` keeps track of its current actions through 
 :ref:`states <c2c-states>`. ``mongosync`` enters different states depending on 

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -36,6 +36,9 @@ and API operations:
    :alt: Diagram of relationship between ``mongosync`` states and API operations
    :figwidth: 600px
 
+The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses
+common questions users have asked about ``mongosync``.
+
 Details
 -------
 

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -19,7 +19,7 @@ The :ref:`mongosync <c2c-mongosync>` binary is the primary process used in
 destination cluster and keeps the clusters in continuous sync until you 
 :ref:`finalize <c2c-about-finalizing>` the sync. 
 In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters.
+perform a one time data migration between clusters.
 
 ``mongosync`` keeps track of its current actions through 
 :ref:`states <c2c-states>`. ``mongosync`` enters different states depending on 
@@ -38,8 +38,7 @@ and API operations:
    :alt: Diagram of relationship between ``mongosync`` states and API operations
    :figwidth: 600px
 
-The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses
-common questions users have asked about ``mongosync``.
+The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions users have asked about ``mongosync``.
 
 Details
 -------

--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -19,10 +19,6 @@ The :ref:`mongosync <c2c-mongosync>` binary is the primary process used in
 destination cluster and keeps the clusters in continuous sync until you 
 :ref:`finalize <c2c-about-finalizing>` the sync. 
 
-You can use ``mongosync`` to create 
-dedicated analytics, development, or testing clusters that mirror your 
-production environment. 
-
 ``mongosync`` keeps track of its current actions through 
 :ref:`states <c2c-states>`. ``mongosync`` enters different states depending on 
 the requests it receives. The current ``mongosync`` state determines which API 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -22,17 +22,15 @@ Support.
 Can I perform reads or writes to my destination cluster while ``mongosync`` is syncing?
 ---------------------------------------------------------------------------------------
 
-You can perform reads at any time during synchronization. However, 
-the data that you read is :term:`eventually consistent <eventual consistency>`. 
-``mongosync`` combines and reorders writes from the source to destination
-during synchronization, and also temporarily modifies various collection characteristics. 
-As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing,
-and read consistency is not guaranteed until :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
+You can perform reads at any time during synchronization. 
+However, ``mongosync`` combines and reorders writes from the source to destination during synchronization, 
+and also temporarily modifies various collection characteristics. 
+As a result, the destination is not guaranteed to match the source while the sync is executing. 
+For consistent reads, wait for the migration to :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
 
 Performing writes to your destination cluster during synchronization is not a supported workflow for ``mongosync``. 
-To block writes on the destination cluster during sync and on the source cluster when :ref:`c2c-api-commit` is received, 
-enable :ref:`c2c-write-blocking` when you run the :ref:`c2c-api-start` endpoint.
-If you did not enable write blocking when you started ``mongosync``, run :dbcommand:`setUserWriteBlockMode` on the source cluster to block writes.
+To block writes on the destination cluster during sync, enable :ref:`c2c-write-blocking` when you run the :ref:`c2c-api-start` endpoint.
+If you did not enable write blocking when you started ``mongosync``, run :dbcommand:`setUserWriteBlockMode` on the destination cluster to block writes.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
 To check the value of ``canWrite``, call the :ref:`c2c-api-progress` endpoint.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -25,18 +25,23 @@ that you read is :term:`eventually consistent <eventual consistency>`. For
 consistent reads, wait for the migration to commit. To learn more, see 
 :ref:`mongosync-considerations`.
 
-If you write to a synced namespace before issuing a :ref:`commit 
-<c2c-api-commit>` and while ``canWrite`` is ``false``, the behavior is 
-undefined. To ensure that you don't write to any synced namespaces, enable 
-:ref:`write blocking <c2c-write-blocking>`.
+Attempting to commit without pausing writes on both the source and the destination, or forgoing mongosync commit altogether during cutover, are not supported or tested workflows for mongosync
+
+Performing writes to your destination cluster during synchronization is not a supported or tested 
+workflow for ``mongosync``. 
+``mongosync`` combines and reorders writes from the source to destination during the sync, and also temporarily modifies collection characteristics. 
+As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing. 
+
+To ensure that the destination matches the source, only call the :ref:`commit <c2c-api-commit>` API endpoint 
+with writes paused on the source and destination clusters. To ensure that you don't write to any synced namespaces, enable :ref:`write blocking <c2c-write-blocking>`. 
+
+Upon commit, it is only safe to write to the destination cluster when :ref:``canWrite`` is ``true``. 
+To check the value of ``canWrite``, call the :ref:`progress <c2c-api-progress>` API endpoint.
 
 .. note::
    
    Index builds on the destination cluster are treated as writes 
    while ``mongosync`` is syncing.
-
-To check the value of ``canWrite``, call the :ref:`progress <c2c-api-progress>` 
-API endpoint.
 
 Can ``mongosync`` run on its own hardware? 
 ------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -22,23 +22,22 @@ Support.
 Can I perform reads or writes to my destination cluster while ``mongosync`` is syncing?
 ---------------------------------------------------------------------------------------
 
-You can perform reads during synchronization at any time. However, the data 
-that you read is :term:`eventually consistent <eventual consistency>`. For 
-consistent reads, wait for the migration to commit. To learn more, see 
-:ref:`mongosync-considerations`.
+You can perform reads at any time during synchronization. However, 
+the data that you read is :term:`eventually consistent <eventual consistency>`. 
+``mongosync`` combines and reorders writes from the source to destination
+during synchronization, and also temporarily modifies various collection characteristics. 
+As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing,
+and read consistency is not guaranteed until :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
 
-Performing writes to your destination cluster during synchronization is not a supported or tested 
-workflow for ``mongosync``. 
-``mongosync`` combines and reorders writes from the source to destination during the sync, and also temporarily modifies collection characteristics. 
-As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing. 
-
-To ensure that the destination matches the source when you finalize the sync, only call the :ref:`commit <c2c-api-commit>` endpoint 
-when writes are blocked on the source and destination clusters. To block writes on the destination cluster during sync and 
-on the source cluster when ``commit`` is received, enable :ref:`write blocking <c2c-write-blocking>` when you run the :ref:`c2c-api-start` endpoint.
-If you did not enable write blocking, run :dbcommand:`setUserWriteBlockMode` on the source cluster to block writes.
+Performing writes to your destination cluster during synchronization is not a supported workflow for ``mongosync``. 
+To block writes on the destination cluster during sync and on the source cluster when :ref:`c2c-api-commit` is received, 
+enable :ref:`c2c-write-blocking` when you run the :ref:`c2c-api-start` endpoint.
+If you did not enable write blocking when you started ``mongosync``, run :dbcommand:`setUserWriteBlockMode` on the source cluster to block writes.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
 To check the value of ``canWrite``, call the :ref:`c2c-api-progress` endpoint.
+
+To learn more about permissable reads and writes, see :ref:`c2c-reads-and-writes`. 
 
 .. note::
    

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -32,14 +32,13 @@ workflow for ``mongosync``.
 ``mongosync`` combines and reorders writes from the source to destination during the sync, and also temporarily modifies collection characteristics. 
 As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing. 
 
-To ensure that you don't write to any synced namespaces, enable :ref:`write blocking <c2c-write-blocking>` when you start ``mongosync``. 
-The only way to ensure that the destination matches the source is to commit mongosync with writes paused on both source and destination. 
-
-To ensure that the destination matches the source, only call the :ref:`commit <c2c-api-commit>` API endpoint 
-with writes paused on the source and destination clusters. To block writing on synced namespaces, enable :ref:`write blocking <c2c-write-blocking>`. 
+To ensure that the destination matches the source when you finalize the sync, only call the :ref:`commit <c2c-api-commit>` endpoint 
+when writes are blocked on the source and destination clusters. To block writes on the destination cluster during sync and 
+on the source cluster when ``commit`` is received, enable :ref:`write blocking <c2c-write-blocking>` when you run the :ref:`c2c-api-start` endpoint.
+If you did not enable write blocking, run :dbcommand:`setUserWriteBlockMode` on the source cluster to block writes.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
-To check the value of ``canWrite``, call the :ref:`progress <c2c-api-progress>` API endpoint.
+To check the value of ``canWrite``, call the :ref:`c2c-api-progress` endpoint.
 
 .. note::
    

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -17,6 +17,8 @@ This page provides answers to some frequently asked questions we have
 encountered. If you have additional questions please contact MongoDB
 Support.
 
+.. _c2c-faq-read-write-during-sync:
+
 Can I perform reads or writes to my destination cluster while ``mongosync`` is syncing?
 ---------------------------------------------------------------------------------------
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -25,14 +25,14 @@ Can I perform reads or writes to my destination cluster while ``mongosync`` is s
 You can perform reads at any time during synchronization. 
 However, ``mongosync`` combines and reorders writes from the source to destination during synchronization, 
 and also temporarily modifies various collection characteristics. 
-As a result, the destination is not guaranteed to match the source while the sync is executing. 
+As a result, the destination is not guaranteed to match the source at any point in time when the sync is running. 
 For consistent reads, wait for the migration to :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
 
 Performing writes to your destination cluster during synchronization results in undefined behavior. 
 To block writes on the destination cluster during sync, enable :ref:`write blocking <c2c-write-blocking>` when you :ref:`c2c-api-start` ``mongosync``.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
-To check the value of ``canWrite``, call the :ref:`c2c-api-progress` endpoint.
+To check the value of ``canWrite``, run the :ref:`c2c-api-progress` endpoint.
 
 To learn more about permissable reads and writes during synchronization, see :ref:`c2c-reads-and-writes`. 
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -28,14 +28,13 @@ and also temporarily modifies various collection characteristics.
 As a result, the destination is not guaranteed to match the source while the sync is executing. 
 For consistent reads, wait for the migration to :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
 
-Performing writes to your destination cluster during synchronization is not a supported workflow for ``mongosync``. 
-To block writes on the destination cluster during sync, enable :ref:`c2c-write-blocking` when you run the :ref:`c2c-api-start` endpoint.
-If you did not enable write blocking when you started ``mongosync``, run :dbcommand:`setUserWriteBlockMode` on the destination cluster to block writes.
+Performing writes to your destination cluster during synchronization results in undefined behavior. 
+To block writes on the destination cluster during sync, enable :ref:`write blocking <c2c-write-blocking>` when you :ref:`c2c-api-start` ``mongosync``.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
 To check the value of ``canWrite``, call the :ref:`c2c-api-progress` endpoint.
 
-To learn more about permissable reads and writes, see :ref:`c2c-reads-and-writes`. 
+To learn more about permissable reads and writes during synchronization, see :ref:`c2c-reads-and-writes`. 
 
 .. note::
    

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -27,17 +27,18 @@ that you read is :term:`eventually consistent <eventual consistency>`. For
 consistent reads, wait for the migration to commit. To learn more, see 
 :ref:`mongosync-considerations`.
 
-Attempting to commit without pausing writes on both the source and the destination, or forgoing mongosync commit altogether during cutover, are not supported or tested workflows for mongosync
-
 Performing writes to your destination cluster during synchronization is not a supported or tested 
 workflow for ``mongosync``. 
 ``mongosync`` combines and reorders writes from the source to destination during the sync, and also temporarily modifies collection characteristics. 
 As a result, the destination is not guaranteed to match the source at any point in time while the sync is executing. 
 
-To ensure that the destination matches the source, only call the :ref:`commit <c2c-api-commit>` API endpoint 
-with writes paused on the source and destination clusters. To ensure that you don't write to any synced namespaces, enable :ref:`write blocking <c2c-write-blocking>`. 
+To ensure that you don't write to any synced namespaces, enable :ref:`write blocking <c2c-write-blocking>` when you start ``mongosync``. 
+The only way to ensure that the destination matches the source is to commit mongosync with writes paused on both source and destination. 
 
-Upon commit, it is only safe to write to the destination cluster when :ref:``canWrite`` is ``true``. 
+To ensure that the destination matches the source, only call the :ref:`commit <c2c-api-commit>` API endpoint 
+with writes paused on the source and destination clusters. To block writing on synced namespaces, enable :ref:`write blocking <c2c-write-blocking>`. 
+
+Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
 To check the value of ``canWrite``, call the :ref:`progress <c2c-api-progress>` API endpoint.
 
 .. note::

--- a/source/index.txt
+++ b/source/index.txt
@@ -10,14 +10,11 @@ Cluster-to-Cluster Sync
 
 {+c2c-product-name+} provides continuous data synchronization or a 
 one-time data migration between MongoDB clusters. For notes and caveats on 
-continuous sync, see the :ref:`<mongosync-considerations>` page. You can 
-enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
+continuous sync, see the :ref:`<mongosync-considerations>` page. 
+You can enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 ``mongosync`` can continuously synchronize data between two clusters.
-You can use ``mongosync`` to create dedicated analytics, development,
-or testing clusters that mirror your production environment.
-Synchronized clusters can also support locality requirements for audit
-and data residency compliance. 
+For additional considerations of continuous data synchronization, see :ref:`c2c-faq-read-write-during-sync`. 
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -10,11 +10,8 @@ Cluster-to-Cluster Sync
 
 {+c2c-product-name+} provides continuous data synchronization or a 
 one-time data migration between MongoDB clusters. For notes and caveats on 
-continuous sync, see the :ref:`<mongosync-considerations>` page. 
-You can enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
-
-``mongosync`` can continuously synchronize data between two clusters.
-For additional considerations of continuous data synchronization, see :ref:`c2c-faq-read-write-during-sync`. 
+continuous sync, see the :ref:`mongosync-considerations` page. You can
+enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -23,8 +23,7 @@ restrictions and the :ref:`c2c-mongosync-behavior` page for behavior information
 
 .. include:: /includes/limitations-warning
 
-The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses
-common questions users have asked about ``mongosync``.
+The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions users have asked about ``mongosync``.
 
 .. toctree::
    :titlesonly:

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -23,8 +23,7 @@ destination cluster and keeps the clusters in continuous sync until you
 :ref:`finalize <c2c-about-finalizing>` the sync. 
 
 In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters. To learn more, see 
-:ref:`mongosync-considerations`.
+facilitate a one time data migration between clusters.
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -21,13 +21,9 @@ The ``mongosync`` binary is the primary process used in {+c2c-product-name+}.
 ``mongosync`` migrates data from one cluster to another and can keep the 
 clusters in continuous sync.
 
-You can use ``mongosync`` to create dedicated analytics, development,
-or testing clusters that mirror your production environment.
-Synchronized clusters can also support locality requirements for audit
-and data residency compliance. 
-
 In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters. 
+facilitate a one time data migration between clusters. For additional considerations 
+of continuous data synchronization, see :ref:`c2c-faq-read-write-during-sync` in the FAQ page. 
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -18,12 +18,13 @@ Definition
 ----------
 
 The ``mongosync`` binary is the primary process used in {+c2c-product-name+}. 
-``mongosync`` migrates data from one cluster to another and can keep the 
-clusters in continuous sync.
+``mongosync`` migrates data from a source cluster to a 
+destination cluster and keeps the clusters in continuous sync until you 
+:ref:`finalize <c2c-about-finalizing>` the sync. 
 
 In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters. For additional considerations 
-of continuous data synchronization, see :ref:`c2c-faq-read-write-during-sync` in the FAQ page. 
+facilitate a one time data migration between clusters. To learn more, see 
+:ref:`mongosync-considerations`.
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -21,7 +21,6 @@ The ``mongosync`` binary is the primary process used in {+c2c-product-name+}.
 ``mongosync`` migrates data from a source cluster to a 
 destination cluster and keeps the clusters in continuous sync until you 
 :ref:`finalize <c2c-about-finalizing>` the sync. 
-
 In addition to continuous data synchronization, ``mongosync`` can also
 facilitate a one time data migration between clusters.
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -30,6 +30,9 @@ For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 To get started with ``mongosync``, refer to the :ref:`Quick Start Guide
 <c2c-quickstart>`.
 
+The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses
+common questions users have asked about ``mongosync``.
+
 Compatibility
 -------------
 

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -22,15 +22,14 @@ The ``mongosync`` binary is the primary process used in {+c2c-product-name+}.
 destination cluster and keeps the clusters in continuous sync until you 
 :ref:`finalize <c2c-about-finalizing>` the sync. 
 In addition to continuous data synchronization, ``mongosync`` can also
-facilitate a one time data migration between clusters.
+perform a one time data migration between clusters.
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 
 To get started with ``mongosync``, refer to the :ref:`Quick Start Guide
 <c2c-quickstart>`.
 
-The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses
-common questions users have asked about ``mongosync``.
+The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions users have asked about ``mongosync``.
 
 Compatibility
 -------------

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -152,6 +152,8 @@ Capped Collections
 
 .. include:: /includes/collections/behavior-capped-collections.rst
 
+.. _c2c-reads-and-writes: 
+
 Reads and Writes
 ----------------
 


### PR DESCRIPTION
## DESCRIPTION

Update "Can I perform reads or writes to my destination cluster while mongosync is syncing?" [FAQ entry](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/faq/#can-i-perform-reads-or-writes-to-my-destination-cluster-while-mongosync-is-syncing-) to include the below context:

> mongosync combines and reorders writes from the source to destination during the sync, and also temporarily modifies various collection characteristics. As a result, the destination is not guaranteed to match the source, even a stale version of the source, at any point in time while the sync is still executing. The only way to ensure that the destination matches the source is to commit mongosync with writes paused on both source and destination. Upon commit, it is only safe to resume writes on the destination once canWrite is true. Attempting to commit without pausing writes on both the source and the destination, or forgoing mongosync commit altogether during cutover, are not supported or tested workflows for mongosync

In continuous sync, users need to commit mongosync in order to have a point of consistency. Disaster recovery is currently not supported by mongosync, because mongosync does not guarantee consistency during synchronization.

On the [mongosync reference](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/mongosync/), [About mongosync](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/about-mongosync/), and [landing](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/) pages, link to the FAQ and remove this paragraph: 

> You can use mongosync to create dedicated analytics, development, or testing clusters that mirror your production environment. Synchronized clusters can also support locality requirements for audit and data residency compliance.

## STAGING
- [FAQ](https://deploy-preview-532--docs-cluster-to-cluster-sync.netlify.app/faq/)
- [mongosync reference](https://deploy-preview-532--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/)
- [landing](https://deploy-preview-532--docs-cluster-to-cluster-sync.netlify.app/)
- [about-mongosync](https://deploy-preview-532--docs-cluster-to-cluster-sync.netlify.app/about-mongosync/)

## JIRA
[DOCSP-45816](https://jira.mongodb.org/browse/DOCSP-45816)

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)


