### PR TITLE
DOCSP-46039-Clarify-verifier-limitation-about-TTLs-v1.9-backport (545)

### DIFF
--- a/source/includes/fact-verifier-unsupported.rst
+++ b/source/includes/fact-verifier-unsupported.rst
@@ -1,7 +1,8 @@
 The verifier doesn't check the following namespaces: 
 
 - Capped collections
-- Collections with TTL indexes
+- Collections with TTL indexes, including TTL indexes that are added or dropped
+  during migration
 - Collections that don't use the default collation
 - Views
 
@@ -13,4 +14,3 @@ The verifier doesn't check the following collection features:
 To verify the above data and metadata, script additional checks
 for these collections and collection features. For more
 information, see :ref:`c2c-verification`.
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46039: Clarify verifier limitation about TTLs (#545)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/545)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)