### PR TITLE
DOCSP-48399-v1.8-backport

### DIFF
--- a/source/includes/api/requests/start-rs-shard.sh
+++ b/source/includes/api/requests/start-rs-shard.sh
@@ -12,7 +12,7 @@ curl localhost:27182/api/v1/start -XPOST \
                 "shardCollection": {
                    "key": [
                       { "location": 1 },
-                      { "region": 1 },
+                      { "region": 1 }
                    ]
                 }
             }

--- a/source/reference/beta-program-private/orr.txt
+++ b/source/reference/beta-program-private/orr.txt
@@ -62,10 +62,6 @@ You might exceed the :term:`oplog window` if you:
 To increase the size of the oplog on the source cluster, use
 :setting:`~replication.oplogSizeMB`. 
 
-.. note::
-
-  ORR is compatible with :ref:`embedded verification<c2c-embedded-verifier>`. 
-
 Learn More 
 ----------
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-48399-start-sync-syntax-error (#664)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/664)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)