### PR TITLE
Remove mentions of embedded verifier not supporting sharded clusters

### DIFF
--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -12,10 +12,6 @@ Limitations
 
 The embedded verifier has the following limitations:
 
-- The verifier doesn't support sharded clusters. If the
-  migration includes a sharded cluster, ``mongosync`` disables
-  the verifier.
-
 - ``mongosync`` stores the verifier state in memory, which can
   result in a significant memory overhead. To run the verifier,
   ``mongosync`` requires approximately 10 GB of memory, plus an

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -208,8 +208,7 @@ Request Body Parameters
        transitions to the ``COMMITTED`` state. If it does
        encounter errors, it fails the migration.
 
-       The verifier is enabled by default for replica set to
-       replica set migrations.
+       The verifier is enabled by default.
 
        :red:`WARNING`: The verifier does not check all
        collections or data. For details, see

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -209,8 +209,7 @@ Request Body Parameters
        encounter errors, it fails the migration.
 
        The verifier is enabled by default for replica set to
-       replica set migrations. If the migration includes a
-       sharded cluster, the verifier is disabled.
+       replica set migrations.
 
        :red:`WARNING`: The verifier does not check all
        collections or data. For details, see

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -37,8 +37,7 @@ collections on the destination cluster to confirm that
 it was successful in transferring documents from the
 source cluster to the destination.
 
-When you start the ``mongosync`` process, it provides a disclaimer advising the 
-user that the verifier is enabled by default.
+When you start the ``mongosync`` process, it provides the following disclaimer: 
 
 .. code-block:: none
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -37,30 +37,30 @@ collections on the destination cluster to confirm that
 it was successful in transferring documents from the
 source cluster to the destination.
 
-When you start the ``mongosync`` process, it provides a
-disclaimer advising the user that the verifier is enabled
-by default.
+When you start the ``mongosync`` process, it provides a disclaimer advising the 
+user that the verifier is enabled by default.
 
 .. code-block:: none
 
-   Embedded verification is enabled by default for replica set to replica set migrations.
-   Verification checks for data consistency between the source and destination clusters.
-   Verification will cause mongosync to fail if any inconsistencies are detected, but it
-   does not check for all possible data inconsistencies. Please see the documentation at
-   https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/verification/embedded
-   for more details. Verification requires approximately 0.5 GB of memory per 1 million documents
-   on the source cluster and will fail if insufficient memory is available. Accepting this
-   disclaimer indicates that you understand the limitations and memory requirements for this
-   tool. To skip this disclaimer prompt, use –-acceptDisclaimer.
+   Embedded verification is enabled by default. Verification checks for data 
+   consistency between the source and destination clusters. Verification will 
+   cause mongosync to fail if any inconsistencies are detected, but it does not 
+   check for all possible data inconsistencies. Please see the documentation at 
+   https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/verification/embedded 
+   for more details. Verification requires approximately 0.5 GB of memory per 1 
+   million documents on the source cluster and will fail if insufficient memory 
+   is available. Accepting this disclaimer indicates that you understand the 
+   limitations and memory requirements for this tool. To skip this disclaimer 
+   prompt, use –-acceptDisclaimer.
 
-   To disable the embedded verifier, specify 'verification: false' when starting mongosync. Please see
-   https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/verification/
+   To disable the embedded verifier, specify 'verification: false' when starting 
+   mongosync. Please see https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/verification/ 
    for alternative verification methods.
 
    Do you want to continue? (y/n):
 
-If you have already read and accepted the disclaimer, you can
-start ``mongosync`` with the :option:`--acceptDisclaimer` option
+If you have already read and accepted the disclaimer, you can 
+start ``mongosync`` with the :option:`--acceptDisclaimer` option 
 to skip this notification.
 
 Settings

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -56,6 +56,8 @@ source to the destination cluster.
 
        The verifier doesn't check every aspect of a migration:
 
+       - To verify sync on unsupported namespaces, use a different 
+         verification method.
        - To verify index sync, use the :ref:`Index Comparison
          <c2c-index-comparison>` method. 
        - To verify metdata sync, use the :ref:`Metadata

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -56,8 +56,6 @@ source to the destination cluster.
 
        The verifier doesn't check every aspect of a migration:
 
-       - To verify sync on unsupported namespaces and sharded
-         clusters, use a different verification method.
        - To verify index sync, use the :ref:`Index Comparison
          <c2c-index-comparison>` method. 
        - To verify metdata sync, use the :ref:`Metadata


### PR DESCRIPTION
Mongosync's embedded verifier now supports sharded clusters. 

### JIRA
https://jira.mongodb.org/browse/DOCSP-45326

### Staging
https://deploy-preview-534--docs-cluster-to-cluster-sync.netlify.app/reference/verification/
https://deploy-preview-534--docs-cluster-to-cluster-sync.netlify.app/reference/verification/embedded/
https://deploy-preview-534--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/
https://deploy-preview-534--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/

