### PR TITLE
DOCSP-48987-update-server-compat-v1.11-backport (715)

### DIFF
--- a/source/reference/supported-server-version.txt
+++ b/source/reference/supported-server-version.txt
@@ -50,7 +50,7 @@ clusters:
      - 6.0
 
    * - 7.0
-     - 7.0.13
+     - 7.0.14
      - 6.0
 
 .. _c2c-sync-different-versions:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [change version (#715)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/715)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)