### PR TITLE
DOCSP-45863-embedded-verifier-migrations

### DIFF
--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -32,11 +32,6 @@ The embedded verifier has the following limitations:
 
 - .. include:: /includes/fact-verifier-buildIndexes
 
-.. note:: 
-
-   Starting in version 1.10, the verifier checks metadata and indexes 
-   for DDL events only when migrating from a pre-6.0 source cluster.
-
 Unsupported Verification Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -41,10 +41,11 @@ Unsupported Verification Checks
 
    Starting in version 1.10, the verifier checks for data inconsistencies from 
    a :ref:`DDL event <c2c-older-version-limitations>` that occurred on the 
-   pre-6.0 source cluster during migration.
+   pre-6.0 source cluster during migration. This is because pre-6.0 migrations 
+   do not support DDL events.
 
-   To learn more about pre-6.0 migrations and DDL events, see 
-   :ref:`Pre-6.0 Migration Limitations <c2c-older-version-limitations>`.
+   To learn more, see :ref:`Pre-6.0 Migration Limitations 
+   <c2c-older-version-limitations>`.
 
 Unsupported Beta Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -39,8 +39,12 @@ Unsupported Verification Checks
 
 .. note:: 
 
-   Starting in version 1.10, the verifier checks metadata and indexes 
-   for DDL events only when migrating from a pre-6.0 source cluster.
+   Starting in version 1.10, the verifier checks for data inconsistencies from 
+   a :ref:`DDL event <c2c-older-version-limitations>` that occurred on the 
+   pre-6.0 source cluster during migration.
+
+   To learn more about pre-6.0 migrations and DDL events, see 
+   :ref:`Pre-6.0 Migration Limitations <c2c-older-version-limitations>`.
 
 Unsupported Beta Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -32,10 +32,20 @@ The embedded verifier has the following limitations:
 
 - .. include:: /includes/fact-verifier-buildIndexes
 
+.. note:: 
+
+   Starting in version 1.10, the verifier checks metadata and indexes 
+   for DDL events only when migrating from a pre-6.0 source cluster.
+
 Unsupported Verification Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/fact-verifier-unsupported
+
+.. note:: 
+
+   Starting in version 1.10, the verifier checks metadata and indexes 
+   for DDL events only when migrating from a pre-6.0 source cluster.
 
 Unsupported Beta Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -22,10 +22,6 @@ Verify with Embedded Verifier
 of checks on the destination cluster to verify the sync of
 supported collections. 
 
-.. important::
-
-   .. include:: /includes/fact-verifier-unsupported
-
 .. versionadded:: 1.9
 
 About this Task
@@ -92,6 +88,16 @@ Steps
 
 Behavior
 --------
+
+Limitations 
+~~~~~~~~~~~
+
+.. include:: /includes/fact-verifier-unsupported
+
+.. note:: 
+
+   Starting in version 1.10, the verifier checks metadata and indexes 
+   for DDL events only when migrating from a pre-6.0 source cluster.
 
 Verification Checks
 ~~~~~~~~~~~~~~~~~~~

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -22,6 +22,17 @@ Verify with Embedded Verifier
 of checks on the destination cluster to verify the sync of
 supported collections. 
 
+.. note:: 
+
+   ``mongosync`` preserves document field order from the source cluster's 
+   primary node because it reads using :readmode:`primary` read preference. The 
+   embedded verifier checks documents in the destination cluster based on the 
+   source cluster’s primary node, so it cannot verify discrepancies between 
+   the different source cluster nodes. If an :term:`election` occurs, 
+   discrepancies in document field order between the source cluster’s nodes will 
+   cause the embedded verifier to fail the migration, even if ``mongosync`` 
+   copied the documents correctly.
+
 .. versionadded:: 1.9
 
 About this Task

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -27,11 +27,10 @@ supported collections.
    ``mongosync`` reads using :readmode:`primary` read preference, so it 
    preserves document field order from the source cluster's primary node. The 
    embedded verifier also checks documents based on the source cluster’s primary 
-   node. Because of this read preference, the verifier cannot verify 
-   discrepancies between the different source cluster nodes. In rare cases, 
-   discrepancies in document field order between the source cluster’s nodes will 
-   cause the embedded verifier to fail the migration, even if ``mongosync`` 
-   copied the documents correctly.
+   node, but at a different time from when ``mongosync`` reads them. Because of 
+   this, in rare cases, discrepancies in document field order between the source 
+   cluster’s nodes can cause the embedded verifier to fail the migration, even 
+   if ``mongosync`` copied the documents correctly.
 
 .. versionadded:: 1.9
 

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -24,14 +24,14 @@ supported collections.
 
 .. note:: 
 
-   ``mongosync`` preserves document field order from the source cluster's 
-   primary node because it reads using :readmode:`primary` read preference. The 
-   embedded verifier checks documents in the destination cluster based on the 
-   source cluster’s primary node, so it cannot verify discrepancies between 
-   the different source cluster nodes. If an :term:`election` occurs, 
-   discrepancies in document field order between the source cluster’s nodes will 
-   cause the embedded verifier to fail the migration, even if ``mongosync`` 
-   copied the documents correctly.
+   ``mongosync`` reads using :readmode:`primary` read preference, so it 
+   preserves document field order from the source cluster's primary node. The 
+   embedded verifier also checks documents based on the source cluster’s primary 
+   node. Because of this read preference, the verifier cannot verify 
+   discrepancies between the different source cluster nodes. If an 
+   :term:`election` occurs, discrepancies in document field order between the 
+   source cluster’s nodes will cause the embedded verifier to fail the 
+   migration, even if ``mongosync`` copied the documents correctly.
 
 .. versionadded:: 1.9
 

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -89,16 +89,6 @@ Steps
 Behavior
 --------
 
-Limitations 
-~~~~~~~~~~~
-
-.. include:: /includes/fact-verifier-unsupported
-
-.. note:: 
-
-   Starting in version 1.10, the verifier checks metadata and indexes 
-   for DDL events only when migrating from a pre-6.0 source cluster.
-
 Verification Checks
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -28,10 +28,10 @@ supported collections.
    preserves document field order from the source cluster's primary node. The 
    embedded verifier also checks documents based on the source cluster’s primary 
    node. Because of this read preference, the verifier cannot verify 
-   discrepancies between the different source cluster nodes. If an 
-   :term:`election` occurs, discrepancies in document field order between the 
-   source cluster’s nodes will cause the embedded verifier to fail the 
-   migration, even if ``mongosync`` copied the documents correctly.
+   discrepancies between the different source cluster nodes. In rare cases, 
+   discrepancies in document field order between the source cluster’s nodes will 
+   cause the embedded verifier to fail the migration, even if ``mongosync`` 
+   copied the documents correctly.
 
 .. versionadded:: 1.9
 


### PR DESCRIPTION
## DESCRIPTION
Adds a note that during pre-6.0 migrations, the verifier checks metadata and indexes _only_ for DDL events. 
- Opted to keep the previously documented limitations in their own section, remove the redundant note at the top of the page, and make the new functionality a note since it doesn't apply to all migrations.

## STAGING 
https://deploy-preview-557--docs-cluster-to-cluster-sync.netlify.app/reference/verification/embedded/#unsupported-verification-checks

## JIRA
https://jira.mongodb.org/browse/DOCSP-45863