### PR TITLE
DOCSP-48145-quickstart-nested-components-v1.9-backport (646)

### DIFF
--- a/source/includes/fact-oplog-disk-storage.rst
+++ b/source/includes/fact-oplog-disk-storage.rst
@@ -4,12 +4,10 @@ sync. For example, to migrate 10 GB of data, the destination cluster must have
 at least 10 GB available for the data and another 10 GB for the insert oplog 
 entries from the initial sync.
 
-.. important:: 
-  
-   To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
-   larger oplog on the destination. If you enable the embedded verifier and 
-   reduce the size of the destination oplog, the embedded verifier might not be 
-   able to keep up, causing ``mongosync`` to error.
+To use :ref:`embedded verification <c2c-embedded-verifier>`, you must have a 
+larger oplog on the destination. If you enable the embedded verifier and 
+reduce the size of the destination oplog, the embedded verifier might not be 
+able to keep up, causing ``mongosync`` to error.
 
 If you need to reduce the overhead of the destination oplog entries and the 
 embedded verifier is disabled, you can: 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-48145-quickstart-nested-components (#646)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/646)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)