### PR TITLE
DOCSP-46767-update-mongosync-nongenuine-note-v1.9-backport (562)

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -51,5 +51,5 @@ targets = [
         ]
 variant = "warning"
 value = """\
-        MongoDB Command Line Database Tool binaries are not supported or tested for use with non-genuine MongoDB deployments. While the tools may work on these deployments, compatibility is not guaranteed.
+        MongoDB ``mongosync`` binaries are not supported or tested for use with non-genuine MongoDB deployments. While the tools may work on these deployments, compatibility is not guaranteed.
         """


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46767-update-mongosync-nongenuine-note (#562)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/562)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)