### PR TITLE
DOCSP-46877 C2C 1.10 Release Tasks

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -12,8 +12,6 @@ About ``mongosync``
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 The :ref:`mongosync <c2c-mongosync>` binary is the primary process used in 
 {+c2c-product-name+}. ``mongosync`` migrates data from a source cluster to a 
 destination cluster and keeps the clusters in continuous sync until you 

--- a/source/connecting.txt
+++ b/source/connecting.txt
@@ -14,8 +14,6 @@ Connecting ``mongosync``
    :depth: 1
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 To configure a connection with :ref:`mongosync <c2c-mongosync>`, refer
 to the connection documentation that matches your environment:
 

--- a/source/connecting/atlas-to-atlas.txt
+++ b/source/connecting/atlas-to-atlas.txt
@@ -12,8 +12,6 @@ Connect Two Atlas Clusters
    :depth: 1
    :class: twocols
 
-.. include:: /includes/in-dev.rst
-
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect Atlas clusters using

--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -13,8 +13,6 @@ Connect a Self-Managed Cluster to Atlas
    :depth: 1
    :class: twocols
 
-.. include:: /includes/in-dev.rst
-
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect a self-managed cluster to an

--- a/source/connecting/onprem-to-onprem.txt
+++ b/source/connecting/onprem-to-onprem.txt
@@ -13,8 +13,6 @@ Connect Two Self-Managed Clusters
    :depth: 1
    :class: twocols
 
-.. include:: /includes/in-dev.rst
-
 .. include:: /includes/fact-connect-intro
 
 This page provides instructions to connect self-managed clusters using

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,8 +6,6 @@ Cluster-to-Cluster Sync
 
 .. default-domain:: mongodb
 
-.. include:: /includes/in-dev.rst
-
 {+c2c-product-name+} provides continuous data synchronization or a 
 one-time data migration between MongoDB clusters. For notes and caveats on 
 continuous sync, see the :ref:`mongosync-considerations` page. You can

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -11,8 +11,6 @@ Installation
    :depth: 1
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 These documents provide instructions to install {+c2c-full-product-name+}.
 
 :ref:`c2c-install-linux`

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -16,8 +16,6 @@
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 Overview
 --------
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -12,8 +12,6 @@
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 {+c2c-product-name+} uses `Semantic Versioning 2.0.0
 <https://semver.org/>`__. Version numbers have the form ``X.Y.Z``, where
 ``X`` is the major version, ``Y`` is the minor version, and ``Z`` is the

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -11,19 +11,15 @@ more information on types of MongoDB releases, see
 To see changes in {+c2c-product-name+} releases, see the following
 release notes.
 
-Upcoming Stable Release
-~~~~~~~~~~~~~~~~~~~~~~~
-
-- :ref:`c2c-release-notes-1.10`
-
 Current Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`c2c-release-notes-1.9`
+- :ref:`c2c-release-notes-1.10`
 
 Previous Releases
 ~~~~~~~~~~~~~~~~~
 
+- :ref:`c2c-release-notes-1.9`
 - :ref:`c2c-release-notes-1.8`
 - :ref:`c2c-release-notes-1.7`
 - :ref:`c2c-release-notes-1.6`

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -12,8 +12,6 @@ Release Notes for mongosync 1.10
    :depth: 2
    :class: singlecol
 
-.. include:: /includes/in-dev.rst
-
 This page describes changes and new features introduced in  
 {+c2c-full-product-name+} 1.10.
 


### PR DESCRIPTION
## DESCRIPTION 
- Removed `in development` banners from all applicable pages 
- Updated current stable release to 1.10

## STAGING 
- [1.10 release notes](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.10/#std-label-c2c-release-notes-1.10)
- [release notes (check current stable releases)](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/release-notes/#release-notes)
- [about mongosync](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/about-mongosync/)
- [connecting mongosync](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/connecting/)
- [installation](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/installation/)
- [quickstart](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/quickstart/)
- [versioning](https://deploy-preview-570--docs-cluster-to-cluster-sync.netlify.app/reference/versioning/)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-46877