### PR TITLE
DOCSP-48399-start-sync-syntax-error-v1.11-backport (664)

### DIFF
--- a/source/includes/api/requests/start-rs-shard.sh
+++ b/source/includes/api/requests/start-rs-shard.sh
@@ -12,7 +12,7 @@ curl localhost:27182/api/v1/start -XPOST \
                 "shardCollection": {
                    "key": [
                       { "location": 1 },
-                      { "region": 1 },
+                      { "region": 1 }
                    ]
                 }
             }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48399-start-sync-syntax-error (#664)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/664)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)