### PR TITLE
DOCSP-48393-reorder-shardingEntries-note-v1.10-backport (672)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -235,6 +235,11 @@ Sharding Parameters
 To sync from a replica set to a sharded cluster, set the 
 ``sharding`` option to shard collections on the destination cluster.
 
+``mongosync`` throws an error if the ``sharding`` option is not set when
+syncing from a replica set to a sharded cluster. ``mongosync`` also
+throws an error if the ``sharding`` option is set with any other
+configuration.
+
 The ``sharding`` option has the following parameters:
 
 .. list-table::
@@ -285,11 +290,6 @@ The ``sharding`` option has the following parameters:
      - Sets the fields to use for the shard key.
 
        For more information, see :ref:`shard-key`.
-
-``mongosync`` throws an error if the ``sharding`` option is not set when
-syncing from a replica set to a sharded cluster. ``mongosync`` also
-throws an error if the ``sharding`` option is set with any other
-configuration.
 
 Response
 --------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.10`:
 - [DOCSP-48393-reorder-shardingEntries-note (#672)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/672)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)