### PR TITLE
DOCSP-46895 1.11 Release Notes

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -2,7 +2,7 @@
     "repoOwner": "mongodb",
     "repoName": "docs-cluster-to-cluster-sync",
   
-    "targetBranchChoices": ["master", "v1.10", "v1.9", "v1.8"],
+    "targetBranchChoices": ["master", "v1.11", "v1.10", "v1.9", "v1.8"],
   
     "editor": "code",
   

--- a/snooty.toml
+++ b/snooty.toml
@@ -27,10 +27,10 @@ toc_landing_pages = ["/quickstart",
                     ]
 
 [constants]
-version = "1.10"
-version-previous = "1.9"
-latest-version="1.10.0"
-version-dev = "1.10"
+version = "1.11"
+version-previous = "1.10"
+latest-version="1.11.0"
+version-dev = "1.11"
 c2c-product-name = "Cluster-to-Cluster Sync"
 c2c-full-product-name = "MongoDB Cluster-to-Cluster Sync"
 mdb-download-center = "`MongoDB Download Center <https://www.mongodb.com/try/download/mongosync>`__"

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -4,6 +4,8 @@
 Release Notes for mongosync 1.11
 ================================
 
+.. default-domain:: mongodb
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -17,6 +19,8 @@ This page describes changes and new features introduced in
 
 1.11.0 Release
 --------------
+
+**February 5, 2025**
 
 Destination-Only Write-Blocking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -35,3 +39,27 @@ Permissions
 ``mongosync`` requires additional permissions
 on Atlas destination clusters for default migrations.
 See :ref:`c2c-atlas-permissions`.
+
+Other Notes 
+~~~~~~~~~~~
+
+Fixed Issues:
+
+- Fixed a bug introduced in v1.9.0, where the embedded verifier could 
+  incorrectly report failure if a collection with a TTL index was renamed and 
+  later recreated without a TTL index.
+
+- Fixed a bug introduced in v1.0.0 where a prepareUnique index could be made 
+  unique on the destination collection/a previously unique index could be left 
+  in a prepareUnique state on the destination collection after cutover.
+
+Other Changes:
+
+- Added destination-only write blocking, which is enabled by default.
+
+Minimum Supported Version
+-------------------------
+
+.. include:: /includes/fact-version-compatibility.rst
+
+.. include:: /includes/migration-upgrade-recommendation.rst

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -20,7 +20,7 @@ This page describes changes and new features introduced in
 1.11.0 Release
 --------------
 
-**February 5, 2025**
+**February 6, 2025**
 
 Destination-Only Write-Blocking
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -53,10 +53,6 @@ Fixed Issues:
   unique on the destination collection or a previously unique index could be 
   left in a ``prepareUnique`` state on the destination collection after cutover.
 
-Other Changes:
-
-- Added destination-only write blocking, which is enabled by default.
-
 Minimum Supported Version
 -------------------------
 

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -46,12 +46,12 @@ Other Notes
 Fixed Issues:
 
 - Fixed a bug introduced in v1.9.0, where the embedded verifier could 
-  incorrectly report failure if a collection with a TTL index was renamed and 
+  incorrectly report a failure if a collection with a TTL index was renamed and 
   later recreated without a TTL index.
 
-- Fixed a bug introduced in v1.0.0 where a prepareUnique index could be made 
-  unique on the destination collection/a previously unique index could be left 
-  in a prepareUnique state on the destination collection after cutover.
+- Fixed a bug introduced in v1.0.0 where a ``prepareUnique`` index could be made 
+  unique on the destination collection or a previously unique index could be 
+  left in a ``prepareUnique`` state on the destination collection after cutover.
 
 Other Changes:
 


### PR DESCRIPTION
## DESCRIPTION 
- Updates 1.11 release notes 
- Update backport script to include 1.11 (in preparation for 1.12 version bump) 

**NOTE:** Destination-only write blocking as a new feature will be documented in #581 and added to the release notes there.

## STAGING 
https://deploy-preview-585--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.11/

## JIRA 
https://jira.mongodb.org/browse/DOCSP-46895