### PR TITLE
DOCSP-46814-finalize-cutover-typo-v1.9-backport (568)

### DIFF
--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -53,9 +53,8 @@ Steps
         near ``0`` and the ``phase`` fields should show ``"stream
         hashing"``.
 
-        If ``/commit`` is called and the values are not near
-        ``0`` or if the verifier is not in the stream hashing
-        phase, the cutover process might take a long a time.
+        If the verifier is not in the stream hashing phase, the cutover
+        process might take a long time.
 
       The following example returns the status of the
       synchronization process.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46814-finalize-cutover-typo (#568)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/568)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)