### PR TITLE
DOCSP-48653: Make it clear the embedded verifier is on by default for sharded clusters

### DIFF
--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -20,7 +20,9 @@ Verify with Embedded Verifier
 
 ``mongosync`` includes an embedded verifier to perform a series
 of checks on the destination cluster to verify the sync of
-supported collections. 
+supported collections. Starting in version 1.9, ``mongosync`` enables
+the verifier by default on replica set clusters. In version 1.10, 
+``mongosync`` enables the verifier by default on sharded clusters.
 
 .. note:: 
 
@@ -75,9 +77,6 @@ Steps
       .. literalinclude:: /includes/api/responses/success.json
          :language: json
          :copyable: false
-
-      Note, the verifier is enabled by default for replica set
-      migrations.
 
    .. step:: Examine Progress
 

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -17,12 +17,16 @@ Verify with Embedded Verifier
    :depth: 1
    :class: singlecol
 
+.. versionadded:: 1.9
 
 ``mongosync`` includes an embedded verifier to perform a series
 of checks on the destination cluster to verify the sync of
-supported collections. Starting in version 1.9, ``mongosync`` enables
-the verifier by default on replica set clusters. In version 1.10, 
-``mongosync`` enables the verifier by default on sharded clusters.
+supported collections. 
+
+``mongosync`` enables the verifier by default on replica set clusters. 
+
+Starting in version 1.10, ``mongosync`` enables the verifier by 
+default on sharded clusters.
 
 .. note:: 
 
@@ -33,8 +37,6 @@ the verifier by default on replica set clusters. In version 1.10,
    this, in rare cases, discrepancies in document field order between the source 
    cluster’s nodes can cause the embedded verifier to fail the migration, even 
    if ``mongosync`` copied the documents correctly.
-
-.. versionadded:: 1.9
 
 About this Task
 ---------------

--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -21,9 +21,8 @@ Verify with Embedded Verifier
 
 ``mongosync`` includes an embedded verifier to perform a series
 of checks on the destination cluster to verify the sync of
-supported collections. 
-
-``mongosync`` enables the verifier by default on replica set clusters. 
+supported collections. ``mongosync`` enables the verifier by 
+default on replica set clusters. 
 
 Starting in version 1.10, ``mongosync`` enables the verifier by 
 default on sharded clusters.

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -27,8 +27,8 @@ Upgrades to Embedded Verifier
 
 - .. include:: /includes/verify-reversible-migrations.rst
 
-- ``mongosync`` now supports the embedded verifier by default on
-  sharded clusters.
+- ``mongosync`` now enables the embedded verifier on
+  sharded clusters by default.
 
 .. _c2c-older-version-support:
 

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -27,6 +27,9 @@ Upgrades to Embedded Verifier
 
 - .. include:: /includes/verify-reversible-migrations.rst
 
+- ``mongosync`` now supports the embedded verifier by default on
+  sharded clusters.
+
 .. _c2c-older-version-support:
 
 Older Version Support

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -27,7 +27,7 @@ Upgrades to Embedded Verifier
 
 - .. include:: /includes/verify-reversible-migrations.rst
 
-- ``mongosync`` now enables the embedded verifier on
+- ``mongosync`` enables the embedded verifier on
   sharded clusters by default.
 
 .. _c2c-older-version-support:


### PR DESCRIPTION
Backport to 1.10

Clarifies that embedded verifier is on by default for sharded clusters.

https://jira.mongodb.org/browse/DOCSP-48653

- https://deploy-preview-696--docs-cluster-to-cluster-sync.netlify.app/reference/verification/embedded/
- https://deploy-preview-696--docs-cluster-to-cluster-sync.netlify.app/release-notes/1.10/#upgrades-to-embedded-verifier

