### PR TITLE
DOCSP-48609-add-mongosync-notes-v1.11-backport (691)

### DIFF
--- a/source/reference/limitations.txt
+++ b/source/reference/limitations.txt
@@ -135,6 +135,9 @@ Sharded Clusters
      starting ``mongosync``. This gives the cluster time to
      finish any in progress chunk migrations.
 
+- ``mongosync`` doesn't support running the command :dbcommand:`transitionFromDedicatedConfigServer`
+  during execution.
+
 - You must not run the :dbcommand:`moveChunk` and
   :dbcommand:`moveRange` commands on the source or destination clusters.
 - The shard key cannot be :ref:`refined <shard-key-refine>` while

--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -136,6 +136,18 @@ primary shard to each database by means of a round-robin.
    restart the migration from the start. For more information, see
    :ref:`c2c-sharded-limitations`. 
 
+Config Shard Cluster
+''''''''''''''''''''
+
+Starting in 8.0, MongoDB introduces support for config shard clusters, also known
+as embedded config server clusters.
+
+``mongosync`` supports sync from dedicated config server sharded clusters to 
+embedded config server sharded clusters and vice versa. Additionally, ``mongosync`` 
+supports sync from replica sets to config sharded clusters, but not vice versa.
+
+To learn more about embedded config servers, see :ref:`config-shard-concept`.
+
 Multiple Clusters
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48609-add-mongosync-notes (#691)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/691)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)