### PR TITLE
DOCSP-46058-Clarify-docs-for-verification-behavior-during-commit-v1.9-backport (544)

### DIFF
--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -102,8 +102,9 @@ confirm that ``mongosync`` was successful in transferring
 documents from the source cluster to the destination.
 
 If the verifier encounters errors, it fails the migration with
-an error. If the verifier finds no errors, ``mongosync``
-transitions to the ``COMMITTED`` state.
+an error. If the verifier finds no errors, the ``/progress``
+endpoint returns ``canWrite: true``. To learn more about the ``canWrite`` field, 
+see :ref:`c2c-canWrite-committed`.
 
 Please `contact <https://mongodb.com/contact>`__ support to
 investigate verification issues.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46058: Clarify docs for verification behavior during commit (#544)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/544)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)