### PR TITLE
DOCSP-46893: Destination-only Write-blocking

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -33,7 +33,8 @@ As a result, the destination is not guaranteed to match the source at any point 
 For consistent reads, wait for the migration to :ref:`c2c-api-commit`. To learn more, see :ref:`mongosync-considerations`. 
 
 Performing writes to your destination cluster during synchronization results in undefined behavior. 
-To block writes on the destination cluster during sync, enable :ref:`write blocking <c2c-write-blocking>` when you :ref:`c2c-api-start` ``mongosync``.
+``mongosync`` blocks writes on the destination cluster by default. To learn
+more about write-blocking, see :ref:`c2c-write-blocking` and :ref:`c2c-api-start`.
 
 Upon commit, it is only safe to write to the destination cluster when ``canWrite`` is ``true``. 
 To check the value of ``canWrite``, run the :ref:`c2c-api-progress` endpoint.

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -29,8 +29,8 @@
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request, so ``mongosync`` enables destination-only write-blocking by default. 
-  Ensure that no writes are made to the destination cluster during the migration.
+  request, so dual write-blocking is not supported. Destination-only 
+  write-blocking is supported.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>`. Instead, create an index to support your shard key 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -28,9 +28,10 @@
 - :ref:`/reverse <c2c-api-reverse>` endpoint is not supported. You can't 
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
-- You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request, so dual write-blocking is not supported. Destination-only 
-  write-blocking is supported.
+- You can't set the ``enableUserWriteBlocking`` option to ``true``
+  in the ``/start`` request, so dual write-blocking is not supported. 
+  Destination-only write-blocking is supported. Ensure that no writes are 
+  made to the source cluster after you call the ``/commit`` endpoint.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>`. Instead, create an index to support your shard key 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -29,8 +29,8 @@
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request, so destination-only write-blocking is enabled. Ensure that no writes 
-  are made to the source cluster during the migration.
+  request, so destination-only write-blocking is enabled by default. 
+  Ensure that no writes are made to the destination cluster during the migration.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>`. Instead, create an index to support your shard key 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -29,7 +29,7 @@
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request, so destination-only write-blocking is enabled by default. 
+  request, so ``mongosync`` enables destination-only write-blocking by default. 
   Ensure that no writes are made to the destination cluster during the migration.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -29,8 +29,8 @@
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
 - You can't enable the ``enableUserWriteBlocking`` option in the ``/start`` 
-  request. Ensure that no writes are made to the source or destination cluster 
-  during the migration.
+  request, so destination-only write-blocking is enabled. Ensure that no writes 
+  are made to the source cluster during the migration.
 
 - You can't enable the ``createSupportingIndexes`` :ref:`sharding parameter 
   <c2c-api-start-sharding>`. Instead, create an index to support your shard key 

--- a/source/includes/fact-permissions-body.rst
+++ b/source/includes/fact-permissions-body.rst
@@ -1,5 +1,5 @@
 The user specified in the ``mongosync`` connection string must have the
 required permissions on the source and destination clusters. The
-permissions vary depending on your environment and if you want to run a
-dual write-blocking or reverse sync.
+permissions vary depending on your environment and if you want to 
+modify write-blocking settings or use reverse sync.
 

--- a/source/includes/fact-permissions-body.rst
+++ b/source/includes/fact-permissions-body.rst
@@ -1,5 +1,5 @@
 The user specified in the ``mongosync`` connection string must have the
 required permissions on the source and destination clusters. The
 permissions vary depending on your environment and if you want to run a
-write-blocking or reverse sync.
+dual write-blocking or reverse sync.
 

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,6 +1,11 @@
 By default, ``mongosync`` enables destination-only 
 write-blocking on the destination cluster. 
-``mongosync`` unblocks writes right before ``canWrite`` is set to ``true``.
+``mongosync`` unblocks writes right before the 
+:ref:`/progress <c2c-api-progress>` endpoint reports 
+that ``canWrite`` is ``true``. You can explicitly
+enable destination-only write-blocking by using
+the :ref:`/start <c2c-api-start>` endpoint to set
+``enableUserWriteBlocking`` to ``"destinationOnly"``.
 
 You can enable dual write-blocking, which blocks
 writes on both the source and destination clusters. 
@@ -10,11 +15,11 @@ If you enable dual write-blocking, ``mongosync`` blocks writes:
   unblocks writes right before it sets ``canWrite`` to ``true``
 - On the source cluster after you call ``/commit``
 
-To enable dual write-blocking, use the :ref:`start API <c2c-api-start>`
+To enable dual write-blocking, use :ref:`/start <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``.
 
 You can use
-the :ref:`start API <c2c-api-start>`
+:ref:`/start <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``false``.
 
 You cannot enable dual write-blocking or disable

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,9 +1,21 @@
-``mongosync`` does not enable write-blocking by default. If you enable
-write-blocking, ``mongosync`` blocks writes:
+By default, ``mongosync`` enables destination-only 
+write-blocking on the destination cluster. 
+It unblocks writes right before ``canWrite`` is set to ``true``.
 
-- On the destination cluster during sync.
-- On the source cluster when ``commit`` is received.
+You can enable dual write-blocking, which blocks
+writes on both the source and destination clusters. 
+If you enable dual write-blocking, ``mongosync`` blocks writes:
 
-To enable write-blocking, use the :ref:`start API <c2c-api-start>`
-to set ``enableUserWriteBlocking`` to ``true``. You cannot enable
+- On the destination cluster during the migration and 
+  unblocks them right before ``canWrite`` is set to ``true``
+- On the source cluster after ``/commit`` is called
+
+To enable dual write-blocking, use the :ref:`start API <c2c-api-start>`
+to set ``enableUserWriteBlocking`` to ``true``.
+
+You can also disable write-blocking by using
+the :ref:`start API <c2c-api-start>`
+to set ``enableUserWriteBlocking`` to ``false``.
+
+You cannot enable dual write-blocking or disable
 write-blocking after the sync starts.

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -7,8 +7,7 @@ enable destination-only write-blocking by using
 the :ref:`/start <c2c-api-start>` endpoint to set
 ``enableUserWriteBlocking`` to ``"destinationOnly"``.
 
-You can enable dual write-blocking, which blocks
-writes on both the source and destination clusters. 
+You can enable dual write-blocking. 
 If you enable dual write-blocking, ``mongosync`` blocks writes:
 
 - On the destination cluster during the migration. ``mongosync``

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -1,19 +1,19 @@
 By default, ``mongosync`` enables destination-only 
 write-blocking on the destination cluster. 
-It unblocks writes right before ``canWrite`` is set to ``true``.
+``mongosync`` unblocks writes right before ``canWrite`` is set to ``true``.
 
 You can enable dual write-blocking, which blocks
 writes on both the source and destination clusters. 
 If you enable dual write-blocking, ``mongosync`` blocks writes:
 
-- On the destination cluster during the migration and 
-  unblocks them right before ``canWrite`` is set to ``true``
-- On the source cluster after ``/commit`` is called
+- On the destination cluster during the migration. ``mongosync``
+  unblocks writes right before it sets ``canWrite`` to ``true``
+- On the source cluster after you call ``/commit``
 
 To enable dual write-blocking, use the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``true``.
 
-You can also disable write-blocking by using
+You can use
 the :ref:`start API <c2c-api-start>`
 to set ``enableUserWriteBlocking`` to ``false``.
 

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -19,4 +19,7 @@
   You cannot limit the filter to collections within the database.
 
   For more information, see :ref:`c2c-filter-with-out`.
+- Filtering does not support dual :ref:`write 
+  blocking <c2c-write-blocking>`. It supports destination-only
+  write-blocking. 
 

--- a/source/includes/limitations-filtering.rst
+++ b/source/includes/limitations-filtering.rst
@@ -20,6 +20,6 @@
 
   For more information, see :ref:`c2c-filter-with-out`.
 - Filtering does not support dual :ref:`write 
-  blocking <c2c-write-blocking>`. It supports destination-only
+  blocking <c2c-write-blocking>`. You can use destination-only
   write-blocking. 
 

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -2,3 +2,7 @@ Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
 restarting data synchronization operations from the beginning. You can 
 only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync`` 
 1.7.2 or later.
+
+.. important::
+   
+   ``mongosync`` does not support live upgrades to version 1.11.

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -2,13 +2,32 @@
    :header-rows: 1
    :stub-columns: 1
 
-   * - Version
-     - 1.11
-     - 1.7.2 and later
-     - 1.7.0 
+   * - 
+     - 1.11 Destination
+     - 1.7.3 to 1.10 Destination
+     - 1.7.2 Destination
+     - 1.7.0 to 1.7.1 Destination
 
-   * - Notes
-     - Live upgrades to 1.11 not supported
-     - Can only live upgrade to ``mongosync``
-       1.7.3 or later
-     - Upgrade to any version except 1.11
+   * - 1.11 Source
+     -
+     -
+     -
+     -
+
+   * - 1.7.3 to 1.10 Source
+     - 
+     - √
+     -
+     -
+ 
+   * - 1.7.2 Source
+     - 
+     - √
+     - 
+     - 
+  
+   * - 1.7.0 to 1.7.1 Source
+     -
+     - √
+     - √
+     -

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -1,33 +1,4 @@
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-
-   * - 
-     - 1.11 Destination
-     - 1.7.3 to 1.10 Destination
-     - 1.7.2 Destination
-     - 1.7.0 to 1.7.1 Destination
-
-   * - 1.11 Source
-     -
-     -
-     -
-     -
-
-   * - 1.7.3 to 1.10 Source
-     - 
-     - √
-     -
-     -
- 
-   * - 1.7.2 Source
-     - 
-     - √
-     - 
-     - 
-  
-   * - 1.7.0 to 1.7.1 Source
-     -
-     - √
-     - √
-     -
+Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
+restarting data synchronization operations from the beginning. You can 
+only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync`` 
+1.7.2 or later.

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -1,4 +1,4 @@
-.. list-table
+.. list-table::
    :header-rows: 1
    :stub-columns: 1
 

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -1,4 +1,4 @@
 Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
 restarting data synchronization operations from the beginning. You can 
 only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync`` 
-1.7.2 or later.
+1.7.2 or later. You cannot live upgrade to ``mongosync`` 1.11.

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -1,4 +1,14 @@
-Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
-restarting data synchronization operations from the beginning. You can 
-only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync`` 
-1.7.2 or later. You cannot live upgrade to ``mongosync`` 1.11.
+.. list-table
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Version
+     - 1.11
+     - 1.7.2 and later
+     - 1.7.0 
+
+   * - Notes
+     - Live upgrades to 1.11 not supported
+     - Can only live upgrade to ``mongosync``
+       1.7.3 or later
+     - Upgrade to any version except 1.11

--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -13,8 +13,9 @@
    * - default
      - - atlasAdmin
      - - atlasAdmin
-
-   * - write-blocking, reversing, or multiple reversals
+       - bypassWriteBlockMode privilege
+       
+   * - dual write-blocking, reversing, or multiple reversals
      - - atlasAdmin
        - bypassWriteBlockMode privilege
      - - atlasAdmin

--- a/source/includes/table-permissions-self-hosted.rst
+++ b/source/includes/table-permissions-self-hosted.rst
@@ -21,7 +21,7 @@
        - :authrole:`readWriteAnyDatabase`
        - :authrole:`restore`
 
-   * - Write-blocking
+   * - Dual Write-Blocking
      - - :authrole:`backup`
        - :authrole:`clusterManager`
        - :authrole:`clusterMonitor`

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -168,13 +168,15 @@ characteristics that ``mongosync`` alters during the synchronization process.
        replicated as non-hidden on the destination cluster.
 
    * - Write Blocking
-     - If you enable write-blocking, ``mongosync`` blocks writes: 
-       
+     - If you enable dual write-blocking, ``mongosync`` blocks writes: 
+
        - On the destination cluster during sync.
        - On the source cluster when ``commit`` is received.
 
-       See also:
-       :ref:`c2c-write-blocking`
+       ``mongosync`` enables destination-only write-blocking
+       by default.
+       
+       To learn more, see :ref:`c2c-write-blocking`.
   
    * - Capped Collections
      - ``commit`` resets the required maximum size of capped collections

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -49,7 +49,8 @@ To use the ``reverse`` endpoint:
 
 .. note::
 
-   :ref:`c2c-write-blocking` is a prerequisite for running ``reverse``.
+   :ref:`Dual write-blocking <c2c-write-blocking>` is a 
+   prerequisite for running ``reverse``.
 
 You cannot update these options after the sync starts. 
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -113,19 +113,25 @@ Request Body Parameters
        .. versionadded:: 1.3.0
 
    * - ``enableUserWriteBlocking``
-     - boolean
+     - boolean or string
      - Optional
-     - If set to ``true``, blocks writes on the destination cluster
-       while the synchronization is in progress. After the
-       synchronization is committed to the destination cluster, the
-       original source cluster blocks writes and the destination cluster
-       accepts writes.
+     - If set to ``true`` or ``"true"``, blocks writes on the destination 
+       cluster while the migration is in progress, and unblocks writes right
+       before ``canWrite`` is ``true``. Blocks writes on the source
+       cluster after ``mongosync`` calls the :ref:`/commit <c2c-api-commit>`
+       endpoint.
+
+       If set to ``false`` or ``"false"``, no write blocking occurs.
+
+       If set to ``"destinationOnly"``, blocks writes on the destination
+       cluster while migration is in progress, and unblocks writes right
+       before ``canWrite`` is ``true``.
 
        :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
        you cannot set ``enableUserWriteBlocking`` to ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true``. To allow the source cluster to accept writes again,
+       to ``true`` or ``"true"``. To allow the source cluster to accept writes again,
        for example after running migration tests, run the following
        command: 
 
@@ -133,7 +139,7 @@ Request Body Parameters
           
           db.adminCommand( { setUserWriteBlockMode: 1, global: false } )
 
-       Default value is ``false``.
+       Default value is ``"destinationOnly"``.
 
    * - ``includeNamespaces``
      - array
@@ -160,7 +166,7 @@ Request Body Parameters
        reversed.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true``.
+       to ``true`` or ``"true"``.
 
        This option is not supported for the following configurations:
 
@@ -170,10 +176,7 @@ Request Body Parameters
 
        * Reversible sync when ``buildIndexes`` is set to ``never``.
 
-       * Reversible sync with the embedded verifier. The
-         verifier supports the initial forward direction of
-         reversible sync. When you call the ``/reverse``
-         endpoint it disables the verifier.
+       * Reversible sync with the embedded verifier.
 
        :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
        you cannot set ``reversible`` to ``true``.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -115,13 +115,14 @@ Request Body Parameters
    * - ``enableUserWriteBlocking``
      - boolean or string
      - Optional
-     - If set to ``true`` or ``"true"``, blocks writes on the destination 
+     - If set to ``true``, blocks writes on the destination 
        cluster while the migration is in progress, and unblocks writes right
-       before ``canWrite`` is ``true``. Blocks writes on the source
+       before the :ref:`/progress <c2c-api-progress>` endpoint reports 
+       that ``canWrite`` is ``true``.  Blocks writes on the source
        cluster after ``mongosync`` calls the :ref:`/commit <c2c-api-commit>`
        endpoint.
 
-       If set to ``false`` or ``"false"``, no write blocking occurs.
+       If set to ``false``, no write blocking occurs.
 
        If set to ``"destinationOnly"``, blocks writes on the destination
        cluster while migration is in progress, and unblocks writes right
@@ -131,7 +132,7 @@ Request Body Parameters
        you cannot set ``enableUserWriteBlocking`` to ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true`` or ``"true"``. To allow the source cluster to accept writes again,
+       to ``true``. To allow the source cluster to accept writes again,
        for example after running migration tests, run the following
        command: 
 
@@ -166,7 +167,7 @@ Request Body Parameters
        reversed.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true`` or ``"true"``.
+       to ``true``.
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -176,8 +176,6 @@ Request Body Parameters
 
        * Reversible sync when ``buildIndexes`` is set to ``never``.
 
-       * Reversible sync with the embedded verifier.
-
        :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
        you cannot set ``reversible`` to ``true``.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -78,7 +78,7 @@ Steps
       - If you start ``mongosync`` with ``enableUserWriteBlocking``
         set to ``true``, ``mongosync`` blocks all write operations
         on the destination cluster and unblocks them right before ``canWrite``
-        is set to ``true``. It blocks writes on the source after it calls
+        is set to ``true``. ``mongosync`` blocks writes on the source after it calls
         ``/commit``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
         to ``"destinationOnly"``, ``mongosync`` only blocks writes on the 
@@ -126,8 +126,9 @@ Steps
          to ensure that the ``mongosync`` state is ``COMMITTING`` or
          ``COMMITTED``.
 
-      Once you complete this step, if you previously set ``enableUserWriteBlocking``
-      to ``true`` then ``mongosync`` blocks writes on the source cluster.
+      If you previously set ``enableUserWriteBlocking``
+      to ``true``, ``mongosync`` blocks writes on the source cluster
+      once you complete this step.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -75,15 +75,17 @@ Steps
 
    .. step:: Stop any write operations to the synced collections on the source.
 
+      - ``mongosync`` enables destination-only write-blocking by default. 
+        You can explicitly enable it by starting ``mongosync`` with
+        ``enableUserWriteBlocking`` set to ``"destinationOnly"``.
+        ``mongosync`` only blocks writes on the 
+        destination and unblocks them right before ``canWrite`` is
+        set to ``true``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking``
         set to ``true``, ``mongosync`` blocks all write operations
         on the destination cluster and unblocks them right before ``canWrite``
         is set to ``true``. ``mongosync`` blocks writes on the source after you call
         ``/commit``.
-      - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
-        to ``"destinationOnly"``, ``mongosync`` only blocks writes on the 
-        destination and unblocks them right before ``canWrite`` is
-        set to ``true``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
         to ``false``, ensure that you disable writes.
         For example, run the :dbcommand:`setUserWriteBlockMode` command on the

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -76,10 +76,16 @@ Steps
    .. step:: Stop any write operations to the synced collections on the source.
 
       - If you start ``mongosync`` with ``enableUserWriteBlocking``
-        set to ``true``, ``mongosync`` blocks all write operations on
-        the entire source cluster during the commit (step 4) for you.
-      - If you didn't start ``mongosync`` with
-        ``enableUserWriteBlocking``, ensure that you disable writes.
+        set to ``true``, ``mongosync`` blocks all write operations
+        on the destination cluster and unblocks them right before ``canWrite``
+        is set to ``true``. It blocks writes on the source after it calls
+        ``/commit``.
+      - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
+        to ``"destinationOnly"``, ``mongosync`` only blocks writes on the 
+        destination and unblocks them right before ``canWrite`` is
+        set to ``true``.
+      - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
+        to ``false``, ensure that you disable writes.
         For example, run the :dbcommand:`setUserWriteBlockMode` command on the
         source cluster:
 
@@ -120,7 +126,8 @@ Steps
          to ensure that the ``mongosync`` state is ``COMMITTING`` or
          ``COMMITTED``.
 
-      Once you complete this step, ``mongosync`` blocks writes on the source cluster.
+      Once you complete this step, if you previously set ``enableUserWriteBlocking``
+      to ``true`` then ``mongosync`` blocks writes on the source cluster.
 
    .. step:: Wait until you can perform writes on the destination cluster.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -78,7 +78,7 @@ Steps
       - If you start ``mongosync`` with ``enableUserWriteBlocking``
         set to ``true``, ``mongosync`` blocks all write operations
         on the destination cluster and unblocks them right before ``canWrite``
-        is set to ``true``. ``mongosync`` blocks writes on the source after it calls
+        is set to ``true``. ``mongosync`` blocks writes on the source after you call
         ``/commit``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
         to ``"destinationOnly"``, ``mongosync`` only blocks writes on the 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -163,7 +163,7 @@ Write Blocking
 
 .. include:: /includes/fact-write-blocking-enable.rst
 
-You must enable write-blocking when you start ``mongosync`` if you want
+You must enable dual write-blocking when you start ``mongosync`` if you want
 to use :ref:`reverse synchronization <c2c-api-reverse>` later.
 
 User Permissions
@@ -256,11 +256,14 @@ synchronization. The original values are restored during the commit process.
      - Synchronization replicates hidden indexes as non-hidden.
 
    * - Write Blocking
-     - If you enable write-blocking, ``mongosync`` blocks writes: 
+     - If you enable dual write-blocking, ``mongosync`` blocks writes: 
 
        - On the destination cluster during sync.
        - On the source cluster when ``commit`` is received.
-      
+
+       ``mongosync`` enables destination-only write-blocking
+       by default.
+       
        To learn more, see :ref:`c2c-write-blocking`.
 
    * - Capped Collections

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -163,8 +163,8 @@ Write Blocking
 
 .. include:: /includes/fact-write-blocking-enable.rst
 
-You must enable dual write-blocking when you start ``mongosync`` if you want
-to use :ref:`reverse synchronization <c2c-api-reverse>` later.
+If you want to use :ref:`reverse synchronization <c2c-api-reverse>` later,
+you must enable dual write-blocking when you start ``mongosync``.
 
 User Permissions
 ''''''''''''''''
@@ -263,7 +263,7 @@ synchronization. The original values are restored during the commit process.
 
        ``mongosync`` enables destination-only write-blocking
        by default.
-       
+
        To learn more, see :ref:`c2c-write-blocking`.
 
    * - Capped Collections

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -36,4 +36,4 @@ Pre-6.0 Migrations
 - When migrating from a 4.4 source cluster, you must have 
   :authrole:`clusterManager` permissions on the source cluster.
 
-- Write blocking and reverse sync are not supported.
+- Dual write-blocking and reverse sync are not supported.

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -21,6 +21,8 @@ The self-managed permissions are:
 
 .. include:: /includes/table-permissions-self-hosted.rst
 
+.. _c2c-atlas-permissions:
+
 Atlas Clusters
 --------------
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -70,7 +70,7 @@ restarting data synchronization operations from the beginning.
 
 .. important::
 
-   ``mongosync`` does not support upgrades to version 1.11.
+   ``mongosync`` does not support live upgrades to version 1.11.
 
 After the live upgrade, ``mongosync`` continues operations that were in
 progress before the upgrade.

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -68,8 +68,7 @@ Live Upgrade
 Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
 restarting data synchronization operations from the beginning.
 
-For more information on what versions you can live upgrade to or from,
-see the following table:
+``mongosync`` supports live upgrades between the following versions:
 
 .. include:: /includes/live-upgrade.rst
 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -68,9 +68,9 @@ Live Upgrade
 Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
 restarting data synchronization operations from the beginning.
 
-``mongosync`` supports live upgrades between the following versions:
+.. important::
 
-.. include:: /includes/live-upgrade.rst
+   ``mongosync`` does not support upgrades to version 1.11.
 
 After the live upgrade, ``mongosync`` continues operations that were in
 progress before the upgrade.

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -65,6 +65,12 @@ Live Upgrade
 
 .. versionadded:: 1.7.0
 
+Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
+restarting data synchronization operations from the beginning.
+
+For more information on what versions you can live upgrade to or from,
+see the following table:
+
 .. include:: /includes/live-upgrade.rst
 
 After the live upgrade, ``mongosync`` continues operations that were in

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -14,11 +14,12 @@ release notes.
 Current Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`c2c-release-notes-1.10`
+- :ref:`c2c-release-notes-1.11`
 
 Previous Releases
 ~~~~~~~~~~~~~~~~~
 
+- :ref:`c2c-release-notes-1.10`
 - :ref:`c2c-release-notes-1.9`
 - :ref:`c2c-release-notes-1.8`
 - :ref:`c2c-release-notes-1.7`
@@ -36,6 +37,7 @@ Previous Releases
 .. toctree::
    :titlesonly: 
 
+   1.11 </release-notes/1.11>
    1.10 </release-notes/1.10>
    1.9 </release-notes/1.9>
    1.8 </release-notes/1.8>

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -22,3 +22,16 @@ Destination-Only Write-Blocking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/fact-write-blocking-enable.rst
+
+Live Upgrades
+~~~~~~~~~~~~~
+
+:ref:`Live upgrades <c2c-versioning-live-upgrade>` 
+to version 1.11 are not supported.
+
+Permissions
+~~~~~~~~~~~
+
+``mongosync`` requires additional permissions
+on Atlas destination clusters for default migrations.
+See :ref:`c2c-atlas-permissions`.

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -1,0 +1,24 @@
+.. _c2c-release-notes-1.11:
+
+================================
+Release Notes for mongosync 1.11
+================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes changes and new features introduced in  
+{+c2c-full-product-name+} 1.11.
+
+.. _1.11.0-c2c-release-notes:
+
+1.11.0 Release
+--------------
+
+Destination-Only Write-Blocking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- .. include:: /includes/fact-write-blocking-enable.rst

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -21,4 +21,4 @@ This page describes changes and new features introduced in
 Destination-Only Write-Blocking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- .. include:: /includes/fact-write-blocking-enable.rst
+.. include:: /includes/fact-write-blocking-enable.rst


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-46893

Document: https://docs.google.com/document/d/1aGSzqekj5-ui8PZnem1ND_SV7__gYNfn64ROtELD4l4/edit?tab=t.0

Staging (search for "block" to narrow down changed sections):

- [FAQ](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/faq/#can-i-perform-reads-or-writes-to-my-destination-cluster-while-mongosync-is-syncing-)
- [Filtering limitations](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#filtered-sync)
- [Pre-6.0 Limitations](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/limitations/#pre-6.0-migrations)
- [Permissions page](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/permissions/) (intro, title change on tables, permissions added to atlas table, pre 6.0 migration below)
- [Write blocking](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#write-blocking) and [Table](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#temporary-changes-to-collection-characteristics)
- [Live upgrade](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/versioning/#live-upgrade)
- [Commit endpoint](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/api/commit/#collection-characteristic-changes)
- [Reverse endpoint](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/#requirements)
- [Start request body parameters](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#request-body-parameters)
- [Step 2](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/#stop-any-write-operations-to-the-synced-collections-on-the-source.) and [Step 3](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/#send-a-commit-request-to-mongosync.)
- [1.11 Release notes](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.11/)
- [Release notes](https://deploy-preview-581--docs-cluster-to-cluster-sync.netlify.app/release-notes/)