### PR TITLE
DOCSP-44803-pause-and-crash-behavior

### DIFF
--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -78,6 +78,9 @@ Behavior
   cluster. To learn more, see :ref:`Frequently Asked Questions
   <c2c-faq-increase-oplog>`. 
 
+For more information on the ``PAUSED`` state, see :ref:`Paused Sync
+Behavior <c2c-pause-behavior>`.
+
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -417,8 +417,8 @@ and use the same parameters as your interupted sync. Once you restart
 Paused Sync
 ~~~~~~~~~~~
 
-If ``mongosync`` is in the :ref:`c2c-state-paused` state, MongoDB does
-not support the following actions:
+If ``mongosync`` is in the :ref:`PAUSED <c2c-state-paused>` state,
+MongoDB does not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster
 - Enabling and then disabling the balancer

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -413,6 +413,8 @@ and use the same parameters as your interupted sync. Once you restart,
 ``mongosync``, ``mongosync`` resumes the operation from where it
 stopped.
 
+.. _c2c-pause-behavior:
+
 Paused Sync
 ~~~~~~~~~~~
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -404,7 +404,7 @@ Errors and Crashes
 ~~~~~~~~~~~~~~~~~~
 
 If ``mongosync`` encounters an error or becomes unavailable during
-synchronization, you can resume your ``mongosync`` operation from where
+synchronization, or you can resume your ``mongosync`` operation from where
 it stopped. The ``mongosync`` binary is stateless and stores the
 metadata for a restart on the destination cluster. 
 
@@ -412,13 +412,21 @@ To continue sync, restart ``mongosync`` once it becomes available again
 and use the same parameters as your interupted sync. Once you restart
 ``mongosync``, the process resumes from where it stopped.
 
+Cluster Availability
+~~~~~~~~~~~~~~~~~~~~
+
+If your source or destination cluster crashes unexpectedly, you can safely
+restart ``mongosync`` from where it left off. Once your cluster is available
+again, restart ``mongosync`` and use the same parameters as your interupted
+sync. 
+
 .. _c2c-pause-behavior:
 
 Paused Sync
 ~~~~~~~~~~~
 
 If ``mongosync`` is in the :ref:`PAUSED <c2c-state-paused>` state,
-MongoDB does not support the following actions:
+``mongosync`` does not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster
 - Enabling and then disabling the balancer

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -409,7 +409,7 @@ it stopped. The ``mongosync`` binary is stateless and stores the
 metadata for a restart on the destination cluster. 
 
 To continue sync, restart ``mongosync`` once it becomes available again
-and use the same parameters as your interupted sync. Once you restart,
+and use the same parameters as your interupted sync. Once you restart
 ``mongosync``, the process resumes from where it stopped.
 
 .. _c2c-pause-behavior:

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -394,6 +394,26 @@ Latency between the nodes of any replica set on the source or destination cluste
   sets. If the majority of these nodes aren't in the same region, there 
   will be negative performance implications.
 
+Interruptions During Sync
+-------------------------
+
+The following considerations pertain to interruptions during the
+``mongosync`` process. 
+
+System Crashes
+~~~~~~~~~~~~~~
+
+Paused Sync
+~~~~~~~~~~~
+
+If ``mongosync`` is in the :ref:`c2c-state-paused` state, MongoDB does
+not support the following actions:
+
+- Upgrading the MongoDB version of the source or destination cluster
+- Enabling and then disabling the balancer
+
+However, you can upgrade ``mongosync`` during while it is in the
+``PAUSED`` state. 
 
 Learn More
 ----------

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -417,7 +417,7 @@ and use the same parameters as your interupted sync. Once you restart,
 Paused Sync
 ~~~~~~~~~~~
 
-If ``mongosync`` is in the :ref<`c2c-state-paused> state, MongoDB does
+If ``mongosync`` is in the :ref<c2c-state-paused> state, MongoDB does
 not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -400,8 +400,18 @@ Interruptions During Sync
 The following considerations pertain to interruptions during the
 ``mongosync`` process. 
 
-System Crashes
-~~~~~~~~~~~~~~
+Errors and Crashes
+~~~~~~~~~~~~~~~~~~
+
+If ``mongosync`` encounters an error or becomes unavailable during
+synchronization, you can resume your ``mongosync`` operation. The
+``mongosync`` binary is stateless and stores the metadata for a restart
+on the destination cluster. 
+
+To continue sync, restart ``mongosync`` once it becomes available again
+and use the same parameters as your interupted sync. Once you restart,
+``mongosync``, ``mongosync`` resumes the operation from where it
+stopped.
 
 Paused Sync
 ~~~~~~~~~~~
@@ -412,7 +422,7 @@ not support the following actions:
 - Upgrading the MongoDB version of the source or destination cluster
 - Enabling and then disabling the balancer
 
-However, you can upgrade ``mongosync`` during while it is in the
+You can upgrade ``mongosync`` while it is in the
 ``PAUSED`` state. 
 
 Learn More

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -404,28 +404,26 @@ Errors and Crashes
 ~~~~~~~~~~~~~~~~~~
 
 If ``mongosync`` encounters an error or becomes unavailable during
-synchronization, you can resume your ``mongosync`` operation. The
-``mongosync`` binary is stateless and stores the metadata for a restart
-on the destination cluster. 
+synchronization, you can resume your ``mongosync`` operation from where
+it stopped. The ``mongosync`` binary is stateless and stores the
+metadata for a restart on the destination cluster. 
 
 To continue sync, restart ``mongosync`` once it becomes available again
 and use the same parameters as your interupted sync. Once you restart,
-``mongosync``, ``mongosync`` resumes the operation from where it
-stopped.
+``mongosync``, the process resumes from where it stopped.
 
 .. _c2c-pause-behavior:
 
 Paused Sync
 ~~~~~~~~~~~
 
-If ``mongosync`` is in the :ref:`c2c-state-paused` state, MongoDB does
+If ``mongosync`` is in the :ref<`c2c-state-paused> state, MongoDB does
 not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster
 - Enabling and then disabling the balancer
 
-You can upgrade ``mongosync`` while it is in the
-``PAUSED`` state. 
+You can upgrade ``mongosync`` while it is in the ``PAUSED`` state. 
 
 Learn More
 ----------

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -417,7 +417,7 @@ and use the same parameters as your interupted sync. Once you restart
 Paused Sync
 ~~~~~~~~~~~
 
-If ``mongosync`` is in the :ref<c2c-state-paused> state, MongoDB does
+If ``mongosync`` is in the :ref`c2c-state-paused` state, MongoDB does
 not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -417,7 +417,7 @@ and use the same parameters as your interupted sync. Once you restart
 Paused Sync
 ~~~~~~~~~~~
 
-If ``mongosync`` is in the :ref`c2c-state-paused` state, MongoDB does
+If ``mongosync`` is in the :ref:`c2c-state-paused` state, MongoDB does
 not support the following actions:
 
 - Upgrading the MongoDB version of the source or destination cluster


### PR DESCRIPTION
## DESCRIPTION

Adds information on when mongosync behavior during crashes or pauses

## STAGING

https://deploy-preview-577--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#interruptions-during-sync
https://deploy-preview-577--docs-cluster-to-cluster-sync.netlify.app/reference/api/pause/#behavior

## JIRA

https://jira.mongodb.org/browse/DOCSP-44803

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
