### PR TITLE
DOCSP-48421-clarify-verifier-lag-time-v1.9-backport (673)

### DIFF
--- a/source/includes/api/tables/progress-response.rst
+++ b/source/includes/api/tables/progress-response.rst
@@ -53,6 +53,17 @@
        writes on the source cluster. The time difference becomes zero
        when ``mongosync`` commits the migration.
 
+       With the introduction of the :ref:`embdedded verfier<c2c-embedded-verifier>`
+       in version 1.9, there are three different ``lagTimeSeconds`` fields whenever
+       embedded verification is enabled: 
+       
+       - ``lagTimeSeconds`` for ``mongosync``
+       - ``lagTimeSeconds`` for the source cluster for the verifier
+       - ``lagTimeSeconds`` for the destination cluster for the verifier
+
+       When embdedded verification is disabled, ``lagTimeSeconds`` only applies
+       to ``mongosync``.
+
    * - ``totalEventsApplied``
      - integer
      - The approximate number of change events this instance of 

--- a/source/reference/api/commit.txt
+++ b/source/reference/api/commit.txt
@@ -36,7 +36,9 @@ Before using the ``commit`` endpoint:
 - Use the :ref:`progress <c2c-api-progress>` endpoint to confirm the
   following values:
 
-  - ``lagTimeSeconds`` is near ``0`` (*Recommended, but not required*)
+  - ``lagTimeSeconds`` for ``mongosync``, the source cluster 
+    for the verifier, and the destination cluster for the 
+    verifier are all near ``0`` (*Recommended, but not required*)
 
     .. note:: lagTimeSeconds
 
@@ -48,6 +50,9 @@ Before using the ``commit`` endpoint:
        
        When ``lagTimeSeconds`` is ``0``, the source and destination
        clusters are in a consistent state.
+
+       For more information on the ``lagTimeSeconds`` fields, see
+       :ref:`c2c-api-progress`.
 
   - ``state: "RUNNING"``
   - ``canCommit: true``


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-48421-clarify-verifier-lag-time (#673)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/673)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)