### PR TITLE
DOCSP-37757-add-regex-info

### DIFF
--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -85,8 +85,7 @@ Filters have the following syntax:
        }
     ]
 
-To learn more about syntax for ``pattern`` and ``options`` for regular
-expression filtering, see :ref:`c2c-filter-regex`. 
+To learn more about the ``pattern`` and ``options`` regular expression syntax, see :ref:`c2c-filter-regex`. 
 
 Filters must include either the ``database`` field or the ``databaseRegex`` field.
 

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -85,7 +85,7 @@ Filters have the following syntax:
        }
     ]
 
-To learn more about syntax for ``regex-pattern`` and options for regular
+To learn more about syntax for ``pattern`` and ``options`` for regular
 expression filtering, see :ref:`c2c-filter-regex`. 
 
 Filters must include either the ``database`` field or the ``databaseRegex`` field.

--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -85,6 +85,9 @@ Filters have the following syntax:
        }
     ]
 
+To learn more about syntax for ``regex-pattern`` and options for regular
+expression filtering, see :ref:`c2c-filter-regex`. 
+
 Filters must include either the ``database`` field or the ``databaseRegex`` field.
 
 If you need the filter to match specific collections, you can use either 

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -38,8 +38,7 @@ you can use regular expressions:
 
 The regular expression pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
 
-The following ``options`` are available for use with regular
-expressions:
+Regular expressions in filter documents use the following ``options``:
 
 .. list-table::
    :header-rows: 1

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -38,7 +38,9 @@ you can use regular expressions:
 
 The regular expression pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
 
-Regular expressions in filter documents use the following ``options``:
+Regular expressions in filter documents use ``options`` listed in the :query:`regex
+<$regex>` guide. ``options`` is a string of concatenated options. For example, to specify
+the ``i`` and ``s`` options, pass in "si" to ``options``.
 
 .. list-table::
    :header-rows: 1
@@ -141,8 +143,8 @@ creating a series of filters for individual databases or groups of collections.
 Details
 =======
 
-Regular Expression Options
---------------------------
+Regular Expression Options Example
+----------------------------------
 
 ``databaseRegex`` and ``collectionsRegex`` each supports an ``options`` field,
 which you can use to configure regular expression options.
@@ -151,7 +153,10 @@ Internally, ``mongosync`` passes the filter and options to the
 with Filtred Sync.
 
 For example, this filter would match collections in the ``sales`` database
-that begin start with the ``accounts_`` string:
+that begin with the ``accounts_`` string. The filter also specifies the option ``m`` to
+match characters at the beginning or end of each line for strings with multiline values, and the
+option ``s`` to allow the dot character to match all characters including newline
+characters.
 
 .. code-block:: json
 

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -36,6 +36,63 @@ you can use regular expressions:
       }
    }
 
+The regular express pattern you pass into a filter must follow the :query:`regular
+expression <$regex>` syntax supported by the MongoDB server.
+
+The following ``options`` are available for use with regular
+expressions:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Option
+     - Description
+
+   * - ``i``
+     - Case insensitivity to match upper and lower cases. For an
+       example, see :ref:`regex-case-insensitive`.
+
+   * - ``m``
+
+     - For patterns that include anchors (i.e. ``^`` for the start,
+       ``$`` for the end), match at the beginning or end of each
+       line for strings with multiline values. Without this option,
+       these anchors match at beginning or end of the string. For an
+       example, see :ref:`regex-multiline-match`.
+
+       If the pattern contains no anchors or if the string value has
+       no newline characters (e.g. ``\n``), the ``m`` option has no
+       effect.
+
+   * - ``x``
+
+     - "Extended" capability to ignore all white space characters in
+       the ``$regex`` pattern unless escaped or included in a
+       character class.
+
+       Additionally, it ignores characters in-between and including
+       an un-escaped hash/pound (``#``) character and the next new
+       line, so that you may include comments in complicated
+       patterns. This only applies to data characters; white space
+       characters may never appear within special character
+       sequences in a pattern.
+
+       The ``x`` option does not affect the handling of the VT
+       character (i.e. code 11).
+
+   * - ``s``
+
+     - Allows the dot character (i.e. ``.``) to match all
+       characters *including* newline characters. For an example,
+       see :ref:`regex-dot-new-line`.
+
+   * - ``u``
+
+     -  Supports Unicode. This flag is accepted, but is redundant. UTF is set by 
+        default in the ``$regex`` operator, making the ``u`` option 
+        unnecessary. 
+
 Regular expressions in filter documents use the following fields:
 
 .. list-table::

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -40,7 +40,7 @@ The regular expression pattern you pass into a filter must follow the :query:`re
 
 Regular expressions in filter documents use ``options`` listed in the :query:`regex
 <$regex>` guide. ``options`` is a string of concatenated options. For example, to specify
-the ``i`` and ``s`` options, pass in "si" to ``options``. The order of concatenated
+the ``i`` and ``s`` options, pass in ``"si"`` to ``options``. The order of concatenated
 options does not matter.
 
 .. list-table::

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -43,57 +43,6 @@ Regular expressions in filter documents use ``options`` listed in the :query:`re
 the ``i`` and ``s`` options, pass in ``"si"`` to ``options``. The order of concatenated
 options does not matter.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 20 80
-
-   * - Option
-     - Description
-
-   * - ``i``
-     - Case insensitivity to match upper and lower cases. For an
-       example, see :ref:`regex-case-insensitive`.
-
-   * - ``m``
-
-     - For patterns that include anchors (i.e. ``^`` for the start,
-       ``$`` for the end), match at the beginning or end of each
-       line for strings with multiline values. Without this option,
-       these anchors match at beginning or end of the string. For an
-       example, see :ref:`regex-multiline-match`.
-
-       If the pattern contains no anchors or if the string value has
-       no newline characters (e.g. ``\n``), the ``m`` option has no
-       effect.
-
-   * - ``x``
-
-     - "Extended" capability to ignore all white space characters in
-       the ``$regex`` pattern unless escaped or included in a
-       character class.
-
-       Additionally, it ignores characters in-between and including
-       an un-escaped hash/pound (``#``) character and the next new
-       line, so that you may include comments in complicated
-       patterns. This only applies to data characters; white space
-       characters may never appear within special character
-       sequences in a pattern.
-
-       The ``x`` option does not affect the handling of the VT
-       character (i.e. code 11).
-
-   * - ``s``
-
-     - Allows the dot character (i.e. ``.``) to match all
-       characters *including* newline characters. For an example,
-       see :ref:`regex-dot-new-line`.
-
-   * - ``u``
-
-     -  Supports Unicode. This flag is accepted, but is redundant. UTF is set by 
-        default in the ``$regex`` operator, making the ``u`` option 
-        unnecessary. 
-
 Regular expressions in filter documents use the following fields:
 
 .. list-table::

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -40,7 +40,8 @@ The regular expression pattern you pass into a filter must follow the :query:`re
 
 Regular expressions in filter documents use ``options`` listed in the :query:`regex
 <$regex>` guide. ``options`` is a string of concatenated options. For example, to specify
-the ``i`` and ``s`` options, pass in "si" to ``options``.
+the ``i`` and ``s`` options, pass in "si" to ``options``. The order of concatenated
+options does not matter.
 
 .. list-table::
    :header-rows: 1

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -36,7 +36,7 @@ you can use regular expressions:
       }
    }
 
-The regular express pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
+The regular expression pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
 
 The following ``options`` are available for use with regular
 expressions:

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -36,8 +36,7 @@ you can use regular expressions:
       }
    }
 
-The regular express pattern you pass into a filter must follow the :query:`regular
-expression <$regex>` syntax supported by the MongoDB server.
+The regular express pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
 
 The following ``options`` are available for use with regular
 expressions:


### PR DESCRIPTION
## DESCRIPTION

Adds details on regex syntax in c2c

## STAGING

https://deploy-preview-731--docs-cluster-to-cluster-sync.netlify.app/reference/collection-level-filtering/
https://deploy-preview-731--docs-cluster-to-cluster-sync.netlify.app/reference/collection-level-filtering/filter-regex/


## JIRA

https://jira.mongodb.org/browse/DOCSP-37757

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)