### PR TITLE
DOCSP-46986-destinationDataHandling-note-v1.9-backport (598)

### DIFF
--- a/source/reference/beta-program-private/many-to-one.txt
+++ b/source/reference/beta-program-private/many-to-one.txt
@@ -42,6 +42,17 @@ commands when starting :ref:`mongosync <c2c-mongosync>`:
 To start the sync operation between the source clusters and the
 destination cluster, see :ref:`c2c-quickstart-synchronize`.
 
+When beginning your sync operation for a many-to-one migration, add
+the following parameter to the :ref:`/start <c2c-api-start>` requests: 
+
+.. code:: 
+
+   "destinationDataHandling": "ignorePreExistingNamespaces"
+
+Setting ``"destinationDataHandling"`` to ``"ignorePreExistingNamespaces"`` 
+allows each migration to write to the destination cluster that may have 
+pre-existing namespaces from the other many-to-one migrations.
+
 Behavior 
 --------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-46986-destinationDataHandling-note (#598)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/598)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)