### PR TITLE
1.13.1-Release-v1.13-backport (720)

### DIFF
--- a/source/release-notes/1.13.txt
+++ b/source/release-notes/1.13.txt
@@ -11,7 +11,21 @@ Release Notes for mongosync 1.13
    :class: singlecol
 
 This page describes changes and new features introduced in  
-{+c2c-full-product-name+} 1.13.
+{+c2c-full-product-name+} 1.13 and subsequent patch releases.
+
+Patch Releases
+--------------
+
+1.13.1 Release
+~~~~~~~~~~~~~~
+
+**April 10, 2025**
+
+Issues Fixed:
+
+- Fixed a bug introduced in ``mongosync`` 1.10 where ``mongosync`` failed
+  to retry on some transient network errors, which could cause it to unnecessarily 
+  exit with an error.
 
 .. _1.13.0-c2c-release-notes:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [1.13.1 Release (#720)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/720)

<!--- Backport version: 9.6.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)