### PR TITLE
DOCSP-49351-clarify-warning

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -102,8 +102,8 @@ Request Body Parameters
 
          .. include:: /includes/fact-verifier-buildIndexes
 
-         :red:`WARNING:` Do **not** manually build indexes while ``mongosync`` is 
-         performing a migration.  Wait until the migration is fully 
+         :red:`WARNING:` Do **not** manually build indexes on the destination cluster
+         while ``mongosync`` is performing a migration.  Wait until the migration is fully
          committed.
 
          For more information on the indexes it does build, see 


### PR DESCRIPTION
## DESCRIPTION

Clarify warning for manually building indexes on the destination cluster

## STAGING

https://deploy-preview-733--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/

## JIRA

https://jira.mongodb.org/browse/DOCSP-49351

## SELF-REVIEW CHECKLIST

- [ ] Does each file have 3-5 taxonomy facet tags?
  See the [taxonomy tagging instructions](https://wiki.corp.mongodb.com/display/DE/Taxonomy+tagging+instructions) and this [example PR](https://github.com/10gen/cloud-docs/pull/5042/files) 
- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## EXTERNAL REVIEW REQUIREMENTS

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
