### PR TITLE
DOCSP-48043-replace-outdated-blurb-w-link-to-versions-file-v1.10-backport (643)

### DIFF
--- a/source/includes/fact-minimum-server-version-support.rst
+++ b/source/includes/fact-minimum-server-version-support.rst
@@ -1,1 +1,0 @@
-The minimum supported server versions of MongoDB are 6.0.16 and 7.0.9.

--- a/source/reference/mongosync.txt
+++ b/source/reference/mongosync.txt
@@ -34,17 +34,8 @@ The :ref:`Frequently Asked Questions (FAQ) <c2c-faq>` page addresses questions u
 Compatibility
 -------------
 
-- .. include:: /includes/fact-partial-8.0-support.rst
-
-- .. include:: /includes/fact-minimum-server-version-support.rst
-     
-  You can migrate data on clusters (source) with versions of MongoDB
-  lower than 6.0 to an Atlas cluster (destination). Migration from clusters with
-  lower version requires additional preparation and configuration in
-  the clusters with the lower version. `Contact
-  <https://mongodb.com/contact>`__ your account team to inquire about 
-  Professional Services.  
-
+- For details on version compatibility requirements, see 
+  :ref:`MongoDB Server Version Compatibility <c2c-server-version-compatibility>`.
 - ``mongosync`` supports replica sets and sharded clusters.
 - Standalone MongoDB instances are not supported. :ref:`Convert the
   standalone instance <server-replica-set-deploy-convert>` to a


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.10`:
 - [DOCSP-48043replace-outdated-blurb-w-link-to-versions-file (#643)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/643)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)