### PR TITLE
DOCSP-48662-Fix-inaccurate-wording-on-Live-Upgrades-notice-v1.11-backport (698)

### DIFF
--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -19,8 +19,8 @@ Live Upgrades
 
 .. important::
 
-   Starting in version 1.11, ``mongosync`` does not support live upgrades due
-   to the expanded permissions required for mongosync 1.11. To upgrade to the
+   ``mongosync`` does not support live upgrades to version 1.11 due
+   to the expanded permissions required for ``mongosync`` 1.11. To upgrade to the
    most recent version, see :ref:`c2c-release-version-numbers`. 
 
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48662: Fix inaccurate wording on Live Upgrades notice (#698)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/698)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)