### PR TITLE
DOCSP-48421-clarify-verifier-lag-time

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -56,6 +56,7 @@
        With the introduction of the :ref:`embdedded verfier<c2c-embedded-verifier>`
        in version 1.9, there are three different ``lagTimeSeconds`` fields whenever
        embedded verification is enabled: 
+       
        - ``lagTimeSeconds`` for ``mongosync``
        - ``lagTimeSeconds`` for the source cluster for the verifier
        - ``lagTimeSeconds`` for the destination cluster for the verifier

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -53,6 +53,12 @@
        writes on the source cluster. The time difference becomes zero
        when ``mongosync`` commits the migration.
 
+       With the introduction of the :ref:`embdedded verfier<c2c-embedded-verifier>`
+       in version 1.9, there are now three different ``lagTimeSeconds`` fields: 
+        - ``lagTimeSeconds`` for ``mongosync``
+        - ``lagTimeSeconds`` for the source cluster for the verifier
+        - ``lagTimeSeconds`` for the destination cluster for the verifier
+
    * - ``totalEventsApplied``
      - integer
      - The approximate number of change events this instance of 

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -54,10 +54,14 @@
        when ``mongosync`` commits the migration.
 
        With the introduction of the :ref:`embdedded verfier<c2c-embedded-verifier>`
-       in version 1.9, there are now three different ``lagTimeSeconds`` fields: 
+       in version 1.9, there are three different ``lagTimeSeconds`` fields whenever
+       embedded verification is enabled: 
        - ``lagTimeSeconds`` for ``mongosync``
        - ``lagTimeSeconds`` for the source cluster for the verifier
        - ``lagTimeSeconds`` for the destination cluster for the verifier
+
+       When embdedded verification is disabled, ``lagTimeSeconds`` only applies
+       to ``mongosync``.
 
    * - ``totalEventsApplied``
      - integer

--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -55,9 +55,9 @@
 
        With the introduction of the :ref:`embdedded verfier<c2c-embedded-verifier>`
        in version 1.9, there are now three different ``lagTimeSeconds`` fields: 
-        - ``lagTimeSeconds`` for ``mongosync``
-        - ``lagTimeSeconds`` for the source cluster for the verifier
-        - ``lagTimeSeconds`` for the destination cluster for the verifier
+       - ``lagTimeSeconds`` for ``mongosync``
+       - ``lagTimeSeconds`` for the source cluster for the verifier
+       - ``lagTimeSeconds`` for the destination cluster for the verifier
 
    * - ``totalEventsApplied``
      - integer

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -36,7 +36,9 @@ Before using the ``commit`` endpoint:
 - Use the :ref:`progress <c2c-api-progress>` endpoint to confirm the
   following values:
 
-  - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
+  - ``lagTimeSeconds`` for ``mongosync``, the source cluster 
+    for the verifier, and the destination cluster for the 
+    verifier are all near ``0`` (*Recommended, but not required*)
 
     .. note:: lagTimeSeconds
 
@@ -48,6 +50,9 @@ Before using the ``commit`` endpoint:
        
        When ``lagTimeSeconds`` is ``0``, the source and destination
        clusters are in a consistent state.
+
+       For more information on the ``lagTimeSeconds`` fields, see
+       :ref:`c2c-api-progress`.
 
   - ``state: "RUNNING"``
   - ``canCommit: true``


### PR DESCRIPTION
## DESCRIPTION
Clarifies that there are 3 diff `lagTimeSeconds` fields in the `progress` response in the [progress page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/progress/#std-label-c2c-api-progress) & [commit page](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/commit/). 

## STAGING
- https://deploy-preview-673--docs-cluster-to-cluster-sync.netlify.app/reference/api/progress/#std-label-c2c-api-progress
- https://deploy-preview-673--docs-cluster-to-cluster-sync.netlify.app/reference/api/commit/

## JIRA
https://jira.mongodb.org/browse/DOCSP-48421

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
