### PR TITLE
DOCSP-47851-update-enableUserWriteBlocking-values

### DIFF
--- a/source/includes/api/requests/start-reversible.sh
+++ b/source/includes/api/requests/start-reversible.sh
@@ -4,5 +4,5 @@ curl localhost:27182/api/v1/start -XPOST \
       "source": "cluster0",
       "destination": "cluster1",
       "reversible": true,
-      "enableUserWriteBlocking": true
+      "enableUserWriteBlocking": "sourceAndDestination"
    } '

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -174,7 +174,7 @@ Request Body Parameters
        reversed.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``true``.
+       to ``sourceAndDestination``.
 
        This option is not supported for the following configurations:
 

--- a/source/reference/cutover-process.txt
+++ b/source/reference/cutover-process.txt
@@ -137,7 +137,7 @@ Steps
       :ref:`manually migrate PQS <c2c-migrate-pqs>` to your destination cluster.
 
       If you previously set ``enableUserWriteBlocking``
-      to ``true``, ``mongosync`` blocks writes on the source cluster
+      to ``sourceAndDestination``, ``mongosync`` blocks writes on the source cluster
       once you complete this step.
 
    .. step:: Wait until you can perform writes on the destination cluster.

--- a/source/topologies/multiple-mongosyncs.txt
+++ b/source/topologies/multiple-mongosyncs.txt
@@ -163,11 +163,11 @@ Use ``curl`` or another HTTP client to issue the :ref:`start
 
    curl mongosync01Host:27601/api/v1/start -XPOST --data \
         '{ "source": "cluster0", "destination": "cluster1", \
-           "reversible": false, "enableUserWriteBlocking": false }'
+           "reversible": false, "enableUserWriteBlocking": "none" }'
 
    curl mongosync02Host:27602/api/v1/start -XPOST --data \
         '{ "source": "cluster0", "destination": "cluster1", \
-           "reversible": false, "enableUserWriteBlocking": false }'
+           "reversible": false, "enableUserWriteBlocking": "none" }'
 
 The ``start`` command options must be the same for all of the ``mongosync``
 instances.


### PR DESCRIPTION
## DESCRIPTION

Updates outdated use of enableUserWriteBlocking from "true" and "false" to "enableUserWriteBlocking" and "none"

## STAGING

https://deploy-preview-718--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/
https://deploy-preview-718--docs-cluster-to-cluster-sync.netlify.app/reference/cutover-process/#send-a-commit-request-to-mongosync.
https://deploy-preview-718--docs-cluster-to-cluster-sync.netlify.app/topologies/multiple-mongosyncs/#start-multiple-mongosync-instances

## JIRA

https://jira.mongodb.org/browse/DOCSP-47851

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
