### PR TITLE
DOCSP-46039: Clarify verifier limitation about TTLs

### DIFF
--- a/source/includes/fact-verifier-unsupported.rst
+++ b/source/includes/fact-verifier-unsupported.rst
@@ -1,7 +1,7 @@
 The verifier doesn't check the following namespaces: 
 
 - Capped collections
-- Collections with TTL indexes, including indexes that are dropped or added
+- Collections with TTL indexes, including indexes that are added or dropped
   during migration
 - Collections that don't use the default collation
 - Views

--- a/source/includes/fact-verifier-unsupported.rst
+++ b/source/includes/fact-verifier-unsupported.rst
@@ -1,7 +1,7 @@
 The verifier doesn't check the following namespaces: 
 
 - Capped collections
-- Collections with TTL indexes, including indexes that are added or dropped
+- Collections with TTL indexes, including TTL indexes that are added or dropped
   during migration
 - Collections that don't use the default collation
 - Views

--- a/source/includes/fact-verifier-unsupported.rst
+++ b/source/includes/fact-verifier-unsupported.rst
@@ -1,7 +1,8 @@
 The verifier doesn't check the following namespaces: 
 
 - Capped collections
-- Collections with TTL indexes
+- Collections with TTL indexes, including indexes that are dropped or added
+  during migration
 - Collections that don't use the default collation
 - Views
 
@@ -13,4 +14,3 @@ The verifier doesn't check the following collection features:
 To verify the above data and metadata, script additional checks
 for these collections and collection features. For more
 information, see :ref:`c2c-verification`.
-


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-46039

Adds clarification about TTL indexes.

Staging: https://deploy-preview-545--docs-cluster-to-cluster-sync.netlify.app/reference/verification/embedded/#unsupported-verification-checks