### PR TITLE
DOCSP-46396 removed backup

### DIFF
--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -28,8 +28,7 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
-     - - :authrole:`backup`
-       - :authrole:`clusterManager`
+     - - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`


### PR DESCRIPTION
## DESCRIPTION
removed the `backup` role from the self-managed clusters table (row: write-blocking, column: required destination permissions
## STAGING
https://deploy-preview-556--docs-cluster-to-cluster-sync.netlify.app/reference/permissions/
## JIRA
https://jira.mongodb.org/browse/DOCSP-46396