### PR TITLE
DOCSP-37757-add-regex-info-v1.12-backport (731)

### DIFF
--- a/source/reference/collection-level-filtering.txt
+++ b/source/reference/collection-level-filtering.txt
@@ -85,6 +85,8 @@ Filters have the following syntax:
        }
     ]
 
+To learn more about the ``pattern`` and ``options`` regular expression syntax, see :ref:`c2c-filter-regex`. 
+
 Filters must include either the ``database`` field or the ``databaseRegex`` field.
 
 If you need the filter to match specific collections, you can use either 

--- a/source/reference/collection-level-filtering/filter-regex.txt
+++ b/source/reference/collection-level-filtering/filter-regex.txt
@@ -36,6 +36,13 @@ you can use regular expressions:
       }
    }
 
+The regular expression pattern you pass into a filter must follow the :query:`regex <$regex>` syntax supported by the MongoDB server.
+
+Regular expressions in filter documents use ``options`` listed in the :query:`regex
+<$regex>` guide. ``options`` is a string of concatenated options. For example, to specify
+the ``i`` and ``s`` options, pass in ``"si"`` to ``options``. The order of concatenated
+options does not matter.
+
 Regular expressions in filter documents use the following fields:
 
 .. list-table::
@@ -86,8 +93,8 @@ creating a series of filters for individual databases or groups of collections.
 Details
 =======
 
-Regular Expression Options
---------------------------
+Regular Expression Options Example
+----------------------------------
 
 ``databaseRegex`` and ``collectionsRegex`` each supports an ``options`` field,
 which you can use to configure regular expression options.
@@ -96,7 +103,10 @@ Internally, ``mongosync`` passes the filter and options to the
 with Filtred Sync.
 
 For example, this filter would match collections in the ``sales`` database
-that begin start with the ``accounts_`` string:
+that begin with the ``accounts_`` string. The filter also specifies the option ``m`` to
+match characters at the beginning or end of each line for strings with multiline values, and the
+option ``s`` to allow the dot character to match all characters including newline
+characters.
 
 .. code-block:: json
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.12`:
 - [DOCSP-37757-add-regex-info (#731)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/731)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)