### PR TITLE
DOCSP-46629-replSetResizeOplog-unsupported-Atlas-v1.9-backport (558)

### DIFF
--- a/source/reference/oplog-sizing.txt
+++ b/source/reference/oplog-sizing.txt
@@ -63,6 +63,12 @@ Monitor oplog Size Needed for Initial Sync
       - Increase the ``oplog`` window. Use :dbcommand:`replSetResizeOplog`
         to set ``minRetentionHours`` greater than the current ``oplog`` 
         window.
+
+        .. note:: 
+
+           :dbcommand:`replSetResizeOplog` is unsupported in Atlas. To resize 
+           the oplog in Atlas, see :ref:`set-oplog-min-window`.    
+
       - Scale up the ``mongosync`` instance. Add CPU or memory to scale
         up the ``mongosync`` node so that it has a higher copy rate.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46629-replSetResizeOplog-unsupported-Atlas (#558)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/558)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)