### PR TITLE
DOCSP-48662: Fix inaccurate wording on Live Upgrades notice

### DIFF
--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -19,8 +19,8 @@ Live Upgrades
 
 .. important::
 
-   ``mongosync`` does not support live upgrades due
-   to the expanded permissions required for mongosync 1.11. To upgrade to the
+   ``mongosync`` does not support live upgrades to version 1.11 due
+   to the expanded permissions required for ``mongosync 1.11``. To upgrade to the
    most recent version, see :ref:`c2c-release-version-numbers`. 
 
 

--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -20,7 +20,7 @@ Live Upgrades
 .. important::
 
    ``mongosync`` does not support live upgrades to version 1.11 due
-   to the expanded permissions required for ``mongosync 1.11``. To upgrade to the
+   to the expanded permissions required for ``mongosync`` 1.11. To upgrade to the
    most recent version, see :ref:`c2c-release-version-numbers`. 
 
 

--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -19,7 +19,7 @@ Live Upgrades
 
 .. important::
 
-   Starting in version 1.11, ``mongosync`` does not support live upgrades due
+   ``mongosync`` does not support live upgrades due
    to the expanded permissions required for mongosync 1.11. To upgrade to the
    most recent version, see :ref:`c2c-release-version-numbers`. 
 


### PR DESCRIPTION
Fix inaccurate wording.

Backport to prev versions (1.11?)

https://deploy-preview-698--docs-cluster-to-cluster-sync.netlify.app/reference/live-upgrade/

https://jira.mongodb.org/browse/DOCSP-48662