### PR TITLE
DOCSP-46115 removes mongosync caveat and highlights embedded verifier

### DIFF
--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -159,9 +159,6 @@ source to the destination cluster.
        comparing documents, views, and indexes to confirm the
        sync was successful.
 
-       Migration Verifier is an experimental and unsupported
-       tool.
-
 The specific method you use to verify your data depends on your
 application workload and the complexity of the data.
 

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -45,8 +45,8 @@ source to the destination cluster.
        verifier, which runs a series of verification checks on
        the source and destination clusters to confirm that the
        migration was successful. **This is the preferred
-       verification method for deployments that meet the
-       :ref:`requirements <c2c-verify-embedded-limitations>`.**
+       verification method for deployments that meet the**
+       :ref:`requirements <c2c-verify-embedded-limitations>`.
 
        When the ``mongosync`` process starts, it prompts the
        user with a disclaimer about the embedded verifier. You

--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -44,9 +44,9 @@ source to the destination cluster.
      - Starting in 1.9, ``mongosync`` includes an embedded
        verifier, which runs a series of verification checks on
        the source and destination clusters to confirm that the
-       migration was successful. This is the preferred
+       migration was successful. **This is the preferred
        verification method for deployments that meet the
-       :ref:`requirements <c2c-verify-embedded-limitations>`.
+       :ref:`requirements <c2c-verify-embedded-limitations>`.**
 
        When the ``mongosync`` process starts, it prompts the
        user with a disclaimer about the embedded verifier. You

--- a/source/reference/verification/verifier.txt
+++ b/source/reference/verification/verifier.txt
@@ -33,8 +33,6 @@ About This Task
    Migration Verifier does not support DDL operations. Do not run any DDL 
    operations on the source cluster while verifying data with Migration Verifier. 
 
-Migration Verifier is an experimental and unsupported tool.
-
 For installation instructions and usage limitations, see
 `GitHub <https://github.com/mongodb-labs/migration-verifier>`__.
 


### PR DESCRIPTION
## Description
Removes the sentence stating migration verifier is unsupported/experimental, and bolds the sentence stating embedded verifier is a preferred method.

## Staging
https://deploy-preview-537--docs-cluster-to-cluster-sync.netlify.app/reference/verification/#tasks

https://deploy-preview-537--docs-cluster-to-cluster-sync.netlify.app/reference/verification/verifier/#about-this-task

## JIRA
https://jira.mongodb.org/browse/DOCSP-46115