### PR TITLE
DOCSP-48525-disaster-recovery-faq-entry-v1.10-backport (679)

### DIFF
--- a/source/about-mongosync.txt
+++ b/source/about-mongosync.txt
@@ -19,6 +19,10 @@ destination cluster and keeps the clusters in continuous sync until you
 In addition to continuous data synchronization, ``mongosync`` can also
 perform a one time data migration between clusters.
 
+.. important::
+
+   .. include:: /includes/fact-no-mongosync-disaster-recovery.rst
+
 ``mongosync`` keeps track of its current actions through 
 :ref:`states <c2c-states>`. ``mongosync`` enters different states depending on 
 the requests it receives. The current ``mongosync`` state determines which API 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -23,6 +23,8 @@ Can I change the load level while ``mongosync`` is syncing?
 Yes, you can adjust the cluster workload level during a migration by 
 following the steps in :ref:`c2c-reconfigure-mid-migration`. 
 
+.. _c2c-faq-reads-writes-mongosync:
+
 Can I perform reads or writes to my destination cluster while ``mongosync`` is syncing?
 ---------------------------------------------------------------------------------------
 
@@ -51,6 +53,14 @@ To learn more about permissable reads and writes during synchronization, see
    
    Index builds on the destination cluster are treated as writes 
    while ``mongosync`` is syncing.
+
+Can I use ``mongosync`` to maintain a Disaster Recovery cluster?
+----------------------------------------------------------------
+
+No, you can't currently maintain a Disaster Recovery cluster with ``mongosync``, 
+since ``mongosync`` must :ref:`c2c-api-commit` in order to 
+safely accept traffic to the destination cluster. 
+For more information, see :ref:`c2c-faq-reads-writes-mongosync`.
 
 Why are the destination cluster indexes larger than the source cluster indexes?
 -------------------------------------------------------------------------------

--- a/source/includes/fact-no-mongosync-disaster-recovery.rst
+++ b/source/includes/fact-no-mongosync-disaster-recovery.rst
@@ -1,0 +1,4 @@
+Until you've called :ref:`c2c-api-commit` on ``mongosync`` and ``canWrite`` successfully 
+returns ``true``, the destination cluster cannot be used to accept 
+application read or write traffic. 
+Do not use ``mongosync`` for maintaining Disaster Recovery clusters.

--- a/source/index.txt
+++ b/source/index.txt
@@ -13,6 +13,10 @@ enable {+c2c-product-name+} with the :ref:`mongosync <c2c-mongosync>` utility.
 
 For an overview of the ``mongosync`` process, see :ref:`about-mongosync`.
 
+.. important::
+
+   .. include:: /includes/fact-no-mongosync-disaster-recovery.rst
+
 To get started with ``mongosync``, refer to the :ref:`Quick Start Guide
 <c2c-quickstart>`. For more detailed information, refer to the
 :ref:`c2c-install` or :ref:`c2c-connecting` page that best fits your

--- a/source/quickstart.txt
+++ b/source/quickstart.txt
@@ -41,6 +41,10 @@ the rest of the {+c2c-product-name+} documentation.
   ``mongosync`` syncs writes on the source cluster for the 
   duration of the migration until commit is called.
 
+.. important::
+
+   .. include:: /includes/fact-no-mongosync-disaster-recovery.rst
+
 Follow the instructions below to set up {+c2c-product-name+}, connect
 your clusters, and synchronize your data.
 

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -215,9 +215,9 @@ invalid index options on the destination.
 Considerations for Continuous Sync
 ----------------------------------
 
-For any continuous synchronization use cases with ``mongosync``, ensure that 
-``mongosync`` commits before cutting over from the source to the 
-destination.
+.. important::
+
+   .. include:: /includes/fact-no-mongosync-disaster-recovery.rst
 
 If the source cluster shuts down before ``mongosync`` can commit, such as in 
 a disaster scenario, the destination cluster might not have a consistent 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.10`:
 - [DOCSP-48525-disaster-recovery-faq-entry (#679)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/679)

<!--- Backport version: 9.6.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)