### PR TITLE
DOCSP-48399-start-sync-syntax-error

### DIFF
--- a/source/includes/api/requests/start-rs-shard.sh
+++ b/source/includes/api/requests/start-rs-shard.sh
@@ -12,7 +12,7 @@ curl localhost:27182/api/v1/start -XPOST \
                 "shardCollection": {
                    "key": [
                       { "location": 1 },
-                      { "region": 1 },
+                      { "region": 1 }
                    ]
                 }
             }


### PR DESCRIPTION
## DESCRIPTION
Fix syntax error on [start page. ](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/start/#start-sync-from-replica-set-to-sharded-cluster)

## STAGING
https://deploy-preview-664--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/#start-sync-from-replica-set-to-sharded-cluster

## JIRA
https://jira.mongodb.org/browse/DOCSP-48399

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)