### PR TITLE
DOCSP-46294-ttl-collections-are-unsupported

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -87,6 +87,8 @@ to discuss requirements and individualized options.
 Unsupported Collection Types
 ----------------------------
 
+``mongosync`` does not support the following collection types:
+
 - Time-series collections
 - Clustered collections with :ref:`expireAfterSeconds
   <db.createCollection.expireAfterSeconds>` set

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -99,7 +99,7 @@ Unsupported Collection Types
      TTL collections are collections that specify an
      :ref:`expireAfterSeconds <db.createCollection.expireAfterSeconds>`
      value to remove data after a specific amount of time. TTL
-     colletions are **not** collections that contain a :ref:`TTL index
+     collections are **not** collections that contain a :ref:`TTL index
      <index-feature-ttl>`.
 
 .. _c2c-sharded-limitations:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -96,8 +96,8 @@ Unsupported Collection Types
 
      TTL collections are collections that specify an
      :ref:`expireAfterSeconds <db.createCollection.expireAfterSeconds>`
-     value to remove data after a speciic amount of time. TTL
-     colletions are not collections that contain a :ref:`TTL index
+     value to remove data after a specific amount of time. TTL
+     colletions are **not** collections that contain a :ref:`TTL index
      <index-feature-ttl>`.
 
 .. _c2c-sharded-limitations:

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -96,7 +96,7 @@ Unsupported Collection Types
 
   .. note::
 
-     TTL collections are collections that specify an
+     TTL collections are collections that contain an
      :ref:`expireAfterSeconds <db.createCollection.expireAfterSeconds>`
      value to remove data after a specific amount of time. TTL
      collections are **not** collections that contain a :ref:`TTL index

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -87,9 +87,18 @@ to discuss requirements and individualized options.
 Unsupported Collection Types
 ----------------------------
 
-- Time-series collections aren't supported.
+- Time-series collections
 - Clustered collections with :ref:`expireAfterSeconds
-  <db.createCollection.expireAfterSeconds>` set aren't supported.
+  <db.createCollection.expireAfterSeconds>` set
+- TTL collections
+
+  .. note::
+
+     TTL collections are collections that specify an
+     :ref:`expireAfterSeconds <db.createCollection.expireAfterSeconds>`
+     value to remove data after a speciic amount of time. TTL
+     colletions are not collections that contain a :ref:`TTL index
+     <index-feature-ttl>`.
 
 .. _c2c-sharded-limitations:
 


### PR DESCRIPTION
## DESCRIPTION

Mongosync does not support TTL collections

## STAGING

https://deploy-preview-540--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#unsupported-collection-types

## JIRA

https://jira.mongodb.org/browse/DOCSP-46294

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)