### PR TITLE
DOCSP-48369-mongosync-version-bump-1.13

### DIFF
--- a/source/reference/versioning.txt
+++ b/source/reference/versioning.txt
@@ -61,6 +61,10 @@ same time, version 1.3 would continue to receive patches until version
 Upgrade or Downgrade
 ~~~~~~~~~~~~~~~~~~~~
 
+.. note::
+
+   ``mongosync`` supports live upgrades from v1.12 to v1.13. 
+
 Use the following steps to upgrade or downgrade ``mongosync``:
 
 - Stop all currently running ``mongosync`` processes.


### PR DESCRIPTION
## DESCRIPTION
Add note to 1.13 C2C mongosync versioning page that in 1.13, live updating is supported for 1.12 -> 1.13. 

## STAGING
https://deploy-preview-681--docs-cluster-to-cluster-sync.netlify.app/reference/versioning/#upgrade-or-downgrade

## JIRA
https://jira.mongodb.org/browse/DOCSP-48369

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
