### PR TITLE
DOCSP-48515-Source-destination-balancing-v1.11-backport (678)

### DIFF
--- a/source/reference/mongosync/mongosync-behavior.txt
+++ b/source/reference/mongosync/mongosync-behavior.txt
@@ -113,6 +113,17 @@ destination cluster.
 Chunk Distribution
 ''''''''''''''''''
 
+.. important::
+   
+   Even if the source cluster is balanced, ``mongosync`` doesn't
+   ensure balance of the destination cluster. Because ``mongosync``
+   doesn't support the execution of sharding operations during
+   migration, you must wait until it is safe to accept writes 
+   to rebalance the destination cluster. See :ref:`sharding-balancing`
+   for guidance on how to rebalance the cluster and 
+   :ref:`sharded cluster limitations <c2c-sharded-limitations>`
+   for information on sharded cluster limitations in ``mongosync``.
+
 ``mongosync`` does not preserve chunk distribution from the source to
 the destination, even with multiple ``mongosync`` instances. It is not
 possible to reproduce a particular pre-split of chunks from a source


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48515: Source/destination balancing (#678)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/678)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)