### PR TITLE
DOCSP-44803-pause-and-crash-behavior-v1.10-backport (577)

### DIFF
--- a/source/reference/api/pause.txt
+++ b/source/reference/api/pause.txt
@@ -78,6 +78,9 @@ Behavior
   cluster. To learn more, see :ref:`Frequently Asked Questions
   <c2c-faq-increase-oplog>`. 
 
+For more information on the ``PAUSED`` state, see :ref:`Paused Sync
+Behavior <c2c-pause-behavior>`.
+
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -394,6 +394,44 @@ Latency between the nodes of any replica set on the source or destination cluste
   sets. If the majority of these nodes aren't in the same region, there 
   will be negative performance implications.
 
+Interruptions During Sync
+-------------------------
+
+The following considerations pertain to interruptions during the
+``mongosync`` process. 
+
+Errors and Crashes
+~~~~~~~~~~~~~~~~~~
+
+If ``mongosync`` encounters an error or becomes unavailable during
+synchronization, or you can resume your ``mongosync`` operation from where
+it stopped. The ``mongosync`` binary is stateless and stores the
+metadata for a restart on the destination cluster. 
+
+To continue sync, restart ``mongosync`` once it becomes available again
+and use the same parameters as your interupted sync. Once you restart
+``mongosync``, the process resumes from where it stopped.
+
+Cluster Availability
+~~~~~~~~~~~~~~~~~~~~
+
+If your source or destination cluster crashes unexpectedly, you can safely
+restart ``mongosync`` from where it left off. Once your cluster is available
+again, restart ``mongosync`` and use the same parameters as your interupted
+sync. 
+
+.. _c2c-pause-behavior:
+
+Paused Sync
+~~~~~~~~~~~
+
+If ``mongosync`` is in the :ref:`PAUSED <c2c-state-paused>` state,
+``mongosync`` does not support the following actions:
+
+- Upgrading the MongoDB version of the source or destination cluster
+- Enabling and then disabling the balancer
+
+You can upgrade ``mongosync`` while it is in the ``PAUSED`` state. 
 
 Learn More
 ----------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.10`:
 - [DOCSP-44803-pause-and-crash-behavior (#577)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/577)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)