### PR TITLE
DOCSP-47695-remove-live-upgrade-v1.11-backport (628)

### DIFF
--- a/source/includes/fact-verifier-limitations.rst
+++ b/source/includes/fact-verifier-limitations.rst
@@ -24,8 +24,6 @@ The embedded verifier has the following limitations:
 
 - .. include:: /includes/fact-verifier-buildIndexes
 
-- .. include:: /includes/fact-verification-support-1.9.0.rst
-
 Unsupported Verification Checks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/api/progress.txt
+++ b/source/reference/api/progress.txt
@@ -77,14 +77,6 @@ Behavior
   collection copy phase (``estimatedCopiedBytes`` = 
   ``estimatedTotalBytes``).
 
-- When performing a live upgrade from an earlier version to 1.8.0 or 
-  higher, the collection copy data starts over from 
-  ``[0 bytes copied / 1 bytes total]``. After a live upgrade, 
-  ``/progress`` only reports the progress of data copied after the 
-  upgrade completed.
-
-  .. include:: /includes/fact-restart-resume-delay.rst
-
 Endpoint Protection
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -1,0 +1,84 @@
+:orphan:
+
+.. meta::
+   :robots: noindex, nosnippet
+
+.. _c2c-live-upgrade:
+
+=============
+Live Upgrades
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+.. important::
+
+   Starting in version 1.11, ``mongosync`` does not support live upgrades due
+   to the expanded permissions required for mongosync 1.11. To upgrade to the
+   most recent version, see :ref:`c2c-release-version-numbers`. 
+
+
+Starting in ``mongosync`` 1.7.0, you can live upgrade ``mongosync`` without
+restarting data synchronization operations from the beginning.
+
+After the live upgrade, ``mongosync`` continues operations that were in
+progress before the upgrade.
+
+To live upgrade ``mongosync``, perform these steps:
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+
+   .. step:: (Optional) Pause the ``mongosync`` processes
+
+      To pause ``mongosync``, run :ref:`c2c-api-pause` on each running
+      ``mongosync`` process.
+
+      You can resume the ``mongosync`` processes later from the paused
+      state, as shown in the final step.
+
+      .. tip::
+
+         If you don't want to immediately resume data synchronization
+         operations after live upgrade, consider pausing the
+         ``mongosync`` processes. This is useful if you're coordinating
+         operations from multiple ``mongosync`` processes.
+
+   .. step:: Stop the ``mongosync`` processes
+
+      Use your operating system to stop each running ``mongosync``
+      process. To stop a process, see your operating system
+      documentation for the specific steps.
+
+   .. step:: Download and install the new ``mongosync`` binaries
+
+      To download and install the new ``mongosync`` binaries, see
+      :ref:`download and install mongosync <c2c-install>`.
+
+   .. step:: Initialize the ``mongosync`` processes
+
+      To initialize the ``mongosync`` processes, see 
+      :ref:`Quickstart <c2c-quickstart>`. During initialization after a
+      live upgrade, ``mongosync`` updates the persistent metadata.
+
+   .. step:: Resume the ``mongosync`` processes
+
+      If you paused any ``mongosync`` processes earlier in the optional
+      first step, run :ref:`c2c-api-resume` on all ``mongosync``
+      processes.
+
+If a data synchronization operation was already in progress before the
+live upgrade, new features added in the latest ``mongosync`` version may
+not all be supported after the live upgrade. Performance improvements
+and bug fixes are always supported after the live upgrade. For more
+information on the new features that might be supported after a live
+upgrade, see the :ref:`1.7.0-c2c-release-notes`.

--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -58,79 +58,10 @@ released, version 2.0 would no longer receive patch releases. At the
 same time, version 1.3 would continue to receive patches until version
 1.4 was released.
 
-.. _c2c-versioning-live-upgrade:
+Upgrade or Downgrade
+~~~~~~~~~~~~~~~~~~~~
 
-Live Upgrade
-~~~~~~~~~~~~
-
-.. versionadded:: 1.7.0
-
-Starting in ``mongosync`` 1.7.0, you can upgrade ``mongosync`` without
-restarting data synchronization operations from the beginning.
-
-.. important::
-
-   ``mongosync`` does not support live upgrades to version 1.11.
-
-After the live upgrade, ``mongosync`` continues operations that were in
-progress before the upgrade.
-
-To live upgrade ``mongosync``, perform these steps:
-
-.. procedure::
-   :style: normal
-
-   .. step:: (Optional) Pause the ``mongosync`` processes
-   
-      To pause ``mongosync``, run :ref:`c2c-api-pause` on each running
-      ``mongosync`` process.
-      
-      You can resume the ``mongosync`` processes later from the paused
-      state, as shown in the final step.
-      
-      .. tip::
-
-         If you don't want to immediately resume data synchronization
-         operations after live upgrade, consider pausing the
-         ``mongosync`` processes. This is useful if you're coordinating
-         operations from multiple ``mongosync`` processes.
-
-   .. step:: Stop the ``mongosync`` processes
-   
-      Use your operating system to stop each running ``mongosync``
-      process. To stop a process, see your operating system
-      documentation for the specific steps.
-
-   .. step:: Download and install the new ``mongosync`` binaries
-   
-      To download and install the new ``mongosync`` binaries, see
-      :ref:`download and install mongosync <c2c-install>`.
-
-   .. step:: Initialize the ``mongosync`` processes
-
-      To initialize the ``mongosync`` processes, see 
-      :ref:`Quickstart <c2c-quickstart>`. During initialization after a
-      live upgrade, ``mongosync`` updates the persistent metadata.
-
-   .. step:: Resume the ``mongosync`` processes
-
-      If you paused any ``mongosync`` processes earlier in the optional
-      first step, run :ref:`c2c-api-resume` on all ``mongosync``
-      processes.
-
-If a data synchronization operation was already in progress before the
-live upgrade, new features added in the latest ``mongosync`` version may
-not all be supported after the live upgrade. Performance improvements
-and bug fixes are always supported after the live upgrade. For more
-information on the new features that might be supported after a live
-upgrade, see the :ref:`1.7.0-c2c-release-notes`.
-
-Non-Live Upgrade or Downgrade
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you're using an earlier ``mongosync`` version not supported by the
-live upgrade procedure, or you need to downgrade ``mongosync``, perform
-these steps:
+Use the following steps to upgrade or downgrade ``mongosync``:
 
 - Stop all currently running ``mongosync`` processes.
 - Drop all non-system databases in the destination cluster.

--- a/source/release-notes/1.11.txt
+++ b/source/release-notes/1.11.txt
@@ -30,8 +30,8 @@ Destination-Only Write-Blocking
 Live Upgrades
 ~~~~~~~~~~~~~
 
-:ref:`Live upgrades <c2c-versioning-live-upgrade>` 
-to version 1.11 are not supported.
+Starting in version 1.11.0, ``mongosync`` does not support
+:ref:`c2c-live-upgrade`.
 
 Permissions
 ~~~~~~~~~~~

--- a/source/release-notes/1.7.txt
+++ b/source/release-notes/1.7.txt
@@ -191,8 +191,6 @@ Live Upgrade
 
 .. include:: /includes/live-upgrade.rst
 
-For details, see :ref:`c2c-versioning-live-upgrade`.
-
 Synchronize Data Between Clusters with Different MongoDB Server Major Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-47695-remove-live-upgrade (#628)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/628)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)