### PR TITLE
DOCSP-49351-clarify-warning-v1.13-backport (733)

### DIFF
--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -99,8 +99,8 @@ Request Body Parameters
 
          .. include:: /includes/fact-verifier-buildIndexes
 
-         :red:`WARNING:` Do **not** manually build indexes while ``mongosync`` is 
-         performing a migration.  Wait until the migration is fully 
+         :red:`WARNING:` Do **not** manually build indexes on the destination cluster
+         while ``mongosync`` is performing a migration.  Wait until the migration is fully
          committed.
 
          For more information on the indexes it does build, see 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.13`:
 - [change warning (#733)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/733)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)