### PR TITLE
DOCSP-43142-live-upgrade-unsupported-with-beta

### DIFF
--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -67,6 +67,10 @@ Live Upgrade
 
 .. versionadded:: 1.7.0
 
+.. note::
+
+   MongoDB does not support live upgrading from or to a beta binary. 
+
 .. include:: /includes/live-upgrade.rst
 
 After the live upgrade, ``mongosync`` continues operations that were in


### PR DESCRIPTION
## DESCRIPTION
Indicate on the mongosync Versioning page that MongoDB does not support live upgrading from or to a beta binary. 

## STAGING
https://deploy-preview-559--docs-cluster-to-cluster-sync.netlify.app/reference/versioning/#live-upgrade

## JIRA
https://jira.mongodb.org/browse/DOCSP-43142

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
