### PR TITLE
DOCSP-46461-remove-backup-as-required-role-v1.8-backport (551)

### DIFF
--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -14,7 +14,6 @@
      -
 
          - atlasAdmin
-         - backup
 
    * - default
      - destination cluster
@@ -27,7 +26,6 @@
      -
 
          - atlasAdmin
-         - backup
          - bypassWriteBlockMode privilege
 
    * - write-blocking or reversing
@@ -35,7 +33,6 @@
      -
 
          - atlasAdmin
-         - backup
          - bypassWriteBlockMode privilege
 
 For details on Atlas roles, see: :atlas:`Atlas User Roles


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-46461-remove-backup-as-required-role (#551)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/551)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)