### PR TITLE
DOCSP-45965: Embedded Verifier: Verify Reversible Migrations

### DIFF
--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -22,10 +22,6 @@ The embedded verifier has the following limitations:
   verification process restarts from the beginning. This can
   cause verification to fall substantially behind the migration.
 
-- The :ref:`/reverse <c2c-api-reverse>` endpoint disables the
-  verifier. It remains disabled after additional calls to the
-  ``/reverse`` endpoint.
-
 - .. include:: /includes/fact-verifier-buildIndexes
 
 Unsupported Verification Checks

--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -22,7 +22,7 @@
 
          - atlasAdmin
 
-   * - write-blocking or reversing
+   * - write-blocking or reversing (including multiple reversals)
      - source cluster
      -
 
@@ -30,7 +30,7 @@
          - backup
          - bypassWriteBlockMode privilege
 
-   * - write-blocking or reversing
+   * - write-blocking or reversing (including multiple reversals)
      - destination cluster
      -
 

--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -12,15 +12,12 @@
 
    * - default
      - - atlasAdmin
-       - backup
      - - atlasAdmin
 
    * - write-blocking, reversing, or multiple reversals
      - - atlasAdmin
-       - backup
        - bypassWriteBlockMode privilege
      - - atlasAdmin
-       - backup
        - bypassWriteBlockMode privilege
 
 For details on Atlas roles, see: :atlas:`Atlas User Roles

--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -7,37 +7,21 @@
    :stub-columns: 1
 
    * - Sync Type
-     - Target
-     - Required Permissions
+     - Required Source Permissions
+     - Required Destination Permissions
 
    * - default
-     - source cluster
-     -
-
-         - atlasAdmin
-         - backup
-
-   * - default
-     - destination cluster
-     -
-
-         - atlasAdmin
+     - - atlasAdmin
+       - backup
+     - - atlasAdmin
 
    * - write-blocking, reversing, or multiple reversals
-     - source cluster
-     -
-
-         - atlasAdmin
-         - backup
-         - bypassWriteBlockMode privilege
-
-   * - write-blocking, reversing, or multiple reversals
-     - destination cluster
-     -
-
-         - atlasAdmin
-         - backup
-         - bypassWriteBlockMode privilege
+     - - atlasAdmin
+       - backup
+       - bypassWriteBlockMode privilege
+     - - atlasAdmin
+       - backup
+       - bypassWriteBlockMode privilege
 
 For details on Atlas roles, see: :atlas:`Atlas User Roles
 </reference/user-roles/>`.

--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -4,6 +4,7 @@
 
 .. list-table::
    :header-rows: 1
+   :stub-columns: 1
 
    * - Sync Type
      - Target
@@ -22,7 +23,7 @@
 
          - atlasAdmin
 
-   * - write-blocking or reversing (including multiple reversals)
+   * - write-blocking, reversing, or multiple reversals
      - source cluster
      -
 
@@ -30,7 +31,7 @@
          - backup
          - bypassWriteBlockMode privilege
 
-   * - write-blocking or reversing (including multiple reversals)
+   * - write-blocking, reversing, or multiple reversals
      - destination cluster
      -
 

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -48,6 +48,21 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
+   * - Multiple Reversals
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`dbAdminAnyDatabase`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`dbAdminAnyDatabase`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+
 For details on server roles, see: :ref:`authorization`.
 
 To update user permissions, see: :dbcommand:`grantRolesToUser`.

--- a/source/includes/verify-reversible-migrations.rst
+++ b/source/includes/verify-reversible-migrations.rst
@@ -1,0 +1,2 @@
+In version 1.10, ``mongosync`` enables the embedded verifier for
+forward and reverse directions of reversible migrations.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -159,10 +159,7 @@ Embedded Verifier
 ~~~~~~~~~~~~~~~~~
 
 The embedded verifier is enabled by default for replica set
-migrations. When you call the ``/reverse``
-endpoint, ``mongosync`` disables the verifier. The verifier
-remains disabled, even after additional calls to the
-``/reverse`` endpoint.
+migrations.
 
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -159,8 +159,7 @@ Embedded Verifier
 ~~~~~~~~~~~~~~~~~
 
 The embedded verifier is enabled by default for replica set
-migrations and performs verification checks for the forward
-direction of reversible sync. When you call the ``/reverse``
+migrations. When you call the ``/reverse``
 endpoint, ``mongosync`` disables the verifier. The verifier
 remains disabled, even after additional calls to the
 ``/reverse`` endpoint.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -167,11 +167,6 @@ Request Body Parameters
 
        * Reversible sync when ``buildIndexes`` is set to ``never``.
 
-       * Reversible sync with the embedded verifier. The
-         verifier supports the initial forward direction of
-         reversible sync. When you call the ``/reverse``
-         endpoint it disables the verifier.
-
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        
        Default value is ``false``.

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -18,3 +18,11 @@ Release Notes for mongosync 1.10
 
 This page describes changes and new features introduced in  
 {+c2c-full-product-name+} 1.10.
+
+1.10.0 Release
+--------------
+
+Upgrades to Embedded Verifier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ..include:: /includes/verify-reversible-migrations.rst

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -25,4 +25,4 @@ This page describes changes and new features introduced in
 Upgrades to Embedded Verifier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- ..include:: /includes/verify-reversible-migrations.rst
+- .. include:: /includes/verify-reversible-migrations.rst


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-45965

Remove limitations on verifier not being enabled for reverse direction of reversible migration. Also adds permissions info.

Staging:
- https://deploy-preview-549--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/#embedded-verifier
- https://deploy-preview-549--docs-cluster-to-cluster-sync.netlify.app/reference/verification/embedded/#limitations
- https://deploy-preview-549--docs-cluster-to-cluster-sync.netlify.app/reference/permissions/#self-managed-clusters
- https://deploy-preview-549--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.10/
- https://deploy-preview-549--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#request-body-parameters