### PR TITLE
DOCSP-47288: Rename some `enableUserWriteBlocking` internal-only options and disallow live upgrade to 1.12

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -129,13 +129,13 @@ call the :ref:`commit <c2c-api-commit>` endpoint.
    You must block writes to the source cluster before you begin the
    the commit process. 
 
-   If you previously set ``enableUserWriteBlocking`` to ``true`` when
-   you used the :ref:`start <c2c-api-start>` endpoint, ``mongosync``
+   If you previously set ``enableUserWriteBlocking`` to ``"sourceAndDestination"`` 
+   when you used the :ref:`start <c2c-api-start>` endpoint, ``mongosync``
    automatically blocks writes on the source cluster when you use the
    ``commit`` endpoint. 
 
-   If you did not set ``enableUserWriteBlocking`` to ``true``, run
-   :dbcommand:`setUserWriteBlockMode` on the source cluster to
+   If you did not set ``enableUserWriteBlocking`` to ``"sourceAndDestination"``, 
+   run :dbcommand:`setUserWriteBlockMode` on the source cluster to
    block writes. 
 
 The ``commit`` endpoint starts the :ref:`COMMITTING <c2c-state-committing>` 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -28,7 +28,7 @@
 - :ref:`/reverse <c2c-api-reverse>` endpoint is not supported. You can't 
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
-- You can't set the ``enableUserWriteBlocking`` option to ``true`` or
+- You can't set the ``enableUserWriteBlocking`` option to
   ``"sourceAndDestination"`` in the ``/start`` request, so dual write-blocking 
   is not supported. 
   Destination-only write-blocking is supported. Ensure that no writes are 

--- a/source/includes/fact-older-version-limitations.rst
+++ b/source/includes/fact-older-version-limitations.rst
@@ -28,8 +28,9 @@
 - :ref:`/reverse <c2c-api-reverse>` endpoint is not supported. You can't 
   enable the ``reversible`` option in the :ref:`/start <c2c-api-start>` request.
 
-- You can't set the ``enableUserWriteBlocking`` option to ``true``
-  in the ``/start`` request, so dual write-blocking is not supported. 
+- You can't set the ``enableUserWriteBlocking`` option to ``true`` or
+  ``"sourceAndDestination"`` in the ``/start`` request, so dual write-blocking 
+  is not supported. 
   Destination-only write-blocking is supported. Ensure that no writes are 
   made to the source cluster after you call the ``/commit`` endpoint.
 

--- a/source/includes/fact-write-blocking-enable.rst
+++ b/source/includes/fact-write-blocking-enable.rst
@@ -15,11 +15,11 @@ If you enable dual write-blocking, ``mongosync`` blocks writes:
 - On the source cluster after you call ``/commit``
 
 To enable dual write-blocking, use :ref:`/start <c2c-api-start>`
-to set ``enableUserWriteBlocking`` to ``true``.
+to set ``enableUserWriteBlocking`` to ``"sourceAndDestination"``.
 
 You can use
 :ref:`/start <c2c-api-start>`
-to set ``enableUserWriteBlocking`` to ``false``.
+to set ``enableUserWriteBlocking`` to ``"none"``.
 
 You cannot enable dual write-blocking or disable
 write-blocking after the sync starts.

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -1,7 +1,5 @@
 Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
-restarting data synchronization operations from the beginning. You can 
-only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync`` 
-1.7.2 or later.
+restarting data synchronization operations from the beginning.
 
 .. important::
    

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -5,4 +5,4 @@ only live upgrade to ``mongosync`` 1.7.3 or later from ``mongosync``
 
 .. important::
    
-   ``mongosync`` does not support live upgrades to version 1.11.
+   ``mongosync`` does not support live upgrades to version 1.11 or 1.12.

--- a/source/includes/live-upgrade.rst
+++ b/source/includes/live-upgrade.rst
@@ -3,4 +3,4 @@ restarting data synchronization operations from the beginning.
 
 .. important::
    
-   ``mongosync`` does not support live upgrades to version 1.11 or 1.12.
+   ``mongosync`` does not support live upgrades to version 1.12.

--- a/source/reference/api/reverse.txt
+++ b/source/reference/api/reverse.txt
@@ -45,7 +45,7 @@ To use the ``reverse`` endpoint:
   call to the :ref:`/start <c2c-api-start>` API endpoint must set:
   
   - ``reversible`` to ``true``
-  - ``enableUserWriteBlocking`` to ``true``.
+  - ``enableUserWriteBlocking`` to ``"sourceAndDestination"``.
 
 .. note::
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -117,26 +117,29 @@ Request Body Parameters
    * - ``enableUserWriteBlocking``
      - boolean or string
      - Optional
-     - If set to ``true``, blocks writes on the destination 
-       cluster while the migration is in progress, and unblocks writes right
-       before the :ref:`/progress <c2c-api-progress>` endpoint reports 
-       that ``canWrite`` is ``true``.  Blocks writes on the source
-       cluster after ``mongosync`` calls the :ref:`/commit <c2c-api-commit>`
-       endpoint.
+     - Supported options:
+       
+       - ``true`` or ``"sourceAndDestination"``: blocks writes on the destination 
+         cluster while the migration is in progress, and unblocks writes right
+         before the :ref:`/progress <c2c-api-progress>` endpoint reports 
+         that ``canWrite`` is ``true``.  Blocks writes on the source
+         cluster after ``mongosync`` calls the :ref:`/commit <c2c-api-commit>`
+         endpoint.
+         
+         :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
+         you cannot set ``enableUserWriteBlocking`` to ``true`` or
+         ``"sourceAndDestination"``.
 
-       If set to ``false``, no write blocking occurs.
+       - ``false`` or ``"none"``: no write blocking occurs.
 
-       If set to ``"destinationOnly"``, blocks writes on the destination
-       cluster while migration is in progress, and unblocks writes right
-       before ``canWrite`` is ``true``.
-
-       :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
-       you cannot set ``enableUserWriteBlocking`` to ``true``.
+       - ``"destinationOnly"``: blocks writes on the destination
+         cluster while migration is in progress, and unblocks writes right
+         before ``canWrite`` is ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true``. To allow the source cluster to accept writes again,
-       for example after running migration tests, run the following
-       command: 
+       to ``true`` or ``"sourceAndDestination"``. To allow the source cluster 
+       to accept writes again, for example after running migration tests, 
+       run the following command: 
 
        .. code-block:: shell 
           

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -115,29 +115,31 @@ Request Body Parameters
        .. versionadded:: 1.3.0
 
    * - ``enableUserWriteBlocking``
-     - boolean or string
+     - string or boolean
      - Optional
-     - Supported options:
+     - :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
+       you cannot set this parameter.
        
-       - ``true`` or ``"sourceAndDestination"``: blocks writes on the destination 
+       Supported options:
+       
+       - ``"sourceAndDestination"``: blocks writes on the destination 
          cluster while the migration is in progress, and unblocks writes right
          before the :ref:`/progress <c2c-api-progress>` endpoint reports 
          that ``canWrite`` is ``true``.  Blocks writes on the source
          cluster after ``mongosync`` calls the :ref:`/commit <c2c-api-commit>`
          endpoint.
-         
-         :gold:`IMPORTANT:` If you are migrating from a pre-6.0 source cluster, 
-         you cannot set ``enableUserWriteBlocking`` to ``true`` or
-         ``"sourceAndDestination"``.
 
-       - ``false`` or ``"none"``: no write blocking occurs.
+         You can also use ``true`` for backward compatibility.
+
+       - ``"none"``: no write blocking occurs. You can also use ``false``
+         for backward compatibility.
 
        - ``"destinationOnly"``: blocks writes on the destination
          cluster while migration is in progress, and unblocks writes right
          before ``canWrite`` is ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true`` or ``"sourceAndDestination"``. To allow the source cluster 
+       to ``"sourceAndDestination"``. To allow the source cluster 
        to accept writes again, for example after running migration tests, 
        run the following command: 
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -82,12 +82,12 @@ Steps
         destination and unblocks them right before ``canWrite`` is
         set to ``true``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking``
-        set to ``true``, ``mongosync`` blocks all write operations
+        set to ``"sourceAndDestination"``, ``mongosync`` blocks all write operations
         on the destination cluster and unblocks them right before ``canWrite``
         is set to ``true``. ``mongosync`` blocks writes on the source after you call
         ``/commit``.
       - If you start ``mongosync`` with ``enableUserWriteBlocking`` set
-        to ``false``, ensure that you disable writes.
+        to ``"none"``, ensure that you disable writes.
         For example, run the :dbcommand:`setUserWriteBlockMode` command on the
         source cluster:
 

--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -41,7 +41,7 @@ General Limitations
 - Other clients must not write to the destination cluster while
   ``mongosync`` is running.
 - If you want to start the :ref:`commit <c2c-api-commit>`
-  process and you did not set ``enableUserWriteBlocking`` to ``true``
+  process and you did not set ``enableUserWriteBlocking`` to ``"sourceAndDestination"``
   when you used the :ref:`c2c-api-start` endpoint, you
   must :ref:`prevent writes <c2c-api-start>` to the source cluster
   before you start the commit process. 

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -65,12 +65,7 @@ Live Upgrade
 
 .. versionadded:: 1.7.0
 
-Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
-restarting data synchronization operations from the beginning.
-
-.. important::
-
-   ``mongosync`` does not support live upgrades to version 1.11.
+.. include:: /includes/live-upgrade.rst
 
 After the live upgrade, ``mongosync`` continues operations that were in
 progress before the upgrade.

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -14,11 +14,12 @@ release notes.
 Current Stable Release
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`c2c-release-notes-1.11`
+- :ref:`c2c-release-notes-1.12`
 
 Previous Releases
 ~~~~~~~~~~~~~~~~~
 
+- :ref:`c2c-release-notes-1.11`
 - :ref:`c2c-release-notes-1.10`
 - :ref:`c2c-release-notes-1.9`
 - :ref:`c2c-release-notes-1.8`
@@ -37,6 +38,7 @@ Previous Releases
 .. toctree::
    :titlesonly: 
 
+   1.12 </release-notes/1.12>
    1.11 </release-notes/1.11>
    1.10 </release-notes/1.10>
    1.9 </release-notes/1.9>

--- a/source/release-notes/1.12.txt
+++ b/source/release-notes/1.12.txt
@@ -29,6 +29,9 @@ The ``enableUserWriteBlocking`` parameter in the
 - ``"sourceAndDestination"`` for dual write-blocking
 - ``"none"`` for no write-blocking
 
+These options are identical to the ``true`` and ``false`` values, which
+``enableUserWriteBlocking`` still accepts for backward compatibility.
+
 See :ref:`c2c-api-start-params`. 
 
 Live Upgrades

--- a/source/release-notes/1.12.txt
+++ b/source/release-notes/1.12.txt
@@ -29,10 +29,11 @@ The ``enableUserWriteBlocking`` parameter in the
 - ``"sourceAndDestination"`` for dual write-blocking
 - ``"none"`` for no write-blocking
 
-These options are identical to the ``true`` and ``false`` values, which
-``enableUserWriteBlocking`` still accepts for backward compatibility.
+Use these options instead of the old ``true`` and ``false`` values.
+``enableUserWriteBlocking`` still supports ``true`` and ``false``
+for backward compatibility.
 
-See :ref:`c2c-api-start-params`. 
+See :ref:`c2c-api-start-params`.
 
 Live Upgrades
 ~~~~~~~~~~~~~

--- a/source/release-notes/1.12.txt
+++ b/source/release-notes/1.12.txt
@@ -1,0 +1,38 @@
+.. _c2c-release-notes-1.12:
+
+================================
+Release Notes for mongosync 1.12
+================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+This page describes changes and new features introduced in  
+{+c2c-full-product-name+} 1.12.
+
+.. _1.12.0-c2c-release-notes:
+
+1.12.0 Release
+--------------
+
+``enableUserWriteBlocking`` parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``enableUserWriteBlocking`` parameter in the 
+:ref:`/start <c2c-api-start>` API now accepts the following string options:
+
+- ``"sourceAndDestination"`` for dual write-blocking
+- ``"none"`` for no write-blocking
+
+See :ref:`c2c-api-start-params`. 
+
+Live Upgrades
+~~~~~~~~~~~~~
+
+:ref:`Live upgrades <c2c-versioning-live-upgrade>` 
+to version 1.12 are not supported.

--- a/source/reverse-sync.txt
+++ b/source/reverse-sync.txt
@@ -30,7 +30,7 @@ Before you can reverse your sync direction, you must configure
 following parameters:
 
 - ``reversible`` to ``true``
-- ``enableUserWriteBlocking`` to ``true``.
+- ``enableUserWriteBlocking`` to ``"sourceAndDestination"``.
 
 For more information on limitations and requirements of reversing sync,
 see :ref:`c2c-api-reverse`. 

--- a/source/topologies/multiple-mongosyncs.txt
+++ b/source/topologies/multiple-mongosyncs.txt
@@ -311,5 +311,5 @@ instance that is running on ``mongosync01Host`` and using ``port
 .. note::
 
    Reverse synchronization is only possible if ``reversible`` and
-   ``enableUserWriteBlocking`` are both set to ``true`` when the
+   ``enableUserWriteBlocking`` are both set to ``"sourceAndDestination"`` when the
    :ref:`start API <c2c-api-start>` initiates ``mongosync``.


### PR DESCRIPTION
Adds `enableUserWriteBlocking` params and disallows live upgrade to 1.12. Also updates most mentions of `enableUserWriteBlocking` params to use the strings.

https://jira.mongodb.org/browse/DOCSP-47288

Staging:
- https://deploy-preview-611--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#request-body-parameters
- https://deploy-preview-611--docs-cluster-to-cluster-sync.netlify.app/reference/versioning/#live-upgrade
- https://deploy-preview-611--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.12/