### PR TITLE
DOCSP-48735-clarify-required-permissions-v1.13-backport (719)

### DIFF
--- a/source/connecting/onprem-to-atlas.txt
+++ b/source/connecting/onprem-to-atlas.txt
@@ -45,13 +45,13 @@ Roles
 
 .. include:: /includes/fact-permissions-body.rst
 
-The self-managed permissions are:
+The self-managed permissions for the source cluster are:
 
-.. include:: /includes/table-permissions-self-hosted.rst
+.. include:: /includes/table-permissions-self-hosted-onprem-to-atlas.rst
 
-The Atlas permissions are:
+The Atlas permissions for the destination cluster are:
 
-.. include:: /includes/table-permissions-atlas.rst
+.. include:: /includes/table-permissions-atlas-onprem-to-atlas.rst
 
 Behavior
 --------

--- a/source/includes/table-permissions-atlas-onprem-to-atlas.rst
+++ b/source/includes/table-permissions-atlas-onprem-to-atlas.rst
@@ -1,0 +1,24 @@
+..
+   Comment: The nested lists need blank lines before and after each list
+            plus extra indents 
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 20
+
+   * - Sync Type
+     - Required Destination Permissions
+
+   * - Default
+     - - atlasAdmin
+       - :authaction:`bypassWriteBlockingMode`
+       
+   * - Dual write-blocking, reversing, or multiple reversals
+     - - atlasAdmin
+       - :authaction:`bypassWriteBlockingMode`
+
+For details on Atlas roles, see: :atlas:`Built-In Roles and Privileges
+</mongodb-users-roles-and-privileges/>`.
+
+To update Atlas user permissions, see:
+:atlas:`Manage Access to a Project </access/manage-project-access/>`.

--- a/source/includes/table-permissions-self-hosted-onprem-to-atlas.rst
+++ b/source/includes/table-permissions-self-hosted-onprem-to-atlas.rst
@@ -1,0 +1,41 @@
+..
+   Comment: The nested lists need extra indents.  Keep roles in alphabetic
+            order.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+
+   * - Sync Type
+     - Required Source Permissions
+
+   * - Default
+     - - :authrole:`backup`
+       - :authrole:`clusterMonitor`
+       - :authrole:`readAnyDatabase`
+
+   * - Dual Write-Blocking
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+
+   * - Reversing
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+
+   * - Multiple Reversals
+     - - :authrole:`backup`
+       - :authrole:`clusterManager`
+       - :authrole:`clusterMonitor`
+       - :authrole:`dbAdminAnyDatabase`
+       - :authrole:`readWriteAnyDatabase`
+       - :authrole:`restore`
+
+For details on server roles, see: :ref:`authorization`.
+
+To update user permissions, see: :dbcommand:`grantRolesToUser`.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [DOCSP-48735-clarify-required-permissions (#719)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/719)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)