### PR TITLE
DOCSP-48653-Make-it-clear-the-embedded-verifier-is-on-by-default-for-sharded-clusters-v1.11-backport (696)

### DIFF
--- a/source/reference/verification/embedded.txt
+++ b/source/reference/verification/embedded.txt
@@ -17,10 +17,15 @@ Verify with Embedded Verifier
    :depth: 1
    :class: singlecol
 
+.. versionadded:: 1.9
 
 ``mongosync`` includes an embedded verifier to perform a series
 of checks on the destination cluster to verify the sync of
-supported collections. 
+supported collections. ``mongosync`` enables the verifier by 
+default on replica set clusters. 
+
+Starting in version 1.10, ``mongosync`` enables the verifier by 
+default on sharded clusters.
 
 .. note:: 
 
@@ -31,8 +36,6 @@ supported collections.
    this, in rare cases, discrepancies in document field order between the source 
    cluster’s nodes can cause the embedded verifier to fail the migration, even 
    if ``mongosync`` copied the documents correctly.
-
-.. versionadded:: 1.9
 
 About this Task
 ---------------
@@ -75,9 +78,6 @@ Steps
       .. literalinclude:: /includes/api/responses/success.json
          :language: json
          :copyable: false
-
-      Note, the verifier is enabled by default for replica set
-      migrations.
 
    .. step:: Examine Progress
 

--- a/source/release-notes/1.10.txt
+++ b/source/release-notes/1.10.txt
@@ -27,6 +27,9 @@ Upgrades to Embedded Verifier
 
 - .. include:: /includes/verify-reversible-migrations.rst
 
+- ``mongosync`` enables the embedded verifier on
+  sharded clusters by default.
+
 .. _c2c-older-version-support:
 
 Older Version Support


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48653: Make it clear the embedded verifier is on by default for sharded clusters (#696)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/696)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)