### PR TITLE
DOCSP-47126 edited oplog background fact

### DIFF
--- a/source/includes/fact-oplog-background.rst
+++ b/source/includes/fact-oplog-background.rst
@@ -1,18 +1,13 @@
 
 ``mongosync`` applies operations in the ``oplog`` on the source cluster
-to the data on the destination cluster.  When operations 
-that ``mongosync`` has not applied roll off the ``oplog`` 
+to the data on the destination cluster after the 
+:ref:`collection copy <c2c-collection-copy>` phase.  When 
+operations that ``mongosync`` has not applied roll off the ``oplog`` 
 on the source cluster, the sync fails and ``mongosync`` exits.
 
 .. note::
 
    .. include:: /includes/fact-applyOps.rst
-
-During the initial sync, ``mongosync`` may apply operations at a slower
-rate due to copying documents concurrently.
-After the initial sync, ``mongosync`` applies changes 
-faster and is more likely to maintain a position in the ``oplog``
-that is close to the real-time writes occurring on the source cluster.
 
 If you anticipate syncing a large data set, or if you plan to pause
 synchronization for an extended period of time, you might exceed the


### PR DESCRIPTION
## DESCRIPTION
Edited includes file about oplog. Removed outdated paragraph and added that the operations are applied after the collection copy phase. 

## STAGING
-[Oplog sizing page](https://deploy-preview-609--docs-cluster-to-cluster-sync.netlify.app/reference/oplog-sizing/)
-[FAQ page](https://deploy-preview-609--docs-cluster-to-cluster-sync.netlify.app/faq/#should-i-increase-the-size-of-the-oplog-in-the-source-cluster-)

## JIRA
https://jira.mongodb.org/browse/DOCSP-47126

## SELF-REVIEW CHECKLIST

- [] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
