### PR TITLE
DOCSP-46282-destination-oplog-size

### DIFF
--- a/source/includes/example-filter-collection-with-renaming.rst
+++ b/source/includes/example-filter-collection-with-renaming.rst
@@ -60,7 +60,7 @@ You can rename any collection in the ``staff`` database.
 
 You can only rename a collection within the ``students`` database if the
 new and old names are both in the filter. If either of the names is not
-in the filter, ``monogsync`` reports an error and exists.
+in the filter, ``monogsync`` reports an error and exits.
 
 .. code-block:: javascript
 

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -4,7 +4,14 @@ sync. For example, to migrate 10 GB of data, the destination cluster must have
 at least 10 GB available for the data and another 10 GB for the insert oplog 
 entries from the initial sync.
 
-To reduce the overhead of the destination oplog entries, you can: 
+.. important:: 
+  
+   To use embedded verification, you must have a larger oplog on the 
+   destination. If you enable the embedded verifier and reduce the size of the 
+   destination oplog, the embedded verifier can fall off the oplog.
+
+If you need to reduce the overhead of the destination oplog entries and the 
+:ref:`embedded verifier <c2c-embedded-verifier>` is disabled, you can: 
 
 - Use the :setting:`~replication.oplogSizeMB` setting to lower the destination 
   cluster's oplog size.

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -8,8 +8,8 @@ entries from the initial sync.
   
    To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
    larger oplog on the destination. If you enable the embedded verifier and 
-   reduce the size of the destination oplog, the embedded verifier might be 
-   omitted from the oplog.
+   reduce the size of the destination oplog, the embedded verifier might not be 
+   able to keep up, causing ``mongosync`` to error.
 
 If you need to reduce the overhead of the destination oplog entries and the 
 embedded verifier is disabled, you can: 

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -6,12 +6,13 @@ entries from the initial sync.
 
 .. important:: 
   
-   To use embedded verification, you must have a larger oplog on the 
-   destination. If you enable the embedded verifier and reduce the size of the 
-   destination oplog, the embedded verifier can fall off the oplog.
+   To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
+   larger oplog on the destination. If you enable the embedded verifier and 
+   reduce the size of the destination oplog, the embedded verifier can fall off 
+   the oplog.
 
 If you need to reduce the overhead of the destination oplog entries and the 
-:ref:`embedded verifier <c2c-embedded-verifier>` is disabled, you can: 
+embedded verifier is disabled, you can: 
 
 - Use the :setting:`~replication.oplogSizeMB` setting to lower the destination 
   cluster's oplog size.

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -8,8 +8,8 @@ entries from the initial sync.
   
    To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
    larger oplog on the destination. If you enable the embedded verifier and 
-   reduce the size of the destination oplog, the embedded verifier can fall off 
-   the oplog.
+   reduce the size of the destination oplog, the embedded verifier might be 
+   omitted from the oplog.
 
 If you need to reduce the overhead of the destination oplog entries and the 
 embedded verifier is disabled, you can: 


### PR DESCRIPTION
## DESCRIPTION 
- Adds note about the embedded verifier requiring a larger oplog. 

## STAGING 
https://deploy-preview-536--docs-cluster-to-cluster-sync.netlify.app/reference/oplog-sizing/#considerations

## JIRA 
https://jira.mongodb.org/browse/DOCSP-46282