### PR TITLE
DOCSP-40664-verify-signature-v1.8-backport (686)

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -14,6 +14,7 @@ intersphinx = [ "https://www.mongodb.com/docs/atlas/objects.inv",
 
 toc_landing_pages = ["/quickstart",
                      "/installation",
+                     "/installation/verify",
                      "reference/reference",
                      "/connecting",
                      "/topologies",

--- a/source/includes/verification-gpg-results.rst
+++ b/source/includes/verification-gpg-results.rst
@@ -1,0 +1,17 @@
+If the key imports successfully, the command returns:
+
+.. code-block:: sh
+   :copyable: false
+
+   gpg: key 3132835C1D925D5B: public key "MongoDB CLI Tools Release Signing Key <packaging@mongodb.com>" imported
+   gpg: Total number processed: 1
+   gpg:               imported: 1
+
+If you have previously imported the key, the command returns:
+
+.. code-block:: sh
+   :copyable: false
+
+   gpg: key 3132835C1D925D5B: "MongoDB CLI Tools Release Signing Key <packaging@mongodb.com>" not changed
+   gpg: Total number processed: 1
+   gpg:              unchanged: 1

--- a/source/includes/verify-signatures-before-you-begin.rst
+++ b/source/includes/verify-signatures-before-you-begin.rst
@@ -1,0 +1,3 @@
+If you don't have ``mongosync`` installed, download the ``mongosync``
+package from the `Download Center
+<https://www.mongodb.com/try/download/relational-migrator?jmp=docs>`__.

--- a/source/includes/verify-signatures-intro.rst
+++ b/source/includes/verify-signatures-intro.rst
@@ -1,0 +1,4 @@
+The MongoDB release team digitally signs ``mongosync`` packages to
+certify that the packages are a valid and unaltered MongoDB release.
+Before you install ``mongosync``, you can use the digital signature to
+validate the package.

--- a/source/installation.txt
+++ b/source/installation.txt
@@ -24,3 +24,4 @@ These documents provide instructions to install {+c2c-full-product-name+}.
 
    Linux </installation/install-on-linux>
    macOS </installation/install-on-macos>
+   Verify Packages </installation/verify>

--- a/source/installation/verify.txt
+++ b/source/installation/verify.txt
@@ -1,0 +1,33 @@
+.. _c2c-verify-signature:
+
+======================================
+Verify Integrity of mongosync Packages
+======================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. include:: /includes/verify-signatures-intro.rst
+
+To learn how to verify ``mongosync`` packages, see the corresponding
+page for your verification method:
+
+- :ref:`c2c-verify-signatures-macos`
+
+- :ref:`c2c-verify-signatures-gpg`
+
+- :ref:`c2c-verify-signatures-rpm`
+
+.. toctree::
+   :titlesonly:
+
+   macOS </installation/verify/macos>
+   Linux </installation/verify/gpg>
+   RHEL </installation/verify/rpm>

--- a/source/installation/verify/gpg.txt
+++ b/source/installation/verify/gpg.txt
@@ -1,0 +1,89 @@
+.. _c2c-verify-signatures-gpg:
+
+================================
+Verify Packages with GPG (Linux)
+================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. include:: /includes/verify-signatures-intro.rst
+
+This page describes how to use GPG to verify Linux packages.
+
+Before you Begin
+----------------
+
+.. include:: /includes/verify-signatures-before-you-begin.rst
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+
+   .. step:: Import the MongoDB Server Tools public key
+
+      .. code-block:: sh
+
+         curl https://pgp.mongodb.com/server-Tools.asc | gpg --import
+
+      .. include:: /includes/verification-gpg-results.rst
+
+   .. step:: Download the mongosync public signature
+
+      To download the ``mongosync`` public signature, run the following
+      command, replacing the placeholder values with your platform,
+      architecture, and ``mongosync`` version:
+
+      .. code-block:: sh
+
+         curl -LO https://s3.amazonaws.com/downloads.mongodb.org/tools/mongosync/mongosync-<platform>-<architecture>-<version>.tgz.sig
+         
+      .. example::
+
+         The following URL contains the signature file for ``mongosync``
+         on Amazon Linux 2, version {+latest-version+}:
+
+         ``https://s3.amazonaws.com/downloads.mongodb.org/tools/mongosync/mongosync-amazon2-x86_64-{+latest-version+}.tgz.sig``
+
+   .. step:: Verify the package
+
+      .. code-block:: sh
+
+         gpg --verify <path_to_signature_file> <path_to_mongosync_package>
+
+      If the package is signed by MongoDB, the command returns:
+      
+      .. code-block:: sh
+         :copyable: false
+
+         gpg: Signature made Wed 19 Feb 2025 02:19:15 PM EST
+         gpg:                using RSA key D4E45C292A5C94962F0D10E13132835C1D925D5B
+         gpg: Good signature from "MongoDB CLI Tools Release Signing Key <packaging@mongodb.com>" [unknown]
+         
+      If the package is signed but the signing key is not added to your
+      local ``trustdb``, the command returns:
+
+      .. code-block:: sh
+         :copyable: false
+
+         gpg: WARNING: This key is not certified with a trusted signature!
+         gpg:          There is no indication that the signature belongs to the owner.
+         
+      If the package is not properly signed, the command returns an
+      error message:
+
+      .. code-block:: sh
+         :copyable: false
+
+         gpg: Signature made Wed 19 Feb 2025 02:19:15 PM EST
+         gpg:                using RSA key D4E45C292A5C94962F0D10E13132835C1D925D5B
+         gpg: BAD signature from "MongoDB CLI Tools Release Signing Key <packaging@mongodb.com>" [unknown]

--- a/source/installation/verify/macos.txt
+++ b/source/installation/verify/macos.txt
@@ -1,0 +1,45 @@
+.. _c2c-verify-signatures-macos:
+
+================================
+Verify mongosync Binary on macOS
+================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. include:: /includes/verify-signatures-intro.rst
+
+The ``mongosync`` ``.zip`` download for macOS is notarized. This page
+describes how to use ``codesign`` to verify the integrity of the
+unzipped  ``mongosync`` binary.
+
+Before you Begin
+----------------
+
+.. include:: /includes/verify-signatures-before-you-begin.rst
+
+Steps
+-----
+
+To verify the ``mongosync`` binary, run:
+
+.. code-block:: sh
+
+   codesign -dv --verbose=4 <path_to_binary>
+
+If the binary is signed by MongoDB, the output includes the following
+information:
+
+.. code-block:: sh
+   :copyable: false
+
+   Authority=Developer ID Application: MongoDB, Inc. (4XWMY46275)
+   Authority=Developer ID Certification Authority
+   Authority=Apple Root CA

--- a/source/installation/verify/rpm.txt
+++ b/source/installation/verify/rpm.txt
@@ -1,0 +1,54 @@
+.. _c2c-verify-signatures-rpm:
+
+==========================
+Verify RPM Packages (RHEL)
+==========================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. facet::
+   :name: genre
+   :values: tutorial
+
+.. include:: /includes/verify-signatures-intro.rst
+
+This page describes how to verify ``.rpm`` packages on RHEL operating
+systems.
+
+Before you Begin
+----------------
+
+.. include:: /includes/verify-signatures-before-you-begin.rst
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+
+   .. step:: Import the MongoDB Server Tools public key in gpg and rpm
+
+      .. code-block:: sh
+
+         curl https://pgp.mongodb.com/server-Tools.asc | gpg --import
+         
+         rpm --import https://pgp.mongodb.com/server-Tools.asc
+
+      .. include:: /includes/verification-gpg-results.rst
+
+   .. step:: Verify the rpm file
+
+      .. code-block:: sh
+
+         rpm --checksig <path_to_mongosync_rpm_file>
+
+      If the file is signed, the command returns:
+
+      .. code-block:: sh
+         :copyable: false
+
+         <path_to_mongosync_rpm_file> digests signatures OK


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.8`:
 - [DOCSP-40664-verify-signature (#686)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/686)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)