### PR TITLE
replace-outdated-blurb-w-link-to-versions-file

### DIFF
--- a/source/includes/fact-minimum-server-version-support.rst
+++ b/source/includes/fact-minimum-server-version-support.rst
@@ -1,1 +1,0 @@
-The minimum supported server versions of MongoDB are 6.0.17 and 7.0.13.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -34,15 +34,8 @@ The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions u
 Compatibility
 -------------
 
-- .. include:: /includes/fact-minimum-server-version-support.rst
-     
-  You can migrate data on clusters (source) with versions of MongoDB
-  lower than 6.0 to an Atlas cluster (destination). Migration from clusters with
-  lower version requires additional preparation and configuration in
-  the clusters with the lower version. `Contact
-  <https://mongodb.com/contact>`__ your account team to inquire about 
-  Professional Services.  
-
+- For full details on compatibility and version requirements, refer 
+  to :ref:`MongoDB Server Version Compatibility<c2c-server-version-compatibility>`.
 - ``mongosync`` supports replica sets and sharded clusters.
 - Standalone MongoDB instances are not supported. :ref:`Convert the
   standalone instance <server-replica-set-deploy-convert>` to a

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -34,8 +34,8 @@ The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions u
 Compatibility
 -------------
 
-- For full details on compatibility and version requirements, refer 
-  to :ref:`MongoDB Server Version Compatibility<c2c-server-version-compatibility>`.
+- For details on compatibility and version requirements, see 
+  :ref:`MongoDB Server Version Compatibility<c2c-server-version-compatibility>`.
 - ``mongosync`` supports replica sets and sharded clusters.
 - Standalone MongoDB instances are not supported. :ref:`Convert the
   standalone instance <server-replica-set-deploy-convert>` to a

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -34,8 +34,8 @@ The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions u
 Compatibility
 -------------
 
-- For details on compatibility and version requirements, see 
-  :ref:`MongoDB Server Version Compatibility<c2c-server-version-compatibility>`.
+- For details on version compatibility requirements, see 
+  :ref:`MongoDB Server Version Compatibility <c2c-server-version-compatibility>`.
 - ``mongosync`` supports replica sets and sharded clusters.
 - Standalone MongoDB instances are not supported. :ref:`Convert the
   standalone instance <server-replica-set-deploy-convert>` to a


### PR DESCRIPTION
## DESCRIPTION

Replaces outdated information on minimum supported versions with link to the [MongoDB Server Version Compatibility](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/supported-server-version/) document.

Removed text: 

> The minimum supported server versions of MongoDB are 6.0.17 and 7.0.13.
> You can migrate data on clusters (source) with versions of MongoDB lower than 6.0 to an Atlas cluster (destination). Migration from clusters with lower version requires additional preparation and configuration in the clusters with the lower version. Contact your account team to inquire about Professional Services.

## STAGING

https://deploy-preview-643--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/#compatibility

## JIRA

https://jira.mongodb.org/browse/DOCSP-48043