### PR TITLE
DOCSP-47109-document-minimum-privileges-v1.11-backport (650)

### DIFF
--- a/source/includes/minimum-destination-privileges.rst
+++ b/source/includes/minimum-destination-privileges.rst
@@ -1,0 +1,112 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 10 20
+
+   * - Sync Type
+     - Minimum Destination Privileges
+
+   * - Default
+     - .. code-block:: javascript
+
+          [
+             {
+                "resource": { "cluster": true },
+                "actions": [
+                   "appendOplogNote",
+                   "enableSharding",
+                   "getDefaultRWConcern",
+                   "getShardMap",
+                   "hostInfo",
+                   "listDatabases",
+                   "listShards",
+                   "replSetGetConfig",
+                   "replSetGetStatus",
+                   "serverStatus"
+               ]
+             },
+             {
+                "resource": { "db": "", "collection": "" },
+                "actions": [
+                   "bypassDocumentValidation",
+                   "changeStream",
+                   "collMod",
+                   "convertToCapped",
+                   "createCollection",
+                   "createIndex",
+                   "dropCollection",
+                   "dropIndex",
+                   "enableSharding",
+                   "find",
+                   "indexStats",
+                   "insert",
+                   "listCollections",
+                   "listIndexes",
+                   "remove",
+                   "renameCollectionSameDB",
+                   "update",
+                   "bypassWriteBlockingMode",
+                   "setUserWriteBlockMode"
+               ]
+             },
+             {
+                "resource": { "db": "admin", "collection": "system.version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "", "collection": "system.js" },
+                "actions": [ "listCollections", "listIndexes" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "shards" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "", "collection": "system.views" },
+                "actions": [ "dropCollection" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "collections" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "settings" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "tags" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "system_buckets": "" },
+                "actions": [ "listCollections", "listIndexes" ]
+             }
+          ]
+
+   * - Write Blocking
+     - Everything from the default destination privileges.
+  
+   * - Reversing
+     - Everything from the default source privileges and the default destination
+       privileges with the addition of:
+
+       .. code-block:: javascript
+
+          [
+             { "resource": { "db": "", "collection": "" }, "actions": [ "dropDatabase" ] }
+          ]
+
+   * - Multiple Reversals
+     - Everything from the default source privileges and the default destination
+       privileges with the addition of:
+
+       .. code-block:: javascript
+
+          [
+             { "resource": { "db": "", "collection": "" }, "actions": [ "dropDatabase" ] }
+          ]
+

--- a/source/includes/minimum-source-privileges.rst
+++ b/source/includes/minimum-source-privileges.rst
@@ -1,0 +1,151 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 10 30
+
+   * - Sync Type
+     - Minimum Source Privileges
+
+   * - Default
+     - .. code-block:: javascript
+
+          [
+             {
+                 "resource": { "cluster": true },
+                 "actions": [
+                    "appendOplogNote",
+                    "getDefaultRWConcern",
+                    "getShardMap",
+                    "hostInfo",
+                    "listDatabases",
+                    "listShards",
+                    "replSetGetConfig",
+                    "replSetGetStatus",
+                    "serverStatus"
+                 ]
+             },
+             {
+                 "resource": { "db": "", "collection": "" },
+                 "actions": [
+                    "changeStream",
+                    "collStats",
+                    "find",
+                    "indexStats",
+                    "listCollections",
+                    "listIndexes"
+               ]
+             },
+             {
+                 "resource": { "db": "admin", "collection": "system.version" },
+                 "actions": [ "find" ]
+             },
+             {
+                 "resource": { "db": "", "collection": "system.js" },
+                 "actions": [ "listCollections", "listIndexes" ]
+             },
+             {
+                 "resource": { "db": "config", "collection": "shards" },
+                 "actions": [ "find" ]
+             },
+             {
+                 "resource": { "db": "config", "collection": "collections" },
+                 "actions": [ "find" ]
+             },
+             {
+                 "resource": { "db": "config", "collection": "version" },
+                 "actions": [ "find" ]
+             },
+             {
+                 "resource": { "db": "config", "collection": "settings" },
+                 "actions": [ "find" ]
+             },
+             {
+                 "resource": { "system_buckets": "" },
+                 "actions": [ "listCollections", "listIndexes" ]
+             }
+          ]
+
+   * - Write-blocking
+     - Everything from the default source privileges with the addition of:
+       
+       .. code-block:: javascript
+
+          [
+            {
+                "resource": { "cluster": true },
+                "actions": [ "bypassWriteBlockingMode", "setUserWriteBlockMode" ]
+            }
+          ]
+
+   * - Reversing
+     - Everything from the default source privileges and the default destination
+       privileges. 
+
+   * - Multiple Reversals
+     - Everything from the default source privileges and the default destination
+       privileges with the addition of:
+
+       .. code-block:: javascript
+
+          [
+              { "resource": { "db": "", "collection": "" }, "actions": [ "dropDatabase" ] }
+          ]
+
+   * - V4.4 Migration
+     - .. code-block:: javascript
+  
+          [
+             {
+                "resource": { "cluster": true },
+                "actions": [
+                   "addShard",
+                   "appendOplogNote",
+                   "flushRouterConfig",
+                   "getDefaultRWConcern",
+                   "getShardMap",
+                   "hostInfo",
+                   "listDatabases",
+                   "listShards",
+                   "replSetGetConfig",
+                   "replSetGetStatus",
+                   "serverStatus"
+               ]
+             },
+             {
+                "resource": { "db": "", "collection": "" },
+                "actions": [
+                   "changeStream",
+                   "collStats",
+                   "find",
+                   "indexStats",
+                   "listCollections",
+                   "listIndexes"
+               ]
+             },
+             {
+                "resource": { "db": "admin", "collection": "system.version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "", "collection": "system.js" },
+                "actions": [ "listCollections", "listIndexes" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "shards" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "collections" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "settings" },
+                "actions": [ "find" ]
+             }
+          ]
+
+

--- a/source/reference/permissions.txt
+++ b/source/reference/permissions.txt
@@ -30,12 +30,98 @@ The Atlas permissions are:
 
 .. include:: /includes/table-permissions-atlas.rst
 
+.. _c2c-minimum-privileges:
+
+Minimum Privileges
+------------------
+
+.. note::
+
+   Minimum privileges may change across mongosync versions. 
+
+The minimum source privileges are:
+
+.. include:: /includes/minimum-source-privileges.rst
+
+The minimum destination privileges are:
+
+.. include:: /includes/minimum-destination-privileges.rst
+
 .. _c2c-older-version-permissions:
 
 Pre-6.0 Migrations 
 ------------------
 
-- When migrating from a 4.4 source cluster, you must have 
-  :authrole:`clusterManager` permissions on the source cluster.
+- When migrating from a 4.4 source cluster, the source cluster
+  should either have :authrole:`clusterManager` or the minimum 
+  permissions listed for v4.4.
+
+  The minimum source permissions for v4.4 are:
+
+  .. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 10 30
+
+   * - Sync Type
+     - Minimum Source Privileges
+
+   * - V4.4 Migration
+     - .. code-block:: javascript
+  
+          [
+             {
+                "resource": { "cluster": true },
+                "actions": [
+                   "addShard",
+                   "appendOplogNote",
+                   "flushRouterConfig",
+                   "getDefaultRWConcern",
+                   "getShardMap",
+                   "hostInfo",
+                   "listDatabases",
+                   "listShards",
+                   "replSetGetConfig",
+                   "replSetGetStatus",
+                   "serverStatus"
+               ]
+             },
+             {
+                "resource": { "db": "", "collection": "" },
+                "actions": [
+                   "changeStream",
+                   "collStats",
+                   "find",
+                   "indexStats",
+                   "listCollections",
+                   "listIndexes"
+               ]
+             },
+             {
+                "resource": { "db": "admin", "collection": "system.version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "", "collection": "system.js" },
+                "actions": [ "listCollections", "listIndexes" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "shards" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "collections" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "version" },
+                "actions": [ "find" ]
+             },
+             {
+                "resource": { "db": "config", "collection": "settings" },
+                "actions": [ "find" ]
+             }
+          ]
 
 - Dual write-blocking and reverse sync are not supported.
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-47109-document-minimum-privileges (#650)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/650)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)