### PR TITLE
DOCSP-46038-1.9.0-verification-v1.9-backport (578)

### DIFF
--- a/source/includes/fact-verification-support-1.9.0.rst
+++ b/source/includes/fact-verification-support-1.9.0.rst
@@ -1,0 +1,1 @@
+If you live upgrade from any version before 1.9.0, ``mongosync`` disables embedded verification.

--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -32,6 +32,8 @@ The embedded verifier has the following limitations:
 
 - .. include:: /includes/fact-verifier-buildIndexes
 
+- .. include:: /includes/fact-verification-support-1.9.0.rst
+
 Unsupported Verification Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/release-notes/1.9.txt
+++ b/source/release-notes/1.9.txt
@@ -30,6 +30,10 @@ confirm the successful sync of collections from the source
 cluster to the destination. The verifier is enabled by default
 for replica set migrations.
 
+.. note::
+
+   .. include:: /includes/fact-verification-support-1.9.0.rst
+
 To check verification status, see the ``verification`` field in
 the :ref:`/progress <c2c-api-progress>` response.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46038-1.9.0-verification (#578)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/578)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)