### PR TITLE
DOCSP-48400-confusion-multi-shard-key-v1.11-backport (732)

### DIFF
--- a/source/includes/intro-start-api-example-intro.rst
+++ b/source/includes/intro-start-api-example-intro.rst
@@ -1,3 +1,2 @@
-The following example starts a sync job between ``cluster0`` and
-``cluster1``.  The source cluster is ``cluster0`` and the destination
-cluster is ``cluster1``.
+The following example starts a sync job between the source cluster ``cluster0`` and the
+destination cluster ``cluster1``.

--- a/source/reference/api/start.txt
+++ b/source/reference/api/start.txt
@@ -360,6 +360,10 @@ Response:
 Start Sync from Replica Set to Sharded Cluster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The following example starts a sync job between the source replica set ``cluster0`` and the
+destination sharded cluster ``cluster1``. The ``key`` array in this example defines the shard key
+``{"location": 1, "region": 1 }``.
+
 Request:
 
 .. literalinclude:: /includes/api/requests/start-rs-shard.sh


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.11`:
 - [DOCSP-48400-confusion-multi-shard-key (#732)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/732)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)