### PR TITLE
DOCSP-48416-add-network-compression-FAQ-v1.9-backport (738)

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -141,6 +141,21 @@ error:
 ``mongosync`` accepts all other :ref:`connection string options
 <mongodb-uri>`.
 
+Does ``mongosync`` support network compression?
+-----------------------------------------------
+
+``mongosync`` supports network compression. To enable network compression,
+your configuration must meet the following criteria:
+
+- Your source and destination clusters must have network compression enabled
+- Your source and destination cluster connection strings must include the 
+  :urioption:`compressors` connection string option
+- Your cluster configurations and connection string options must share at least 
+  one common compressor
+
+For more information about network compression configuration options, see the 
+:option:`--networkMessageCompressors <mongos --networkMessageCompressors>` option
+in the Database Manual.
 
 Which security and authentication options are supported?
 --------------------------------------------------------


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v1.9`:
 - [DOCSP-48416 add network compression FAQ (#738)](https://github.com/mongodb/docs-cluster-to-cluster-sync/pull/738)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)