### PR TITLE
DOCSP-48963-remove-live-upgrade-blurb-v1.13-backport (716)

### DIFF
--- a/source/reference/live-upgrade.txt
+++ b/source/reference/live-upgrade.txt
@@ -17,13 +17,6 @@ Live Upgrades
    :depth: 2
    :class: singlecol
 
-.. important::
-
-   Starting in version 1.11, ``mongosync`` does not support live upgrades due
-   to the expanded permissions required for mongosync 1.11. To upgrade to the
-   most recent version, see :ref:`c2c-release-version-numbers`. 
-
-
 Starting in ``mongosync`` 1.7.0, you can live upgrade ``mongosync`` without
 restarting data synchronization operations from the beginning.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [remove blurb (#716)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/716)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)