### PR TITLE
DOCSP-46814-finalize-cutover-typo

### DIFF
--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -53,9 +53,8 @@ Steps
         near ``0`` and the ``phase`` fields should show ``"stream
         hashing"``.
 
-        If the ``lagTimeSeconds`` fields are not near ``0`` or if the
-        verifier is not in the stream hashing phase, the cutover process
-        might take a long time.
+        If the verifier is not in the stream hashing phase, the cutover
+        process might take a long time.
 
       The following example returns the status of the
       synchronization process.

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -53,9 +53,9 @@ Steps
         near ``0`` and the ``phase`` fields should show ``"stream
         hashing"``.
 
-        If you call ``/commit`` and the ``lagTimeSeconds`` fields are
-        not near ``0`` or if the verifier is not in the stream hashing
-        phase, the cutover process might take a long time.
+        If the ``lagTimeSeconds`` fields are not near ``0`` or if the
+        verifier is not in the stream hashing phase, the cutover process
+        might take a long time.
 
       The following example returns the status of the
       synchronization process.

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -53,9 +53,9 @@ Steps
         near ``0`` and the ``phase`` fields should show ``"stream
         hashing"``.
 
-        If ``/commit`` is called and the values are not near
-        ``0`` or if the verifier is not in the stream hashing
-        phase, the cutover process might take a long a time.
+        If you call ``/commit`` and the ``lagTimeSeconds`` fields are
+        not near ``0`` or if the verifier is not in the stream hashing
+        phase, the cutover process might take a long time.
 
       The following example returns the status of the
       synchronization process.


### PR DESCRIPTION
## DESCRIPTION

fixes typo on finalize cutover page

## STAGING

https://deploy-preview-568--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/#verify-the-status-of-mongosync.

## JIRA

https://jira.mongodb.org/browse/DOCSP-46814

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
