### PR TITLE
DOCSP-48525-disaster-recovery-faq-entry

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -23,6 +23,8 @@ Can I change the load level while ``mongosync`` is syncing?
 Yes, you can adjust the cluster workload level during a migration by 
 following the steps in :ref:`c2c-reconfigure-mid-migration`. 
 
+.. _c2c-faq-reads-writes-mongosync:
+
 Can I perform reads or writes to my destination cluster while ``mongosync`` is syncing?
 ---------------------------------------------------------------------------------------
 
@@ -233,3 +235,10 @@ No, you can't configure ``mongosync`` to customize chunk distributions
 on a destination sharded cluster.  ``mongosync`` samples each collection
 during initialization to determine how to distribute documents
 efficiently across the destination cluster’s shards after migration.
+
+Can I use mongosync to set up a Disaster Recovery cluster?
+----------------------------------------------------------
+
+This is not possible to do with ``mongosync`` today, since 
+``mongosync`` must commit in order to safely accept traffic to the 
+destination cluster. For more information, see :ref:`c2c-faq-reads-writes-mongosync`.


### PR DESCRIPTION
## DESCRIPTION
Add question to [C2C FAQ](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/faq/#can-i-perform-reads-or-writes-to-my-destination-cluster-while-mongosync-is-syncing-) ab using mongosync for disaster recovery. 

## STAGING
https://www.mongodb.com/docs/cluster-to-cluster-sync/current/faq/#can-i-perform-reads-or-writes-to-my-destination-cluster-while-mongosync-is-syncing-

## JIRA
https://jira.mongodb.org/browse/DOCSP-48525

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)