### PR TITLE
DOCSP-48416-add-network-compression-FAQ

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -156,8 +156,9 @@ your configuration must meet the following criteria:
 - Your cluster configurations and connection string options must share at least 
   one common compressor
 
-For more information about network compression configuration options, see  
-:option:`--networkMessageCompressors <mongos --networkMessageCompressors>`.
+For more information about network compression configuration options, see the 
+:option:`--networkMessageCompressors <mongos --networkMessageCompressors>` option
+in the Database Manual.
 
 Which security and authentication options are supported?
 --------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -144,6 +144,20 @@ error:
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 
+Does ``mongosync`` support network compression?
+-----------------------------------------------
+
+``mongosync`` supports network compression. To enable network compression,
+your configuration must meet the following criteria:
+
+- Your source and destination clusters must have network compression enabled
+- Your source and destination cluster connection strings must include the 
+  :urioption:`compressors` connection string option
+- Your cluster configurations and connection string options must share at least 
+  one common compressor
+
+For more information about network compression configuration options, see 
+:setting:`net.compression.compressors`.
 
 Which security and authentication options are supported?
 --------------------------------------------------------

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -156,8 +156,8 @@ your configuration must meet the following criteria:
 - Your cluster configurations and connection string options must share at least 
   one common compressor
 
-For more information about network compression configuration options, see 
-:setting:`net.compression.compressors`.
+For more information about network compression configuration options, see  
+:option:`--networkMessageCompressors <mongos --networkMessageCompressors>`.
 
 Which security and authentication options are supported?
 --------------------------------------------------------


### PR DESCRIPTION
# Description
Adds an entry to the FAQ noting ``mongosync`` supports network compression.

Also, lists the configuration requirements to enable network compression.

# Staging
https://deploy-preview-738--docs-cluster-to-cluster-sync.netlify.app/faq/#does-mongosync-support-network-compression-

# JIRA
https://jira.mongodb.org/browse/DOCSP-48416