### PR TITLE
(DOCSP-46441) [C2C] Fix 'reF' typo in configuration page

### DIFF
--- a/source/reference/configuration.txt
+++ b/source/reference/configuration.txt
@@ -13,7 +13,7 @@ Configuration
    :class: singlecol
 
 You can configure :ref:`mongosync <c2c-mongosync>` instances at startup 
-by using :reF:`command line options <c2c-cli-options>` or a configuration file.
+by using :ref:`command line options <c2c-cli-options>` or a configuration file.
 The configuration file specifies values for settings that are
 the equivalent of ``mongosync`` command line options.
 


### PR DESCRIPTION
## DESCRIPTION
[DOCSP-45558](https://jira.mongodb.org/browse/DOCSP-45558) introduced an 'Unknown interpreted text role "reF".' error from a capitalization error. This fixes that error, which was not backported into other C2C versions.

## STAGING
https://deploy-preview-548--docs-cluster-to-cluster-sync.netlify.app/reference/configuration/
## JIRA
[DOCSP-46441](https://jira.mongodb.org/browse/DOCSP-46441)

## SELF-REVIEW CHECKLIST

- [x] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)

