### PR TITLE
DOCSP-32849-add-reference-to-restore-role

### DIFF
--- a/source/includes/api/facts/reverse-sync-requirements.rst
+++ b/source/includes/api/facts/reverse-sync-requirements.rst
@@ -1,3 +1,3 @@
-To reverse sync, the user must have assigned the :authrole:`restore`
+To reverse sync, the user must be assigned the :authrole:`restore`
 role for both source and destination and the ``enableUserWriteBlocking``
 field must be set to ``sourceAndDestination``.

--- a/source/includes/api/facts/reverse-sync.rst
+++ b/source/includes/api/facts/reverse-sync.rst
@@ -1,0 +1,3 @@
+To reverse sync, the user must have assigned the :authrole:`restore`
+role for both source and destination and the ``enableUserWriteBlocking``
+field must be set to ``sourceAndDestination``.

--- a/source/includes/fact-permissions-body.rst
+++ b/source/includes/fact-permissions-body.rst
@@ -1,5 +1,5 @@
 The user specified in the ``mongosync`` connection string must have the
-required :ref:`user permissions <c2c-permissions-and-roles>` on the source and destination
-clusters. The permissions vary depending on your environment and if you
-want to modify write-blocking settings or use reverse sync.
-
+required :ref:`user permissions <c2c-permissions-and-roles>` on the
+source and destination clusters. The permissions vary depending on your
+environment and if you want to modify write-blocking settings or use
+reverse sync.

--- a/source/includes/fact-permissions-body.rst
+++ b/source/includes/fact-permissions-body.rst
@@ -1,5 +1,5 @@
 The user specified in the ``mongosync`` connection string must have the
-required :ref:`c2c-permissions-and-roles` on the source and destination
+required :ref:`user permissions <c2c-permissions-and-roles>` on the source and destination
 clusters. The permissions vary depending on your environment and if you
 want to modify write-blocking settings or use reverse sync.
 

--- a/source/includes/fact-permissions-body.rst
+++ b/source/includes/fact-permissions-body.rst
@@ -1,5 +1,5 @@
 The user specified in the ``mongosync`` connection string must have the
-required permissions on the source and destination clusters. The
-permissions vary depending on your environment and if you want to 
-modify write-blocking settings or use reverse sync.
+required :ref:`c2c-permissions-and-roles` on the source and destination
+clusters. The permissions vary depending on your environment and if you
+want to modify write-blocking settings or use reverse sync.
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -35,8 +35,8 @@ Permissions
 
 The user specified in the ``mongosync`` connection string must have the
 required permissions on the source and destination clusters. Refer to
-:ref:`user permissions <c2c-permissions-and-roles>` to ensure that the 
-user has the correct permissions to start the synchronization.
+:ref:`<c2c-permissions-and-roles>` to ensure that the user has the
+correct permissions to start the synchronization.
 
 Multiple ``mongosync`` Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -141,10 +141,11 @@ Request Body Parameters
          cluster while migration is in progress, and unblocks writes right
          before ``canWrite`` is ``true``.
 
-       To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``"sourceAndDestination"``.
-       
        .. include:: /includes/fact-permissions-body.rst
+       
+       To reverse sync, the user must have assigned the :authrole:`restore`
+       role for both source and destination and the ``enableUserWriteBlocking``
+       field must be set to ``"sourceAndDestination"``.
        
        To allow the source cluster to accept writes again, for example
        after running migration tests, run the following command: 
@@ -179,10 +180,11 @@ Request Body Parameters
      - If set to ``true``, enables the sync operation to be
        reversed.
 
-       To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``sourceAndDestination``.
-       
        .. include:: /includes/fact-permissions-body.rst
+       
+       To reverse sync, the user must have assigned the :authrole:`restore`
+       role for both source and destination and the ``enableUserWriteBlocking``
+       field must be set to ``sourceAndDestination``.
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -143,10 +143,12 @@ Request Body Parameters
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
        to ``"sourceAndDestination"`` and the user must have assigned the 
-       :authrole:`restore` role for both source and destination, see 
-       :ref:`c2c-permissions-and-roles` for more details. To allow the 
-       source cluster to accept writes again, for example after running 
-       migration tests, run the following command: 
+       :authrole:`restore` role for both source and destination.
+       
+       For more information, see :ref:`c2c-permissions-and-roles`.
+       
+       To allow the source cluster to accept writes again, for example
+       after running migration tests, run the following command: 
 
        .. code-block:: shell 
           
@@ -180,8 +182,9 @@ Request Body Parameters
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
        to ``sourceAndDestination`` and the user must have assigned the 
-       :authrole:`restore` role for both source and destination, see 
-       :ref:`c2c-permissions-and-roles` for more details.
+       :authrole:`restore` role for both source and destination.
+
+       For more information, see :ref:`c2c-permissions-and-roles`.
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -35,8 +35,8 @@ Permissions
 
 The user specified in the ``mongosync`` connection string must have the
 required permissions on the source and destination clusters. Refer to
-:ref:`c2c-permissions-and-roles` to ensure that the user has the correct
-permissions to start the synchronization.
+:ref:`user permissions <c2c-permissions-and-roles>` to ensure that the 
+user has the correct permissions to start the synchronization.
 
 Multiple ``mongosync`` Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -142,9 +142,11 @@ Request Body Parameters
          before ``canWrite`` is ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``"sourceAndDestination"``. To allow the source cluster 
-       to accept writes again, for example after running migration tests, 
-       run the following command: 
+       to ``"sourceAndDestination"`` and the user must have assigned the 
+       :authrole:`restore` role for both source and destination, see 
+       :ref:`c2c-permissions-and-roles` for more details. To allow the 
+       source cluster to accept writes again, for example after running 
+       migration tests, run the following command: 
 
        .. code-block:: shell 
           
@@ -177,7 +179,9 @@ Request Body Parameters
        reversed.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``sourceAndDestination``.
+       to ``sourceAndDestination`` and the user must have assigned the 
+       :authrole:`restore` role for both source and destination, see 
+       :ref:`c2c-permissions-and-roles` for more details.
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -141,11 +141,7 @@ Request Body Parameters
          cluster while migration is in progress, and unblocks writes right
          before ``canWrite`` is ``true``.
 
-       .. include:: /includes/fact-permissions-body.rst
-       
-       To reverse sync, the user must have assigned the :authrole:`restore`
-       role for both source and destination and the ``enableUserWriteBlocking``
-       field must be set to ``"sourceAndDestination"``.
+       .. include:: /includes/api/facts/reverse-sync.rst
        
        To allow the source cluster to accept writes again, for example
        after running migration tests, run the following command: 
@@ -179,12 +175,8 @@ Request Body Parameters
      - Optional
      - If set to ``true``, enables the sync operation to be
        reversed.
-
-       .. include:: /includes/fact-permissions-body.rst
        
-       To reverse sync, the user must have assigned the :authrole:`restore`
-       role for both source and destination and the ``enableUserWriteBlocking``
-       field must be set to ``sourceAndDestination``.
+       .. include:: /includes/api/facts/reverse-sync.rst
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -35,8 +35,8 @@ Permissions
 
 The user specified in the ``mongosync`` connection string must have the
 required permissions on the source and destination clusters. Refer to
-:ref:`<c2c-permissions-and-roles>` to ensure that the user has the
-correct permissions to start the synchronization.
+:ref:`c2c-permissions-and-roles` to ensure that the user has the correct
+permissions to start the synchronization.
 
 Multiple ``mongosync`` Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -142,10 +142,9 @@ Request Body Parameters
          before ``canWrite`` is ``true``.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``"sourceAndDestination"`` and the user must have assigned the 
-       :authrole:`restore` role for both source and destination.
+       to ``"sourceAndDestination"``.
        
-       For more information, see :ref:`c2c-permissions-and-roles`.
+       .. include:: /includes/fact-permissions-body.rst
        
        To allow the source cluster to accept writes again, for example
        after running migration tests, run the following command: 
@@ -181,10 +180,9 @@ Request Body Parameters
        reversed.
 
        To reverse sync, the ``enableUserWriteBlocking`` field must be set
-       to ``sourceAndDestination`` and the user must have assigned the 
-       :authrole:`restore` role for both source and destination.
-
-       For more information, see :ref:`c2c-permissions-and-roles`.
+       to ``sourceAndDestination``.
+       
+       .. include:: /includes/fact-permissions-body.rst
 
        This option is not supported for the following configurations:
 

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -141,7 +141,7 @@ Request Body Parameters
          cluster while migration is in progress, and unblocks writes right
          before ``canWrite`` is ``true``.
 
-       .. include:: /includes/api/facts/reverse-sync.rst
+       .. include:: /includes/api/facts/reverse-sync-requirements.rst
        
        To allow the source cluster to accept writes again, for example
        after running migration tests, run the following command: 
@@ -176,7 +176,7 @@ Request Body Parameters
      - If set to ``true``, enables the sync operation to be
        reversed.
        
-       .. include:: /includes/api/facts/reverse-sync.rst
+       .. include:: /includes/api/facts/reverse-sync-requirements.rst
 
        This option is not supported for the following configurations:
 


### PR DESCRIPTION
Includes reference to the need of having the `restore` role assigned to the mongosync user for reverse sync operations in the [reference/api/start](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/start/) endpoint document.

It also includes a link to the [User Permissions](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/permissions/) page in the [reference/api/reverse](https://www.mongodb.com/docs/cluster-to-cluster-sync/current/reference/api/reverse/) endpoint document.

## Jira ticket

https://jira.mongodb.org/browse/DOCSP-32849

## Staging

`start` endpoint:

https://deploy-preview-737--docs-cluster-to-cluster-sync.netlify.app/reference/api/start/

`reverse` endpoint:

https://deploy-preview-737--docs-cluster-to-cluster-sync.netlify.app/reference/api/reverse/#requirements