### PR TITLE
DOCSP-46115-removes-mongosync-caveat-and-highlights-embedded-verifier-v1.9-backport (537)

### DIFF
--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -44,8 +44,8 @@ source to the destination cluster.
      - Starting in 1.9, ``mongosync`` includes an embedded
        verifier, which runs a series of verification checks on
        the source and destination clusters to confirm that the
-       migration was successful. This is the preferred
-       verification method for deployments that meet the
+       migration was successful. **This is the preferred
+       verification method for deployments that meet the**
        :ref:`requirements <c2c-verify-embedded-limitations>`.
 
        When the ``mongosync`` process starts, it prompts the
@@ -158,9 +158,6 @@ source to the destination cluster.
        clusters and performs a series of verification checks,
        comparing documents, views, and indexes to confirm the
        sync was successful.
-
-       Migration Verifier is an experimental and unsupported
-       tool.
 
 The specific method you use to verify your data depends on your
 application workload and the complexity of the data.

--- a/source/reference/verification/verifier.txt
+++ b/source/reference/verification/verifier.txt
@@ -33,8 +33,6 @@ About This Task
    Migration Verifier does not support DDL operations. Do not run any DDL 
    operations on the source cluster while verifying data with Migration Verifier. 
 
-Migration Verifier is an experimental and unsupported tool.
-
 For installation instructions and usage limitations, see
 `GitHub <https://github.com/mongodb-labs/migration-verifier>`__.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46115 removes mongosync caveat and highlights embedded verifier (#537)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/537)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)