### PR TITLE
DOCSP-46282-destination-oplog-size-v1.9-backport (536)

### DIFF
--- a/source/includes/example-filter-collection-with-renaming.rst
+++ b/source/includes/example-filter-collection-with-renaming.rst
@@ -60,7 +60,7 @@ You can rename any collection in the ``staff`` database.
 
 You can only rename a collection within the ``students`` database if the
 new and old names are both in the filter. If either of the names is not
-in the filter, ``monogsync`` reports an error and exists.
+in the filter, ``monogsync`` reports an error and exits.
 
 .. code-block:: javascript
 

--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -4,7 +4,15 @@ sync. For example, to migrate 10 GB of data, the destination cluster must have
 at least 10 GB available for the data and another 10 GB for the insert oplog 
 entries from the initial sync.
 
-To reduce the overhead of the destination oplog entries, you can: 
+.. important:: 
+  
+   To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
+   larger oplog on the destination. If you enable the embedded verifier and 
+   reduce the size of the destination oplog, the embedded verifier might not be 
+   able to keep up, causing ``mongosync`` to error.
+
+If you need to reduce the overhead of the destination oplog entries and the 
+embedded verifier is disabled, you can: 
 
 - Use the :setting:`~replication.oplogSizeMB` setting to lower the destination 
   cluster's oplog size.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46282-destination-oplog-size (#536)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/536)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)