### PR TITLE
DOCSP-48355-treat-non-known-cancellations-fatal

### DIFF
--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -372,6 +372,15 @@ error occurs, the ``mongosync`` log may contain the word "error' but
 ``mongosync`` is still able to complete the sync. In the case that a
 sync does not complete, ``mongosync`` writes a fatal log entry. 
 
+``mongosync`` only exits with an info level log when it sees a normal 
+cancellation and crashes with a fatal level log for all other cases.
+
+The known normal cancellations are: 
+
+- If the user calls ``pause``
+- If a test calls ``cancel`` as part of normal operation
+- If ``mongosync`` encounters signals from the ``sigChan`` in ``cmd``/``mongosync``/``main.go``
+
 .. _c2c-mongosync-ddl:
 
 Data Definition Language (DDL) Operations


### PR DESCRIPTION
## DESCRIPTION
Update `mongosync` docs w/ known normal cancellations & fatal cancellations. 

## STAGING
https://deploy-preview-671--docs-cluster-to-cluster-sync.netlify.app/reference/mongosync/mongosync-behavior/#resilience

## JIRA
https://jira.mongodb.org/browse/DOCSP-48355

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
