### PR TITLE
DOCSP-46973-adds-large-destination-index-FAQ

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -51,8 +51,8 @@ Why are the destination cluster indexes larger than the source cluster indexes?
 The following factors may contribute to an increase in index size on destination
 clusters:
 
-- ``mongosync`` inserts and removes data during a migration, which may cause disk 
-  fragmentation.
+- ``mongosync`` inserts and removes data during a migration, which can cause data 
+  to be stored inefficiently on disk.
 - By default, ``mongosync`` builds indexes before copying data. ``mongosync`` 
   copies data in ``_id`` order. If an index is not correlated with  ``_id``, 
   the index size can become large. For more information, see the MongoDB Manual
@@ -63,9 +63,11 @@ Use the following methods to mitigate an increase in index size:
 - Restart the migration with the ``buildIndexes`` 
   :ref:`parameter <c2c-api-start-params>` set to ``never``. When the migration 
   finishes, manually build indexes on the destination cluster.
-- After the migration, perform a rolling sync on the destination cluster.
+- After the migration, perform a rolling :ref:`initial sync <replica-set-sync>` 
+  on the destination cluster.
 - After the migration, run :ref:`<compact>` on the destination cluster. This 
-  rebuilds indexes and releases unneeded disk space to the OS.
+  rebuilds indexes and releases unneeded disk space to the OS, but may impact
+  cluster :ref:`performance <compact-perf>`.
 
 Can ``mongosync`` run on its own hardware? 
 ------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -62,7 +62,7 @@ Use the following methods to mitigate an increase in index size:
 
 - Restart the migration with the ``buildIndexes`` 
   :ref:`parameter <c2c-api-start-params>` set to ``never``. When the migration 
-  is complete, manually build indexes on the destination cluster.
+  finishes, manually build indexes on the destination cluster.
 - After the migration, perform a rolling sync on the destination cluster.
 - After the migration, run :ref:`<compact>` on the destination cluster. This 
   rebuilds indexes and releases unneeded disk space to the OS.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -48,8 +48,8 @@ To learn more about permissable reads and writes during synchronization, see :re
 Why are the destination cluster indexes larger than the source cluster indexes?
 -------------------------------------------------------------------------------
 
-An increase in index size on destination clusters may be caused by the following 
-factors:
+The following factors may contribute to an increase in index size on destination
+clusters:
 
 - ``mongosync`` inserts and removes data during a migration, which may cause disk 
   fragmentation.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -54,7 +54,7 @@ clusters:
 - ``mongosync`` inserts and removes data during a migration, which may cause disk 
   fragmentation.
 - By default, ``mongosync`` builds indexes before copying data. ``mongosync`` 
-  copies data in ``_id`` order. If the index is not correlated with  ``_id``, 
+  copies data in ``_id`` order. If an index is not correlated with  ``_id``, 
   the index size can become large. For more information, see the MongoDB Manual
   :ref:`FAQ: Indexes<faq-indexes-random-data-performance>` page.
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -64,7 +64,7 @@ Use the following methods to mitigate an increase in index size:
   :ref:`parameter <c2c-api-start-params>` set to ``never``. When the migration 
   is complete, manually build indexes on the destination cluster.
 - After the migration, perform a rolling sync on the destination cluster.
-- After the migration, run :command:`compact` on the destination cluster. This 
+- After the migration, run :ref:`<compact>` on the destination cluster. This 
   rebuilds indexes and releases unneeded disk space to the OS.
 
 Can ``mongosync`` run on its own hardware? 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -45,6 +45,28 @@ To learn more about permissable reads and writes during synchronization, see :re
    Index builds on the destination cluster are treated as writes 
    while ``mongosync`` is syncing.
 
+Why are the destination cluster indexes larger than the source cluster indexes?
+-------------------------------------------------------------------------------
+
+An increase in index size on destination clusters may be caused by the following 
+factors:
+
+- ``mongosync`` inserts and removes data during a migration, which may cause disk 
+  fragmentation.
+- By default, ``mongosync`` builds indexes before copying data. ``mongosync`` 
+  copies data in ``_id`` order. If the indexed field is not ``_id``, 
+  the index size can become large. For more information, see the MongoDB Manual
+  :ref:`FAQ: Indexes<faq-indexes-random-data-performance>` page.
+
+Use the following methods to mitigate an increase in index size:
+
+- Restart the migration with the ``buildIndexes`` 
+  :ref:`parameter <c2c-api-start-params>` set to ``never``. When the migration 
+  is complete, manually build indexes on the destination cluster.
+- After the migration, perform a rolling sync on the destination cluster.
+- After the migration, run :ref:`<compact>` on the destination cluster. This 
+  rebuilds indexes and releases unneeded disk space to the OS.
+
 Can ``mongosync`` run on its own hardware? 
 ------------------------------------------
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -54,7 +54,7 @@ clusters:
 - ``mongosync`` inserts and removes data during a migration, which may cause disk 
   fragmentation.
 - By default, ``mongosync`` builds indexes before copying data. ``mongosync`` 
-  copies data in ``_id`` order. If the indexed field is not ``_id``, 
+  copies data in ``_id`` order. If the index is not correlated with  ``_id``, 
   the index size can become large. For more information, see the MongoDB Manual
   :ref:`FAQ: Indexes<faq-indexes-random-data-performance>` page.
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -64,7 +64,7 @@ Use the following methods to mitigate an increase in index size:
   :ref:`parameter <c2c-api-start-params>` set to ``never``. When the migration 
   is complete, manually build indexes on the destination cluster.
 - After the migration, perform a rolling sync on the destination cluster.
-- After the migration, run :ref:`<compact>` on the destination cluster. This 
+- After the migration, run :command:`compact` on the destination cluster. This 
   rebuilds indexes and releases unneeded disk space to the OS.
 
 Can ``mongosync`` run on its own hardware? 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -57,6 +57,8 @@ Request
 
    POST /api/v1/start 
 
+.. _c2c-api-start-params:
+
 Request Body Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## DESCRIPTION
Adds an FAQ entry explaining why destination indexes may be larger than source indexes, and how to mitigate.

## STAGING
[FAQ: Why are the destination cluster indexes larger than the source cluster indexes?](https://deploy-preview-579--docs-cluster-to-cluster-sync.netlify.app/faq/#why-are-the-destination-cluster-indexes-larger-than-the-source-cluster-indexes-)

## JIRA
https://jira.mongodb.org/browse/DOCSP-46973