### PR TITLE
DOCSP-48400-confusion-multi-shard-key

### DIFF
--- a/source/includes/intro-start-api-example-intro.rst
+++ b/source/includes/intro-start-api-example-intro.rst
@@ -1,3 +1,2 @@
-The following example starts a sync job between ``cluster0`` and
-``cluster1``.  The source cluster is ``cluster0`` and the destination
-cluster is ``cluster1``.
+The following example starts a sync job between the source cluster ``cluster0`` and the
+destination cluster ``cluster1``.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -365,6 +365,10 @@ Response:
 Start Sync from Replica Set to Sharded Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The following example starts a sync job between the replica set ``cluster0`` and the
+sharded cluster ``cluster1``. The source cluster is ``cluster0`` and the destination
+cluster is ``cluster1``. The ``key`` array in this example defines the shard key ``{"location": 1, "region": 1 }``.
+
 Request:
 
 .. literalinclude:: /includes/api/requests/start-rs-shard.sh

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -366,8 +366,8 @@ Start Sync from Replica Set to Sharded Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example starts a sync job between the replica set ``cluster0`` and the
-sharded cluster ``cluster1``. The source cluster is ``cluster0`` and the destination
-cluster is ``cluster1``. The ``key`` array in this example defines the shard key ``{"location": 1, "region": 1 }``.
+sharded cluster ``cluster1``. The ``key`` array in this example defines the shard key
+``{"location": 1, "region": 1 }``.
 
 Request:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -365,8 +365,8 @@ Response:
 Start Sync from Replica Set to Sharded Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following example starts a sync job between the replica set ``cluster0`` and the
-sharded cluster ``cluster1``. The ``key`` array in this example defines the shard key
+The following example starts a sync job between the source replica set ``cluster0`` and the
+destination sharded cluster ``cluster1``. The ``key`` array in this example defines the shard key
 ``{"location": 1, "region": 1 }``.
 
 Request:


### PR DESCRIPTION
## DESCRIPTION

Adds details on shard key in mongosync api example

## STAGING

https://deploy-preview-732--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/

## JIRA

https://jira.mongodb.org/browse/DOCSP-48400


## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)