### PR TITLE
DOCSP-48242-mongosync-metadata-post-sync-v1.8-backport (651)

### DIFF
--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -235,6 +235,18 @@ Rolling Index Builds
 
 .. include:: /includes/rolling-build-limitation.rst
 
+``mongosync`` Metadata
+~~~~~~~~~~~~~~~~~~~~~~
+
+``mongosync`` stores its metadata in a database or multiple databases 
+during migration. The metadata databases can be named any of the following: 
+
+- ``mongosync_reserved_for_internal_use``
+- Anything beginning with ``mongosync_internal_``
+- Anything beginning with ``mongosync_reserved_for_verification_``
+
+You should drop any metadata databases after a successful migration. 
+
 Destination Clusters
 --------------------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-48242-mongosync-metadata-post-sync (#651)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/651)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)