### PR TITLE
DOCSP-45862 User permissions older version

### DIFF
--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -174,5 +174,6 @@ Endpoint Protection
 Limitations
 ~~~~~~~~~~~
 
-The ``reverse`` endpoint does not support :ref:`filtered sync
-<c2c-filtered-sync>`.
+The ``reverse`` endpoint does not support:
+
+- :ref:`filtered sync <c2c-filtered-sync>`.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -177,3 +177,4 @@ Limitations
 The ``reverse`` endpoint does not support:
 
 - :ref:`filtered sync <c2c-filtered-sync>`.
+- migrations from :ref:`pre-6.0 source clusters <c2c-older-version-support>`.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -132,6 +132,9 @@ Request Body Parameters
        original source cluster blocks writes and the destination cluster
        accepts writes.
 
+       :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
+       you cannot set ``enableUserWriteBlocking`` to ``true``.
+
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
        to ``true``. To allow the source cluster to accept writes again,
        for example after running migration tests, run the following
@@ -193,6 +196,9 @@ Request Body Parameters
          verifier supports the initial forward direction of
          reversible sync. When you call the ``/reverse``
          endpoint it disables the verifier.
+
+       :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
+       you cannot set ``enableUserWriteBlocking`` to ``true``.
 
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -198,7 +198,7 @@ Request Body Parameters
          endpoint it disables the verifier.
 
        :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
-       you cannot set ``enableUserWriteBlocking`` to ``true``.
+       you cannot set ``reversible`` to ``true``.
 
        For more information, see the :ref:`reverse <c2c-api-reverse>` endpoint.
        

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -34,6 +34,6 @@ Pre-6.0 Migrations
 ------------------
 
 - When migrating from a 4.4 source cluster, you must have 
-  :authrole:`clusterManager` permissions.
+  :authrole:`clusterManager` permissions on the source cluster.
 
 - Write blocking and reverse sync are not supported.

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -28,6 +28,8 @@ The Atlas permissions are:
 
 .. include:: /includes/table-permissions-atlas.rst
 
+.. _c2c-older-version-permissions:
+
 Pre-6.0 Migrations 
 ------------------
 

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -28,3 +28,10 @@ The Atlas permissions are:
 
 .. include:: /includes/table-permissions-atlas.rst
 
+Pre-6.0 Migrations 
+------------------
+
+- When migrating from a 4.4 source cluster, you must have 
+  :authrole:`clusterManager` permissions.
+
+- Write blocking and reverse sync are not supported.

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -19,6 +19,8 @@ Release Notes for mongosync 1.10
 This page describes changes and new features introduced in  
 {+c2c-full-product-name+} 1.10.
 
+.. _c2c-older-version-support:
+
 Older Version Support
 ---------------------
 
@@ -32,6 +34,7 @@ destination MongoDB server versions:
 To learn more, see: 
 
 - :ref:`Pre-6.0 Migration Limitations <c2c-older-version-limitations>`.
+- :ref:`Pre-6.0 Migration Permissions <c2c-older-version-permissions>`.
 - :ref:`c2c-sync-different-versions`.
 
 Minimum Supported Version

--- a/source/reverse-sync.txt
+++ b/source/reverse-sync.txt
@@ -35,6 +35,10 @@ following parameters:
 For more information on limitations and requirements of reversing sync,
 see :ref:`c2c-api-reverse`. 
 
+.. important:: 
+
+   If you are migrating from a pre-6.0 source cluster, you cannot reverse sync.
+
 Steps
 -----
 


### PR DESCRIPTION
## DESCRIPTION 
- Adds Pre-6.0 Migration section to User Permissions Page
- Documents limitation for reversing & write blocking under respective pages/entries

## STAGING 
- [User Permissions](https://deploy-preview-552--docs-cluster-to-cluster-sync.netlify.app/reference/permissions/#pre-6.0-migrations)
- [Reverse limitation](https://deploy-preview-552--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/#limitations)
- [Write blocking limitation](https://deploy-preview-552--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#request:~:text=cluster%20accepts%20writes.-,IMPORTANT%3A%20If%20you%20are%20migrating%20from%20a%20pre%2D6.0%20source%20cluster%2C%20you%20cannot%20set%20enableUserWriteBlocking%20to%20true.,-To%20reverse%20sync)
- [Reversible limitation](https://deploy-preview-552--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#request:~:text=disables%20the%20verifier.-,IMPORTANT%3A%20If%20you%20are%20migrating%20from%20a%20pre%2D6.0%20source%20cluster%2C%20you%20cannot%20set%20enableUserWriteBlocking%20to%20true.,-For%20more%20information)

## JIRA
https://jira.mongodb.org/browse/DOCSP-45862