### PR TITLE
DOCSP-48417-writeBlocking-permission-typo-v1.8-backport (658)

### DIFF
--- a/source/includes/table-permissions-atlas.rst
+++ b/source/includes/table-permissions-atlas.rst
@@ -4,41 +4,26 @@
 
 .. list-table::
    :header-rows: 1
+   :stub-columns: 1
+   :widths: 15 20 20
 
    * - Sync Type
-     - Target
-     - Required Permissions
+     - Required Source Permissions
+     - Required Destination Permissions
 
-   * - default
-     - source cluster
-     -
+   * - Default
+     - - atlasAdmin
+     - - atlasAdmin
+       - :authaction:`bypassWriteBlockingMode`
+       
+   * - Write-blocking or reversing
+     - - atlasAdmin
+       - :authaction:`bypassWriteBlockingMode`
+     - - atlasAdmin
+       - :authaction:`bypassWriteBlockingMode`
 
-         - atlasAdmin
-
-   * - default
-     - destination cluster
-     -
-
-         - atlasAdmin
-
-   * - write-blocking or reversing
-     - source cluster
-     -
-
-         - atlasAdmin
-         - bypassWriteBlockMode privilege
-
-   * - write-blocking or reversing
-     - destination cluster
-     -
-
-         - atlasAdmin
-         - bypassWriteBlockMode privilege
-
-For details on Atlas roles, see: :atlas:`Atlas User Roles
-</reference/user-roles/>`.
+For details on Atlas roles, see: :atlas:`Built-In Roles and Privileges
+</mongodb-users-roles-and-privileges/>`.
 
 To update Atlas user permissions, see:
 :atlas:`Manage Access to a Project </access/manage-project-access/>`.
-
-


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-48417-writeBlocking-permission-typo (#658)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/658)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)