### PR TITLE
DOCSP-46115-removes-mongosync-caveat-and-highlights-embedded-verifier-v1.8-backport (537)

### DIFF
--- a/source/reference/verification.txt
+++ b/source/reference/verification.txt
@@ -133,9 +133,6 @@ source to the destination cluster.
        comparing documents, views, and indexes to confirm the
        sync was successful.
 
-       Migration Verifier is an experimental and unsupported
-       tool.
-
 The specific method you use to verify your data depends on your
 application workload and the complexity of the data.
 

--- a/source/reference/verification/verifier.txt
+++ b/source/reference/verification/verifier.txt
@@ -28,9 +28,12 @@ transferring your application load from the source to the destination cluster.
 About This Task
 ---------------
 
-Migration Verifier is an experimental and unsupported tool.
+.. note::
 
-For installation instructions, see
+   Migration Verifier does not support DDL operations. Do not run any DDL 
+   operations on the source cluster while verifying data with Migration Verifier. 
+
+For installation instructions and usage limitations, see
 `GitHub <https://github.com/mongodb-labs/migration-verifier>`__.
 
 Steps


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-46115 removes mongosync caveat and highlights embedded verifier (#537)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/537)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)