### PR TITLE
DOCSP-47159: Clarify write blocking recommendation on finalize cutover page

### DIFF
--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -179,7 +179,7 @@ Steps
 
       Then, transfer your application workload to the destination cluster.
 
-      If you start ``mongosync``
+      If you started ``mongosync``
       with write-blocking by using the ``enableUserWriteBlocking`` option on
       the :ref:`/start <c2c-api-start>` endpoint, you do not need
       to complete this step.

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -164,7 +164,9 @@ Steps
 
       For more information, see :ref:`c2c-verification`.
 
-   .. step:: Enable application writes on the destination cluster.
+   .. step:: If you did not start ``mongosync`` with 
+      :ref:`write-blocking <c2c-write-blocking>`, 
+      enable application writes on the destination cluster.
 
       To enable writes, update :dbcommand:`setUserWriteBlockMode`:
 
@@ -178,6 +180,10 @@ Steps
          )
 
       Then, transfer your application workload to the destination cluster.
+
+      You do not need to do this step if you start ``mongosync``
+      with write-blocking using the ``enableUserWriteBlocking`` option when
+      you call the :ref:`/start <c2c-api-start>` API endpoint.
 
    .. step:: Call the ``progress`` endpoint to determine the status of the ``mongosync`` process.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -164,9 +164,7 @@ Steps
 
       For more information, see :ref:`c2c-verification`.
 
-   .. step:: If you did not start ``mongosync`` with 
-             :ref:`write-blocking <c2c-write-blocking>`, 
-             enable application writes on the destination cluster.
+   .. step:: If you did not start ``mongosync`` with :ref:`write-blocking <c2c-write-blocking>`, enable application writes on the destination cluster.
 
       To enable writes, update :dbcommand:`setUserWriteBlockMode`:
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -164,7 +164,7 @@ Steps
 
       For more information, see :ref:`c2c-verification`.
 
-   .. step:: If you manually :ref:`blocked writes <c2c-write-blocking>` on the destination cluster by using :dbcommand:`setUserWriteBlockMode`, enable application writes on the destination cluster.
+   .. step:: If you manually blocked writes on the destination cluster by using :dbcommand:`setUserWriteBlockMode`, enable application writes on the destination cluster.
 
       To enable writes, update :dbcommand:`setUserWriteBlockMode`:
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -165,8 +165,8 @@ Steps
       For more information, see :ref:`c2c-verification`.
 
    .. step:: If you did not start ``mongosync`` with 
-      :ref:`write-blocking <c2c-write-blocking>`, 
-      enable application writes on the destination cluster.
+             :ref:`write-blocking <c2c-write-blocking>`, 
+             enable application writes on the destination cluster.
 
       To enable writes, update :dbcommand:`setUserWriteBlockMode`:
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -179,9 +179,10 @@ Steps
 
       Then, transfer your application workload to the destination cluster.
 
-      You do not need to do this step if you start ``mongosync``
-      with write-blocking using the ``enableUserWriteBlocking`` option when
-      you call the :ref:`/start <c2c-api-start>` API endpoint.
+      If you start ``mongosync``
+      with write-blocking by using the ``enableUserWriteBlocking`` option on
+      the :ref:`/start <c2c-api-start>` endpoint, you do not need
+      to complete this step.
 
    .. step:: Call the ``progress`` endpoint to determine the status of the ``mongosync`` process.
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -164,7 +164,7 @@ Steps
 
       For more information, see :ref:`c2c-verification`.
 
-   .. step:: If you did not start ``mongosync`` with :ref:`write-blocking <c2c-write-blocking>`, enable application writes on the destination cluster.
+   .. step:: If you manually :ref:`blocked writes <c2c-write-blocking>` on the destination cluster by using :dbcommand:`setUserWriteBlockMode`, enable application writes on the destination cluster.
 
       To enable writes, update :dbcommand:`setUserWriteBlockMode`:
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-47159

Staging:

https://deploy-preview-599--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/#if-you-manually-blocked-writes-on-the-destination-cluster-by-using---enable-application-writes-on-the-destination-cluster.
